### PR TITLE
Add Calorimeter-only RF Bunch calculation

### DIFF
--- a/src/libraries/PID/DEventRFBunch_factory.cc
+++ b/src/libraries/PID/DEventRFBunch_factory.cc
@@ -17,6 +17,9 @@ using namespace jana;
 jerror_t DEventRFBunch_factory::init(void)
 {
 	dMinTrackingFOM = 0.0;
+	OVERRIDE_TAG = "";
+	
+	gPARMS->SetDefaultParameter("EVENTRFBUNCH:USE_TAG", OVERRIDE_TAG, "Use a particular tag for the general RF bunch calculation instead of the default calculation.");
 	return NOERROR;
 }
 
@@ -48,6 +51,21 @@ jerror_t DEventRFBunch_factory::evnt(JEventLoop* locEventLoop, uint64_t eventnum
 {
 	//There should ALWAYS be one and only one DEventRFBunch created.
 		//If there is not enough information, time is set to NaN
+
+	if(OVERRIDE_TAG != "") {
+		vector<const DEventRFBunch *> rfBunchVec;
+		locEventLoop->Get(rfBunchVec, OVERRIDE_TAG.c_str());
+		
+		if(rfBunchVec.size() > 0) {
+			DEventRFBunch *rfBunchCopy = new DEventRFBunch(*rfBunchVec[0]);
+			_data.push_back(rfBunchCopy);
+			return NOERROR;
+		} else {
+			jerr << "Could not find DEventRFBunch objects with tag " << OVERRIDE_TAG
+				 << ", falling back to default calculation ..." << endl;
+		}
+	}
+
 
 	//Select Good Tracks
 	vector<const DTrackTimeBased*> locTrackTimeBasedVector;

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
@@ -1,9 +1,9 @@
 // $Id$
 //
-//    File: DEventRFBunch_factory_FCAL_CCAL.cc
+//    File: DEventRFBunch_factory_CalorimeterOnly.cc
 //
 
-#include "DEventRFBunch_factory_FCAL_CCAL.h"
+#include "DEventRFBunch_factory_CalorimeterOnly.h"
 #include "BCAL/DBCALShower.h"
 #include "FCAL/DFCALShower.h"
 #include "CCAL/DCCALCluster.h"
@@ -13,7 +13,7 @@ using namespace jana;
 //------------------
 // init
 //------------------
-jerror_t DEventRFBunch_factory_FCAL_CCAL::init(void)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::init(void)
 {
 	dMinTrackingFOM = 0.0;
 	
@@ -31,7 +31,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::init(void)
 //------------------
 // brun
 //------------------
-jerror_t DEventRFBunch_factory_FCAL_CCAL::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
 {
 	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 	DGeometry* locGeometry = locApplication->GetDGeometry(runnumber);
@@ -52,7 +52,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::brun(jana::JEventLoop *locEventLoop, i
 //------------------
 // evnt
 //------------------
-jerror_t DEventRFBunch_factory_FCAL_CCAL::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
 {
 	//There should ALWAYS be one and only one DEventRFBunch created.
 	//If there is not enough information, time is set to NaN
@@ -66,7 +66,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::evnt(JEventLoop* locEventLoop, uint64_
 		return Create_NaNRFBunch();   // there should always be RFTime data, otherwise there's not enough info to choose
 }
 
-jerror_t DEventRFBunch_factory_FCAL_CCAL::Select_RFBunch(JEventLoop* locEventLoop, const DRFTime* locRFTime)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::Select_RFBunch(JEventLoop* locEventLoop, const DRFTime* locRFTime)
 {
 	//If RF Time present:
 		// Let neutral showers vote (assume PID = photon) on RF bunch
@@ -100,7 +100,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::Select_RFBunch(JEventLoop* locEventLoo
 	return NOERROR;
 }
 
-int DEventRFBunch_factory_FCAL_CCAL::Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, bool locUsedTracksFlag, int& locHighestNumVotes)
+int DEventRFBunch_factory_CalorimeterOnly::Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, bool locUsedTracksFlag, int& locHighestNumVotes)
 {
 	map<int, vector<const JObject*> > locNumBeamBucketsShiftedMap;
 	set<int> locBestRFBunchShifts;
@@ -121,7 +121,7 @@ int DEventRFBunch_factory_FCAL_CCAL::Conduct_Vote(JEventLoop* locEventLoop, doub
 }
 
 
-bool DEventRFBunch_factory_FCAL_CCAL::Find_NeutralTimes(JEventLoop* locEventLoop, vector<pair<double, const JObject*> >& locTimes)
+bool DEventRFBunch_factory_CalorimeterOnly::Find_NeutralTimes(JEventLoop* locEventLoop, vector<pair<double, const JObject*> >& locTimes)
 {
 	locTimes.clear();
 
@@ -181,7 +181,7 @@ bool DEventRFBunch_factory_FCAL_CCAL::Find_NeutralTimes(JEventLoop* locEventLoop
 	return (locTimes.size() > 1);
 }
 
-int DEventRFBunch_factory_FCAL_CCAL::Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+int DEventRFBunch_factory_CalorimeterOnly::Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
 	//then find the #beam buckets the RF time needs to shift to match it
 	int locHighestNumVotes = 0;
@@ -208,7 +208,7 @@ int DEventRFBunch_factory_FCAL_CCAL::Find_BestRFBunchShifts(double locRFHitTime,
 	return locHighestNumVotes;
 }
 
-bool DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes)
+bool DEventRFBunch_factory_CalorimeterOnly::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes)
 {
 	//locHighestNumVotes intentionally passed-in as value-type (non-reference)
 		//beam photons are only used to BREAK the tie, not count as equal votes
@@ -238,7 +238,7 @@ bool DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_BeamPhotons(vector<const DBe
 }
 
 
-int DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+int DEventRFBunch_factory_CalorimeterOnly::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
   //Break tie with highest total shower energy
 
@@ -282,7 +282,7 @@ int DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_Neutrals(map<int, vector<cons
   return locBestRFBunchShift;
 }
 
-jerror_t DEventRFBunch_factory_FCAL_CCAL::Create_NaNRFBunch(void)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::Create_NaNRFBunch(void)
 {
 	DEventRFBunch* locEventRFBunch = new DEventRFBunch;
 	locEventRFBunch->dTime = numeric_limits<double>::quiet_NaN();
@@ -297,7 +297,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::Create_NaNRFBunch(void)
 //------------------
 // erun
 //------------------
-jerror_t DEventRFBunch_factory_FCAL_CCAL::erun(void)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::erun(void)
 {
 	return NOERROR;
 }
@@ -305,7 +305,7 @@ jerror_t DEventRFBunch_factory_FCAL_CCAL::erun(void)
 //------------------
 // fini
 //------------------
-jerror_t DEventRFBunch_factory_FCAL_CCAL::fini(void)
+jerror_t DEventRFBunch_factory_CalorimeterOnly::fini(void)
 {
 	return NOERROR;
 }

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
@@ -17,8 +17,8 @@ jerror_t DEventRFBunch_factory_CalorimeterOnly::init(void)
 {
 	dMinTrackingFOM = 0.0;
 	
-	USE_BCAL = true;   // false
-	USE_CCAL = false;  // true
+	USE_BCAL = false;  
+	USE_CCAL = true; 
 	USE_FCAL = true;
 	
 	gPARMS->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_BCAL_SHOWERS", USE_BCAL, "Use BCAL showers for calorimeter-only RF bunch calculation");

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
@@ -1,10 +1,10 @@
 // $Id$
 //
-//    File: DEventRFBunch_factory_FCAL_CCAL.h
+//    File: DEventRFBunch_factory_CalorimeterOnly.h
 //
 
-#ifndef _DEventRFBunch_factory_FCAL_CCAL_
-#define _DEventRFBunch_factory_FCAL_CCAL_
+#ifndef _DEventRFBunch_factory_CalorimeterOnly_
+#define _DEventRFBunch_factory_CalorimeterOnly_
 
 #include <iostream>
 #include <iomanip>
@@ -36,12 +36,12 @@
 using namespace std;
 using namespace jana;
 
-class DEventRFBunch_factory_FCAL_CCAL : public jana::JFactory<DEventRFBunch>
+class DEventRFBunch_factory_CalorimeterOnly : public jana::JFactory<DEventRFBunch>
 {
 	public:
-		DEventRFBunch_factory_FCAL_CCAL(){};
-		~DEventRFBunch_factory_FCAL_CCAL(){};
-		const char* Tag(void){return "FCAL_CCAL";}
+		DEventRFBunch_factory_CalorimeterOnly(){};
+		~DEventRFBunch_factory_CalorimeterOnly(){};
+		const char* Tag(void){return "CalorimeterOnly";}
 
 	private:
 

--- a/src/libraries/PID/DEventRFBunch_factory_FCAL_CCAL.cc
+++ b/src/libraries/PID/DEventRFBunch_factory_FCAL_CCAL.cc
@@ -1,0 +1,312 @@
+// $Id$
+//
+//    File: DEventRFBunch_factory_FCAL_CCAL.cc
+//
+
+#include "DEventRFBunch_factory_FCAL_CCAL.h"
+#include "BCAL/DBCALShower.h"
+#include "FCAL/DFCALShower.h"
+#include "CCAL/DCCALCluster.h"
+
+using namespace jana;
+
+//------------------
+// init
+//------------------
+jerror_t DEventRFBunch_factory_FCAL_CCAL::init(void)
+{
+	dMinTrackingFOM = 0.0;
+	
+	USE_BCAL = true;   // false
+	USE_CCAL = false;  // true
+	USE_FCAL = true;
+	
+	gPARMS->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_BCAL_SHOWERS", USE_BCAL, "Use BCAL showers for calorimeter-only RF bunch calculation");
+	gPARMS->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_CCAL_SHOWERS", USE_CCAL, "Use CCAL showers for calorimeter-only RF bunch calculation");
+	gPARMS->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_FCAL_SHOWERS", USE_FCAL, "Use FCAL showers for calorimeter-only RF bunch calculation");
+	
+	return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t DEventRFBunch_factory_FCAL_CCAL::brun(jana::JEventLoop *locEventLoop, int32_t runnumber)
+{
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(runnumber);
+
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
+
+	double locTargetCenterZ;
+	locGeometry->GetTargetZ(locTargetCenterZ);
+	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);
+
+	locEventLoop->GetSingle(dParticleID);
+
+	return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t DEventRFBunch_factory_FCAL_CCAL::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
+{
+	//There should ALWAYS be one and only one DEventRFBunch created.
+	//If there is not enough information, time is set to NaN
+
+	//Select RF Bunch:
+	vector<const DRFTime*> locRFTimes;
+	locEventLoop->Get(locRFTimes);
+	if(!locRFTimes.empty())
+		return Select_RFBunch(locEventLoop, locRFTimes[0]);
+	else
+		return Create_NaNRFBunch();   // there should always be RFTime data, otherwise there's not enough info to choose
+}
+
+jerror_t DEventRFBunch_factory_FCAL_CCAL::Select_RFBunch(JEventLoop* locEventLoop, const DRFTime* locRFTime)
+{
+	//If RF Time present:
+		// Let neutral showers vote (assume PID = photon) on RF bunch
+		//If None: set DEventRFBunch::dTime to NaN
+
+	//Voting when RF time present:
+		//Propagate track/shower times to vertex
+		//Compare times to possible RF bunches, select the bunch with the most votes
+		//If there is a tie: let DBeamPhoton's vote to break tie
+			//If a tie, and voting with neutral showers:
+				//Select the bunch with the highest total shower energy
+
+	const DDetectorMatches* locDetectorMatches = NULL;
+	locEventLoop->GetSingle(locDetectorMatches);
+
+	vector<pair<double, const JObject*> > locTimes;
+	int locBestRFBunchShift = 0, locHighestNumVotes = 0;
+
+	if(Find_NeutralTimes(locEventLoop, locTimes))
+		locBestRFBunchShift = Conduct_Vote(locEventLoop, locRFTime->dTime, locTimes, false, locHighestNumVotes);
+	else //PASS-THROUGH, WILL HAVE TO RESOLVE WHEN COMBOING
+		locBestRFBunchShift = 0;
+
+	DEventRFBunch* locEventRFBunch = new DEventRFBunch();
+	locEventRFBunch->dTime = locRFTime->dTime + dBeamBunchPeriod*double(locBestRFBunchShift);
+	locEventRFBunch->dTimeVariance = locRFTime->dTimeVariance;
+	locEventRFBunch->dNumParticleVotes = locHighestNumVotes;
+	locEventRFBunch->dTimeSource = SYS_RF;
+	_data.push_back(locEventRFBunch);
+
+	return NOERROR;
+}
+
+int DEventRFBunch_factory_FCAL_CCAL::Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, bool locUsedTracksFlag, int& locHighestNumVotes)
+{
+	map<int, vector<const JObject*> > locNumBeamBucketsShiftedMap;
+	set<int> locBestRFBunchShifts;
+
+	locHighestNumVotes = Find_BestRFBunchShifts(locRFTime, locTimes, locNumBeamBucketsShiftedMap, locBestRFBunchShifts);
+	if(locBestRFBunchShifts.size() == 1)
+		return *locBestRFBunchShifts.begin();
+
+	//tied: break with beam photons
+	vector<const DBeamPhoton*> locBeamPhotons;
+	locEventLoop->Get(locBeamPhotons);
+	if(Break_TieVote_BeamPhotons(locBeamPhotons, locRFTime, locNumBeamBucketsShiftedMap, locBestRFBunchShifts, locHighestNumVotes))
+		return *locBestRFBunchShifts.begin();
+
+	//break tie with highest total shower energy
+	return Break_TieVote_Neutrals(locNumBeamBucketsShiftedMap, locBestRFBunchShifts);
+	
+}
+
+
+bool DEventRFBunch_factory_FCAL_CCAL::Find_NeutralTimes(JEventLoop* locEventLoop, vector<pair<double, const JObject*> >& locTimes)
+{
+	locTimes.clear();
+
+	if(USE_FCAL) {
+		vector< const DFCALShower* > fcalShowers;
+		locEventLoop->Get( fcalShowers );
+
+		for( size_t i = 0; i < fcalShowers.size(); ++i ){
+		  DVector3 locHitPoint = fcalShowers[i]->getPosition();
+		  DVector3 locPath = locHitPoint - dTargetCenter;
+		  double locPathLength = locPath.Mag();
+		  if(!(locPathLength > 0.0))
+			continue;
+  
+		  double locFlightTime = locPathLength/29.9792458;
+		  double locHitTime = fcalShowers[i]->getTime();
+		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, fcalShowers[i] ) );
+		}
+	}
+
+	if(USE_BCAL) {
+		vector< const DBCALShower* > bcalShowers;
+		locEventLoop->Get( bcalShowers );
+
+		for( size_t i = 0; i < bcalShowers.size(); ++i ){
+
+		  DVector3 locHitPoint( bcalShowers[i]->x, bcalShowers[i]->y, bcalShowers[i]->z );
+		  DVector3 locPath = locHitPoint - dTargetCenter;
+		  double locPathLength = locPath.Mag();
+		  if(!(locPathLength > 0.0))
+			continue;
+	  
+		  double locFlightTime = locPathLength/29.9792458;
+		  double locHitTime = bcalShowers[i]->t;
+		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, bcalShowers[i] ) );
+		}
+	}
+	
+	if(USE_CCAL) {
+		vector< const DCCALCluster* > ccalShowers;
+		locEventLoop->Get( ccalShowers );
+
+		for( size_t i = 0; i < ccalShowers.size(); ++i ){
+		  DVector3 locHitPoint = ccalShowers[i]->getCentroid();
+		  DVector3 locPath = locHitPoint - dTargetCenter;
+		  double locPathLength = locPath.Mag();
+		  if(!(locPathLength > 0.0))
+			continue;
+  
+		  double locFlightTime = locPathLength/29.9792458;
+		  double locHitTime = ccalShowers[i]->getTime();
+		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ccalShowers[i] ) );
+		}
+	}
+	
+	    
+	return (locTimes.size() > 1);
+}
+
+int DEventRFBunch_factory_FCAL_CCAL::Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+{
+	//then find the #beam buckets the RF time needs to shift to match it
+	int locHighestNumVotes = 0;
+	locNumBeamBucketsShiftedMap.clear();
+	locBestRFBunchShifts.clear();
+
+	for(unsigned int loc_i = 0; loc_i < locTimes.size(); ++loc_i)
+	{
+		double locDeltaT = locTimes[loc_i].first - locRFHitTime;
+		int locNumBeamBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dBeamBunchPeriod + 0.5) : int(locDeltaT/dBeamBunchPeriod - 0.5);
+		locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].push_back(locTimes[loc_i].second);
+
+		int locNumVotesThisShift = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].size();
+		if(locNumVotesThisShift > locHighestNumVotes)
+		{
+			locHighestNumVotes = locNumVotesThisShift;
+			locBestRFBunchShifts.clear();
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
+		}
+		else if(locNumVotesThisShift == locHighestNumVotes)
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
+	}
+
+	return locHighestNumVotes;
+}
+
+bool DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes)
+{
+	//locHighestNumVotes intentionally passed-in as value-type (non-reference)
+		//beam photons are only used to BREAK the tie, not count as equal votes
+
+	set<int> locInputRFBunchShifts = locBestRFBunchShifts; //only test these RF bunch selections
+	for(size_t loc_i = 0; loc_i < locBeamPhotons.size(); ++loc_i)
+	{
+		double locDeltaT = locBeamPhotons[loc_i]->time() - locRFTime;
+		int locNumBeamBucketsShifted = (locDeltaT > 0.0) ? int(locDeltaT/dBeamBunchPeriod + 0.5) : int(locDeltaT/dBeamBunchPeriod - 0.5);
+		if(locInputRFBunchShifts.find(locNumBeamBucketsShifted) == locInputRFBunchShifts.end())
+			continue; //only use beam votes to break input tie, not contribute to other beam buckets
+
+		locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].push_back(locBeamPhotons[loc_i]);
+
+		int locNumVotesThisShift = locNumBeamBucketsShiftedMap[locNumBeamBucketsShifted].size();
+		if(locNumVotesThisShift > locHighestNumVotes)
+		{
+			locHighestNumVotes = locNumVotesThisShift;
+			locBestRFBunchShifts.clear();
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
+		}
+		else if(locNumVotesThisShift == locHighestNumVotes)
+			locBestRFBunchShifts.insert(locNumBeamBucketsShifted);
+	}
+
+	return (locBestRFBunchShifts.size() == 1);
+}
+
+
+int DEventRFBunch_factory_FCAL_CCAL::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
+{
+  //Break tie with highest total shower energy
+
+  int locBestRFBunchShift = 0;
+  double locHighestTotalEnergy = 0.0;
+
+  set<int>::const_iterator locSetIterator = locBestRFBunchShifts.begin();
+  for(; locSetIterator != locBestRFBunchShifts.end(); ++locSetIterator)
+    {
+      int locRFBunchShift = *locSetIterator;
+      double locTotalEnergy = 0.0;
+
+      const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
+      for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
+	{
+	  // the pointers in locVoters that we care about will either be those to DBCALShower
+	  // or DFCALShower objects -- figure out which and record the energy
+	  
+	  const DFCALShower* fcalShower = dynamic_cast< const DFCALShower* >( locVoters[loc_i] );
+	  if( fcalShower != NULL ){
+
+	    locTotalEnergy += fcalShower->getEnergy();
+	  }
+	  else{
+
+	    const DBCALShower* bcalShower = dynamic_cast< const DBCALShower* >( locVoters[loc_i] );
+	    if( bcalShower != NULL ){
+
+	      locTotalEnergy += bcalShower->E;
+	    }
+	  }
+	}
+
+      if(locTotalEnergy > locHighestTotalEnergy)
+	{
+	  locHighestTotalEnergy = locTotalEnergy;
+	  locBestRFBunchShift = locRFBunchShift;
+	}
+    }
+
+  return locBestRFBunchShift;
+}
+
+jerror_t DEventRFBunch_factory_FCAL_CCAL::Create_NaNRFBunch(void)
+{
+	DEventRFBunch* locEventRFBunch = new DEventRFBunch;
+	locEventRFBunch->dTime = numeric_limits<double>::quiet_NaN();
+	locEventRFBunch->dTimeVariance = numeric_limits<double>::quiet_NaN();
+	locEventRFBunch->dNumParticleVotes = 0;
+	locEventRFBunch->dTimeSource = SYS_NULL;
+	_data.push_back(locEventRFBunch);
+
+	return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t DEventRFBunch_factory_FCAL_CCAL::erun(void)
+{
+	return NOERROR;
+}
+
+//------------------
+// fini
+//------------------
+jerror_t DEventRFBunch_factory_FCAL_CCAL::fini(void)
+{
+	return NOERROR;
+}
+

--- a/src/libraries/PID/DEventRFBunch_factory_FCAL_CCAL.h
+++ b/src/libraries/PID/DEventRFBunch_factory_FCAL_CCAL.h
@@ -1,12 +1,10 @@
 // $Id$
 //
-//    File: DEventRFBunch_factory.h
-// Created: Tue Aug  9 14:29:24 EST 2011
-// Creator: pmatt (on Linux ifarml6 2.6.18-128.el5 x86_64)
+//    File: DEventRFBunch_factory_FCAL_CCAL.h
 //
 
-#ifndef _DEventRFBunch_factory_
-#define _DEventRFBunch_factory_
+#ifndef _DEventRFBunch_factory_FCAL_CCAL_
+#define _DEventRFBunch_factory_FCAL_CCAL_
 
 #include <iostream>
 #include <iomanip>
@@ -38,33 +36,29 @@
 using namespace std;
 using namespace jana;
 
-class DEventRFBunch_factory : public jana::JFactory<DEventRFBunch>
+class DEventRFBunch_factory_FCAL_CCAL : public jana::JFactory<DEventRFBunch>
 {
 	public:
-		DEventRFBunch_factory(){};
-		~DEventRFBunch_factory(){};
-
-		bool Get_RFTimeGuess(JEventLoop* locEventLoop, double& locRFTimeGuess, double& locRFVariance, DetectorSystem_t& locTimeSource) const;
+		DEventRFBunch_factory_FCAL_CCAL(){};
+		~DEventRFBunch_factory_FCAL_CCAL(){};
+		const char* Tag(void){return "FCAL_CCAL";}
 
 	private:
 
-		void Select_GoodTracks(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locSelectedTimeBasedTracks) const;
-		jerror_t Select_RFBunch(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locTrackTimeBasedVector, const DRFTime* locRFTime);
+		jerror_t Select_RFBunch(JEventLoop* locEventLoop, const DRFTime* locRFTime);
 		int Conduct_Vote(JEventLoop* locEventLoop, double locRFTime, vector<pair<double, const JObject*> >& locTimes, bool locUsedTracksFlag, int& locHighestNumVotes);
 
-		bool Find_TrackTimes_SCTOF(const DDetectorMatches* locDetectorMatches, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, vector<pair<double, const JObject*> >& locTimes) const;
-		bool Find_TrackTimes_All(const DDetectorMatches* locDetectorMatches, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, vector<pair<double, const JObject*> >& locTimes);
 		bool Find_NeutralTimes(JEventLoop* locEventLoop, vector<pair<double, const JObject*> >& locTimes);
 
 		int Find_BestRFBunchShifts(double locRFHitTime, const vector<pair<double, const JObject*> >& locTimes, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 
 		bool Break_TieVote_BeamPhotons(vector<const DBeamPhoton*>& locBeamPhotons, double locRFTime, map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts, int locHighestNumVotes);
-		int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
+		//int Break_TieVote_Tracks(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 		int Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts);
 
-		jerror_t Select_RFBunch_NoRFTime(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locTrackTimeBasedVector);
+		//jerror_t Select_RFBunch_NoRFTime(JEventLoop* locEventLoop, vector<const DTrackTimeBased*>& locTrackTimeBasedVector);
 
-		void Get_RFTimeGuess(vector<pair<double, const JObject*> >& locTimes, double& locRFTimeGuess, double& locRFVariance) const;
+		//void Get_RFTimeGuess(vector<pair<double, const JObject*> >& locTimes, double& locRFTimeGuess, double& locRFVariance) const;
 
 		jerror_t Create_NaNRFBunch(void);
 
@@ -75,7 +69,9 @@ class DEventRFBunch_factory : public jana::JFactory<DEventRFBunch>
 
 		double dMinTrackingFOM;
 		
-		string OVERRIDE_TAG;
+		bool USE_FCAL;
+		bool USE_BCAL;
+		bool USE_CCAL;
 
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t brun(jana::JEventLoop *locEventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.

--- a/src/libraries/PID/PID_init.cc
+++ b/src/libraries/PID/PID_init.cc
@@ -22,7 +22,7 @@ using namespace jana;
 #include "DEventRFBunch_factory.h"
 #include "DEventRFBunch_factory_Thrown.h"
 #include "DEventRFBunch_factory_Calibrations.h"
-#include "DEventRFBunch_factory_FCAL_CCAL.h"
+#include "DEventRFBunch_factory_CalorimeterOnly.h"
 #include "DDetectorMatches_factory.h"
 #include "DDetectorMatches_factory_WireBased.h"
 #include "DMCThrown_factory_FinalState.h"
@@ -56,7 +56,7 @@ jerror_t PID_init(JEventLoop *loop)
 	loop->AddFactory(new DEventRFBunch_factory);
 	loop->AddFactory(new DEventRFBunch_factory_Thrown);
 	loop->AddFactory(new DEventRFBunch_factory_Calibrations);
-	loop->AddFactory(new DEventRFBunch_factory_FCAL_CCAL);
+	loop->AddFactory(new DEventRFBunch_factory_CalorimeterOnly);
 	loop->AddFactory(new DDetectorMatches_factory);
 	loop->AddFactory(new DDetectorMatches_factory_WireBased);
 	loop->AddFactory(new DMCThrown_factory_FinalState);

--- a/src/libraries/PID/PID_init.cc
+++ b/src/libraries/PID/PID_init.cc
@@ -22,6 +22,7 @@ using namespace jana;
 #include "DEventRFBunch_factory.h"
 #include "DEventRFBunch_factory_Thrown.h"
 #include "DEventRFBunch_factory_Calibrations.h"
+#include "DEventRFBunch_factory_FCAL_CCAL.h"
 #include "DDetectorMatches_factory.h"
 #include "DDetectorMatches_factory_WireBased.h"
 #include "DMCThrown_factory_FinalState.h"
@@ -55,6 +56,7 @@ jerror_t PID_init(JEventLoop *loop)
 	loop->AddFactory(new DEventRFBunch_factory);
 	loop->AddFactory(new DEventRFBunch_factory_Thrown);
 	loop->AddFactory(new DEventRFBunch_factory_Calibrations);
+	loop->AddFactory(new DEventRFBunch_factory_FCAL_CCAL);
 	loop->AddFactory(new DDetectorMatches_factory);
 	loop->AddFactory(new DDetectorMatches_factory_WireBased);
 	loop->AddFactory(new DMCThrown_factory_FinalState);

--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
@@ -663,8 +663,7 @@ jerror_t JEventProcessor_HLDetectorTiming::evnt(JEventLoop *loop, uint64_t event
     const DEventRFBunch *thisRFBunch = NULL;
     if(NO_TRACKS) {
 	    // If the drift chambers are turned off, we'll need to use the neutral showers
-	    // maybe a dedicated factory is needed for this case...
-	    loop->GetSingle(thisRFBunch);
+	    loop->GetSingle(thisRFBunch, "FCAL_CCAL");
     } else {
 	    loop->GetSingle(thisRFBunch, "Calibrations"); // SC only hits
     }


### PR DESCRIPTION
Added class for calculating the RF bunch for an event using only calorimeter information, using tag "CalorimeterOnly".  The detectors being used for this calculation can be toggled.  

Also added the ability to use the output of a particular factory as the default RF time calculation via command-line option, e.g., -PEVENTRFBUNCH:USE_TAG=CalorimeterOnly

Combo-based RF bunch calculations are still handled in the ANALYSIS library.

Also some changes for PrimEx calibrations.