### PR TITLE
Reject bad time-based additional hypotheses

### DIFF
--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -1121,6 +1121,14 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
     // update the parameters for the track...
     if (fitter->GetChisq()<0) status=DTrackFitter::kFitFailed;
 
+    // if the fit flips the charge of the track, then this is bad as well
+    if(q != fitter->GetFitParameters().charge())
+        status=DTrackFitter::kFitFailed; 
+
+    // if we can't refit the track, it is likely of poor quality, so stop here and do not add the hypothesis
+    if(status == DTrackFitter::kFitFailed)
+        return;
+
     if (status==DTrackFitter::kFitSuccess){
       timebased_track->chisq = fitter->GetChisq();
       timebased_track->Ndof = fitter->GetNdof();


### PR DESCRIPTION
In the cases where we are trying to add additional hypotheses for a track in the time-based stage, and the fit does not converge or flips sign, discard this track.

This means that we aren't assured that there will be a full set of hypotheses for each track,
but these appear to be garbage, in any case.

This eliminates a problem in which tracks were getting multiple fits to the same hypothesis, which caused strange problems for the comboing in the  analysis library.  This might be a sign of some underlying tracking problem, though...