### PR TITLE
do not use unmatched TDC hits to make DTOFHit:

### DIFF
--- a/src/libraries/TOF/DTOFHit_factory.cc
+++ b/src/libraries/TOF/DTOFHit_factory.cc
@@ -368,7 +368,7 @@ jerror_t DTOFHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     hit->dE=dA;  // this will be scaled to energy units later
     hit->Amp = (float)digihit->pulse_peak - pedestal4Amp/(float)nsamples_pedestal;
 
-    if (hit->Amp<0){ // this happens if pulse_peak is reported as zero, resort to use scaled Integral value
+    if (hit->Amp<1){ // this happens if pulse_peak is reported as zero, resort to use scaled Integral value
       hit->Amp = dA*0.163;
     }
     
@@ -423,6 +423,7 @@ jerror_t DTOFHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
       DTOFHit *hit = FindMatch(digihit->plane, digihit->bar, digihit->end, T);
       //DTOFHit *hit = FindMatch(digihit->plane, hit->bar, hit->end, T);
       if(!hit){
+	continue; // Do not use unmatched TDC hits
 	hit = new DTOFHit;
 	hit->plane = digihit->plane;
 	hit->bar   = digihit->bar;

--- a/src/libraries/TOF/DTOFHit_factory.cc
+++ b/src/libraries/TOF/DTOFHit_factory.cc
@@ -424,6 +424,7 @@ jerror_t DTOFHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
       //DTOFHit *hit = FindMatch(digihit->plane, hit->bar, hit->end, T);
       if(!hit){
 	continue; // Do not use unmatched TDC hits
+	/*
 	hit = new DTOFHit;
 	hit->plane = digihit->plane;
 	hit->bar   = digihit->bar;
@@ -434,6 +435,7 @@ jerror_t DTOFHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	hit->has_fADC=false;
 	
 	_data.push_back(hit);
+	*/
       } else if (hit->has_TDC) { // this tof ADC hit has already a matching TDC, make new tof ADC hit
 	DTOFHit *newhit = new DTOFHit;
 	newhit->plane = hit->plane;
@@ -806,7 +808,7 @@ double DTOFHit_factory::CalcWalkCorrNEW(DTOFHit* hit){
   int id=2*TOF_NUM_BARS*hit->plane+TOF_NUM_BARS*hit->end+hit->bar-1;
   double ADC=hit->dE;
 
-  if (ADC<50.){
+  if (ADC<1.){
     return 0;
   }
   


### PR DESCRIPTION
TDC times without ADC info are useless!
this caused nan in the walk correction which was alleviated by an amplitude cut but the real issue
is that a TDC hit without ADC info to do a proper walk correction does not deliver a good timing value!