### PR TITLE
- add optional verbose printout in trk_mainframe.cc to enable dumping

### DIFF
--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -101,7 +101,7 @@ unsigned int DTrackFitterKalmanSIMD::locate(vector<double>&xx,double x){
 }
 
 // Crude approximation for the variance in drift distance due to smearing
-double DTrackFitterKalmanSIMD::fdc_drift_variance(double t){
+double DTrackFitterKalmanSIMD::fdc_drift_variance(double t) const {
    //return FDC_ANODE_VARIANCE;
    if (t<5.) t=5.;
    double sigma=DRIFT_RES_PARMS[0]/(t+1.)+DRIFT_RES_PARMS[1]+DRIFT_RES_PARMS[2]*t*t;
@@ -222,7 +222,7 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
 #define FDC_T0_OFFSET 17.6
 // Interpolate on a table to convert time to distance for the fdc
 /*
-   double DTrackFitterKalmanSIMD::fdc_drift_distance(double t,double Bz){
+   double DTrackFitterKalmanSIMD::fdc_drift_distance(double t,double Bz) const {
    double a=93.31,b=4.614,Bref=2.143;
    t*=(a+b*Bref)/(a+b*Bz);
    int id=int((t+FDC_T0_OFFSET)/2.);
@@ -240,7 +240,7 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
    */
 
 // parametrization of time-to-distance for FDC
-double DTrackFitterKalmanSIMD::fdc_drift_distance(double time,double Bz){
+double DTrackFitterKalmanSIMD::fdc_drift_distance(double time,double Bz) const {
   if (time<0.) return 0.;
   double d=0.; 
   time/=1.+FDC_DRIFT_BSCALE_PAR1+FDC_DRIFT_BSCALE_PAR2*Bz*Bz;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -212,7 +212,9 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
 		 double rho_Z_over_A_LnI,double Z); 
   double GetEnergyVariance(double ds,double beta2,double K_rho_Z_over_A);
 
-
+  double GetFDCDriftDistance(double time, double Bz) const {
+    return fdc_drift_distance(time, Bz);
+  }
 
  protected:
   enum hit_status{
@@ -253,8 +255,8 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
   void locate(const double *xx,int n,double x,int *j);
   unsigned int locate(vector<double>&xx,double x);
   
-  double fdc_drift_variance(double t);
-  double fdc_drift_distance(double t,double Bz);
+  double fdc_drift_variance(double t) const;
+  double fdc_drift_distance(double t,double Bz) const;
 
   void ResetKalmanSIMD(void);
   jerror_t GetProcessNoise(double z,double ds,double chi2c_factor,

--- a/src/programs/Analysis/hdview2/trk_mainframe.cc
+++ b/src/programs/Analysis/hdview2/trk_mainframe.cc
@@ -15,6 +15,7 @@ using namespace std;
 
 #include <CDC/DCDCWire.h>
 #include <CDC/DCDCTrackHit.h>
+#include <TRACKING/DTrackFitterKalmanSIMD.h>
 
 #include <TGButtonGroup.h>
 #include <TGTextEntry.h>
@@ -647,7 +648,15 @@ void trk_mainframe::DrawHitsForOneTrack(
 	
 	// Get state of s-lock checkbutton
 	bool lock_s_coordinate = slock->GetState();
-	
+
+    // Get fdc drift time - distance function
+    vector<const DTrackFitter*> fitters;
+    eventloop->Get(fitters, "KalmanSIMD");
+    const DTrackFitterKalmanSIMD *fitter=0;
+    if (fitters.size() > 0)
+        fitter =  dynamic_cast<const DTrackFitterKalmanSIMD *>(fitters[0]);
+
+
 	vector<pair<const DCoordinateSystem*,double> > &hits = index==0 ? allhits:TRACKHITS;
 	
 	// Loop over all hits and create graphics objects for each
@@ -671,7 +680,23 @@ void trk_mainframe::DrawHitsForOneTrack(
 		double mass = 0.13957;
 		double beta = 1.0/sqrt(1.0 + pow(mass/mom_doca.Mag(), 2.0))*2.998E10;
 		double tof = s/beta/1.0E-9; // in ns
-		dist -= tof*55.0E-4;
+        if (fitter) {
+            double Bz = rt->FindClosestSwimStep(wire)->B[2];
+            dist = fitter->GetFDCDriftDistance(dist / 55.0e-4 - tof, Bz);
+#if PRINT_DRIFT_DISTANCE_MAP
+            static bool print_the_map=true;
+            if (print_the_map) {
+               print_the_map = false;
+               for (double t=0; t < 2.5; t += 0.001) {
+                  double d = fitter->GetFDCDriftDistance(t, Bz);
+                  std::cout << d << " " << t << std::endl;
+               }
+            }
+#endif
+        }
+        else {
+		    dist -= tof*55.0E-4;
+        }
 		shift.SetMag(dist);
 
 		// See comments in DTrack_factory_ALT1.cc::LeastSquaresB
@@ -690,7 +715,17 @@ void trk_mainframe::DrawHitsForOneTrack(
 		//double sign = (shift.Dot(pos_wire)<0.0) ? -1.0:+1.0;
 		double resi = fabs(doca)-fabs(dist);
 		if(!isfinite(resi))continue;
-		
+#if VERBOSE_PRINT_FDC_HIT_INFO
+         std::cout
+           << "hit " << i << ": "
+           << "dist=" << dist
+           << " (" << shift[0] << "," << shift[1] << "," << shift[2] << ")"
+           << ", sdist=" << sdist
+           << " (" << pos_diff[0] << "," << pos_diff[1] << "," << pos_diff[2] << ")"
+           << ", tof=" << tof
+           << " at (" << pos_doca[0] << "," << pos_doca[1] << "," << pos_doca[2] << ")"
+           << std::endl;
+#endif
 		// If the residual is reasonably small, consider this hit to be
 		// on this track and record it (if this is the prime track)
 		if(index==0)TRACKHITS.push_back(hits[i]);
@@ -772,5 +807,3 @@ bool trk_mainframe::WireInList(const DCoordinateSystem *wire, vector<const DCDCT
 
 	return false;
 }
-
-


### PR DESCRIPTION
  of fdc hit information for debugging the tracking. [rtj]
- add public method to DTrackFitterKalmanSIMD to enable user classes
  to request the conversion from drift time to distance on the fdc
  anode wires [rtj]