### PR TITLE
Add option to flag BCAL/FCAL LED trigger events which slip into other  triggers

### DIFF
--- a/src/libraries/TRIGGER/DTrigger_factory.h
+++ b/src/libraries/TRIGGER/DTrigger_factory.h
@@ -19,7 +19,14 @@ class DTrigger_factory : public jana::JFactory<DTrigger>
 		virtual ~DTrigger_factory(){};
 
 	private:
+		jerror_t init(void);						///< Called once at program start.
 		jerror_t evnt(JEventLoop* locEventLoop, uint64_t locEventNumber);
+		
+		bool EMULATE_BCAL_LED_TRIGGER;
+		bool EMULATE_FCAL_LED_TRIGGER;
+		
+		unsigned int BCAL_LED_NHITS_THRESHOLD;
+		unsigned int FCAL_LED_NHITS_THRESHOLD;
 };
 
 #endif // _DTrigger_factory_


### PR DESCRIPTION
 (e.g. the main physics trigger).

This is not turned on by default! 
Use with care!