### PR TITLE
minimal plugin to put Df250WindowRawData into a root tree

### DIFF
--- a/src/plugins/Utilities/scanf250/JEventProcessor_scanf250.cc
+++ b/src/plugins/Utilities/scanf250/JEventProcessor_scanf250.cc
@@ -1,0 +1,198 @@
+// $Id$
+//
+//    File: JEventProcessor_scanf250.cc
+// Created: Tue Oct  9 21:26:13 EDT 2018
+// Creator: njarvis (on Linux egbert 2.6.32-696.23.1.el6.x86_64 x86_64)
+//
+
+#include "JEventProcessor_scanf250.h"
+using namespace jana;
+
+#include <vector>
+
+#include "DAQ/Df250WindowRawData.h"     
+
+#include <TTree.h>
+#include <TBranch.h>
+
+
+
+// Routine used to create our JEventProcessor
+#include <JANA/JApplication.h>
+#include <JANA/JFactory.h>
+extern "C"{
+void InitPlugin(JApplication *app){
+	InitJANAPlugin(app);
+	app->AddProcessor(new JEventProcessor_scanf250());
+}
+} // "C"
+
+//define static local variable //declared in header file
+thread_local DTreeFillData JEventProcessor_scanf250::dTreeFillData;
+
+//------------------
+// JEventProcessor_scanf250 (Constructor)
+//------------------
+JEventProcessor_scanf250::JEventProcessor_scanf250()
+{
+
+}
+
+//------------------
+// ~JEventProcessor_scanf250 (Destructor)
+//------------------
+JEventProcessor_scanf250::~JEventProcessor_scanf250()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_scanf250::init(void)
+{
+	// This is called once at program startup. 
+
+  //TTREE INTERFACE
+  //MUST DELETE WHEN FINISHED: OR ELSE DATA WON'T BE SAVED!!!
+  dTreeInterface = DTreeInterface::Create_DTreeInterface("T", "tree_scanf250.root");
+
+  //TTREE BRANCHES
+  DTreeBranchRegister locTreeBranchRegister;
+
+
+
+  locTreeBranchRegister.Register_Single<ULong64_t>("eventnum");
+  locTreeBranchRegister.Register_Single<UInt_t>("rocid");
+  locTreeBranchRegister.Register_Single<UInt_t>("slot");
+  locTreeBranchRegister.Register_Single<UInt_t>("channel");
+  locTreeBranchRegister.Register_Single<UInt_t>("itrigger");
+
+  locTreeBranchRegister.Register_Single<UInt_t>("NSAMPLES");
+  locTreeBranchRegister.Register_FundamentalArray<UInt_t>("adc", "NSAMPLES");
+
+
+ //REGISTER BRANCHES
+  dTreeInterface->Create_Branches(locTreeBranchRegister);
+
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_scanf250::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+	// This is called whenever the run number changes
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_scanf250::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+	// This is called for every event. Use of common resources like writing
+	// to a file or filling a histogram should be mutex protected. Using
+	// loop->Get(...) to get reconstructed objects (and thereby activating the
+	// reconstruction algorithm) should be done outside of any mutex lock
+	// since multiple threads may call this method at the same time.
+	// Here's an example:
+	//
+	// vector<const MyDataClass*> mydataclasses;
+	// loop->Get(mydataclasses);
+	//
+	// japp->RootFillLock(this);
+	//  ... fill historgrams or trees ...
+	// japp->RootFillUnLock(this);
+
+
+
+
+  vector<const Df250WindowRawData*> wrdvector;
+  loop->Get(wrdvector);
+
+
+  uint32_t nw = (uint32_t)wrdvector.size();
+
+  if (nw) {
+
+    const uint32_t NSAMPLES = 100;
+
+    uint16_t adc[NSAMPLES];       //    vector<uint16_t> samples;
+    for (uint i=0; i<NSAMPLES; i++) adc[i]=0;
+
+
+    for (int i=0; i<(int)nw; i++) {
+
+      const Df250WindowRawData *wrd = wrdvector[i];
+
+      if (wrd) {
+
+        int ns = (int)wrd->samples.size();
+        int rocid = (int)wrd->rocid;
+
+        // add a continue  if the rocid is not wanted
+  
+        if ((rocid<11 || rocid > 22)) continue;
+
+        for (int j=0; j<ns; j++) {
+          adc[j] = wrd->samples[j];
+        }
+
+        dTreeFillData.Fill_Single<ULong64_t>("eventnum",eventnumber);
+        dTreeFillData.Fill_Single<UInt_t>("rocid",wrd->rocid);
+	dTreeFillData.Fill_Single<UInt_t>("slot",wrd->slot);
+	dTreeFillData.Fill_Single<UInt_t>("channel",wrd->channel);
+	dTreeFillData.Fill_Single<UInt_t>("itrigger",wrd->itrigger);
+
+
+
+	size_t index = 0;
+        for (int j=0; j<(int)NSAMPLES; j++) {
+          dTreeFillData.Fill_Array<UInt_t>("adc",adc[j],index);
+          index++;
+	}
+
+	//FILL ARRAY SIZE
+	dTreeFillData.Fill_Single<UInt_t>("NSAMPLES",index);
+
+
+	//FILL ARRAY SIZE
+	dTreeInterface->Fill(dTreeFillData);
+
+      }
+ 
+    }
+
+
+
+  }   // if (nw)
+
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_scanf250::erun(void)
+{
+	// This is called whenever the run number changes, before it is
+	// changed to give you a chance to clean up before processing
+	// events from the next run number.
+
+  delete dTreeInterface;
+
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t JEventProcessor_scanf250::fini(void)
+{
+	// Called before program exit after event processing is finished.
+	return NOERROR;
+}
+

--- a/src/plugins/Utilities/scanf250/JEventProcessor_scanf250.h
+++ b/src/plugins/Utilities/scanf250/JEventProcessor_scanf250.h
@@ -1,0 +1,45 @@
+// $Id$
+//
+//    File: JEventProcessor_scanf250.h
+// Created: Tue Oct  9 21:26:13 EDT 2018
+// Creator: njarvis (on Linux egbert 2.6.32-696.23.1.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_scanf250_
+#define _JEventProcessor_scanf250_
+
+#include <JANA/JEventProcessor.h>
+
+#include <TTree.h>
+#include "ANALYSIS/DTreeInterface.h"
+
+class JEventProcessor_scanf250:public jana::JEventProcessor{
+	public:
+		JEventProcessor_scanf250();
+		~JEventProcessor_scanf250();
+		const char* className(void){return "JEventProcessor_scanf250";}
+
+	private:
+
+
+                //TREE
+                DTreeInterface* dTreeInterface;
+
+                //thread_local: Each thread has its own object: no lock needed
+                //important: manages it's own data internally: don't want to call new/delete every event!
+
+                static thread_local DTreeFillData dTreeFillData;
+
+
+
+
+
+		jerror_t init(void);						///< Called once at program start.
+		jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
+};
+
+#endif // _JEventProcessor_scanf250_
+

--- a/src/plugins/Utilities/scanf250/SConscript
+++ b/src/plugins/Utilities/scanf250/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+


### PR DESCRIPTION
The output filename is hardcoded to tree_scanf250.root (because the plugin uses the analysis library's tree interface, because I believe the usual root tree interface either can't be used or can't be used multithreaded, since some changes that Paul M made about a year ago).

This version requires that the rocid is between 11 and 22.

To get the events processed in order, use PEVIO:NTHREADS=1 and PNTHREADS=1.

If you run this on short mode data which doesn't contain any Df250WindowRawData, it will run silently and produce an empty output file.