### PR TITLE
Likely fix for the bug where 40 event blocks are occassionaly dropped.

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -404,8 +404,8 @@ void JEventSource_EVIOpp::Dispatcher(void)
 		if(swap_needed && SWAP) myjobtype |= DEVIOWorkerThread::JOB_SWAP;
 		
 		// Wake up worker thread to handle event
-		thr->in_use = true;
 		thr->jobtype = (DEVIOWorkerThread::JOBTYPE)myjobtype;
+		thr->in_use = true;
 		thr->istreamorder = istreamorder++;
 
 		thr->cv.notify_all();


### PR DESCRIPTION
This fix was tested on the sim-recon code just before (during?) the sim-rexit.  It seemed to have fixed the issue. The change is just reordering 2 lines of code so I reimplement it here.