### PR TITLE
Fix reduction in rho yield

### DIFF
--- a/src/libraries/TRIGGER/DTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DTrigger_factory.cc
@@ -42,6 +42,7 @@ jerror_t DTrigger_factory::evnt(JEventLoop* locEventLoop, uint64_t locEventNumbe
 	//SET LEVEL-1 TRIGGER INFO
 	if(locL1Trigger != NULL)
 	{
+	        locTrigger->Set_L1TriggerBits(locL1Trigger->trig_mask);
 		uint32_t locFpTrigMask = locL1Trigger->fp_trig_mask;
 	
 		// Sometimes the BCAL/FCAL LED trigger also trip the main physics trigger,
@@ -70,7 +71,6 @@ jerror_t DTrigger_factory::evnt(JEventLoop* locEventLoop, uint64_t locEventNumbe
 		}
 		
 		locTrigger->Set_L1FrontPanelTriggerBits(locFpTrigMask);
-		locTrigger->Set_L1FrontPanelTriggerBits(locL1Trigger->fp_trig_mask);
 
 	}
 	else 


### PR DESCRIPTION
The problem was introduced in PR #34 - apparently I committed the wrong version of the code?

The line where the main trigger bits was accidentally removed.  So honestly, I'm not sure how anything worked during testing...