### PR TITLE
prevent a crash for multi-photon final states without intermediate pa…

### DIFF
--- a/src/libraries/ANALYSIS/DSourceComboer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboer.cc
@@ -2526,7 +2526,7 @@ void DSourceComboer::Combo_Vertically_NParticles(const DSourceComboUse& locCombo
 
 		auto locIsZIndependent_NMinus1 = locCombo_NMinus1->Get_IsComboingZIndependent();
 
-		for(; locParticleSearchIndex != locParticles.size(); ++locParticleSearchIndex)
+		for(; locParticleSearchIndex < locParticles.size(); ++locParticleSearchIndex)
 		{
 			auto& locParticle = locParticles[locParticleSearchIndex];
 			auto locIsZIndependent = (locComboingStage == d_MixedStage_ZIndependent) || (locIsZIndependent_NMinus1 && Get_IsComboingZIndependent(locParticle, locPID));


### PR DESCRIPTION
…rticles (ggg, gggg, ...), Get_ResumeAtIndex_Particles can return an indeterminate value