### PR TITLE
Detect SSP (DIRC) bank data so we don't error on it. 

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -69,6 +69,7 @@ DEVIOWorkerThread::DEVIOWorkerThread(
 	PARSE_EPICS         = true;
 	PARSE_EVENTTAG      = true;
 	PARSE_TRIGGER       = true;
+	PARSE_SSP           = true;
 	
 	LINK_TRIGGERTIME    = true;
 }
@@ -871,6 +872,10 @@ void DEVIOWorkerThread::ParseDataBank(uint32_t* &iptr, uint32_t *iend)
 				ParseJLabModuleData(rocid, iptr, iend_data_block_bank);
 				break;
 
+			case 0x123:
+				ParseSSPBank(rocid, iptr, iend_data_block_bank);
+				break;
+
 			// These were implemented in the ROL for sync events
 			// as 0xEE02 and 0xEE05. However, that violates the
 			// spec. which reserves the top 4 bits as status bits
@@ -904,7 +909,7 @@ void DEVIOWorkerThread::ParseDataBank(uint32_t* &iptr, uint32_t *iend)
 
 
 			default:
-				jerr<<"Unknown module type ("<<det_id<<" = " << hex << det_id << dec << " ) encountered" << endl;
+				jerr<<"Unknown module type ("<<det_id<<" = 0x" << hex << det_id << dec << " ) encountered" << endl;
 //				if(VERBOSE>5){
 					cout << "----- First few words to help with debugging -----" << endl;
 					cout.flush(); cerr.flush();
@@ -1958,6 +1963,23 @@ void DEVIOWorkerThread::ParseF1TDCBank(uint32_t rocid, uint32_t* &iptr, uint32_t
 
 	// Skip filler words
 	while(iptr<iend && (*iptr&0xF8000000)==0xF8000000)iptr++;
+}
+
+//----------------
+// ParseSSPBank
+//----------------
+void DEVIOWorkerThread::ParseSSPBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend)
+{
+	if(!PARSE_SSP){ iptr = &iptr[(*iptr) + 1]; return; }
+
+	/// No support for SSP just yet. 
+	static int iwarnings=0;
+	if(iwarnings<10){
+		jout << "WARNING: SSP data encountered but ignored for the moment" << endl;
+		if(iwarnings==9) jout << "----- LAST WARNING (SSP) ---" << endl;
+		iwarnings++;
+	}
+	iptr = &iptr[(*iptr) + 1];
 }
 
 //----------------

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -89,6 +89,7 @@ class DEVIOWorkerThread{
 		bool  PARSE_EPICS;
 		bool  PARSE_EVENTTAG;
 		bool  PARSE_TRIGGER;
+		bool  PARSE_SSP;
 		
 		bool  LINK_TRIGGERTIME;
 		bool  LINK_CONFIG;
@@ -121,6 +122,7 @@ class DEVIOWorkerThread{
 		void              Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void     MakeDf125WindowRawData(DParsedEvent *pe, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr);
 		void             ParseF1TDCBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
+		void               ParseSSPBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 
 		void LinkAllAssociations(void);
 

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -90,6 +90,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 	PARSE_EPICS = true;
 	PARSE_EVENTTAG = true;
 	PARSE_TRIGGER = true;
+	PARSE_SSP = true;
 	APPLY_TRANSLATION_TABLE = true;
 	IGNORE_EMPTY_BOR = false;
 	F250_EMULATION_MODE = kEmulationAuto;
@@ -127,6 +128,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 	gPARMS->SetDefaultParameter("EVIO:PARSE_EPICS", PARSE_EPICS, "Set this to 0 to disable parsing of EPICS events from the data stream (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_EVENTTAG", PARSE_EVENTTAG, "Set this to 0 to disable parsing of event tag data in the data stream (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_TRIGGER", PARSE_TRIGGER, "Set this to 0 to disable parsing of the built trigger bank from CODA (for benchmarking/debugging)");
+	gPARMS->SetDefaultParameter("EVIO:PARSE_SSP", PARSE_SSP, "Set this to 0 to disable parsing of the SSP (DIRC data) bank from CODA (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:APPLY_TRANSLATION_TABLE", APPLY_TRANSLATION_TABLE, "Apply the translation table to create DigiHits (you almost always want this on)");
 	gPARMS->SetDefaultParameter("EVIO:IGNORE_EMPTY_BOR", IGNORE_EMPTY_BOR, "Set to non-zero to continue processing data even if an empty BOR event is encountered.");
 	gPARMS->SetDefaultParameter("EVIO:TREAT_TRUNCATED_AS_ERROR", TREAT_TRUNCATED_AS_ERROR, "Set to non-zero to have a truncated EVIO file the JANA return code to non-zero indicating the program errored.");
@@ -207,6 +209,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 		w->PARSE_EPICS         = PARSE_EPICS;
 		w->PARSE_EVENTTAG      = PARSE_EVENTTAG;
 		w->PARSE_TRIGGER       = PARSE_TRIGGER;
+		w->PARSE_SSP           = PARSE_SSP;
 		w->LINK_TRIGGERTIME    = LINK_TRIGGERTIME;
 		w->LINK_CONFIG         = LINK_CONFIG;
 		w->run_number_seed     = run_number_seed;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -188,6 +188,7 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		bool     PARSE_EPICS;
 		bool     PARSE_EVENTTAG;
 		bool     PARSE_TRIGGER;
+		bool     PARSE_SSP;
 		bool     APPLY_TRANSLATION_TABLE;
 		int      ET_STATION_NEVENTS;
 		bool     ET_STATION_CREATE_BLOCKING;


### PR DESCRIPTION
This acknowledges the new SSP bank type (presumably for the DIRC) and prints a few warnings, but then allows the parser to continue so that RunPeriod-2018-08 data can be processed.

Parsing of the bank will be filled in later.