### PR TITLE
Fix SSP parser for BLOCKLEVEL>1

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -2126,6 +2126,8 @@ void DEVIOWorkerThread::ParseSSPBank(uint32_t rocid, uint32_t* &iptr, uint32_t *
 			}
 				break;
 			case 1:  // Block Trailer
+				pe_iter = current_parsed_events.begin();
+				pe = NULL;
 				if(VERBOSE>7) cout << "     SSP/DIRC Block Trailer" << endl;
 				break;
 			case 2:  // Event Header

--- a/src/libraries/DIRC/DDIRCPmtHit_factory.cc
+++ b/src/libraries/DIRC/DDIRCPmtHit_factory.cc
@@ -89,7 +89,7 @@ jerror_t DDIRCPmtHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     // loop over leading edges
     for (unsigned int i=0; i < digihits.size(); i++) {
 	    const DDIRCTDCDigiHit *digihit_lead = digihits[i];
-	    if(digihit_lead->edge == 1) continue; // remove trailing edges 
+	    if(digihit_lead->edge == 0) continue; // remove trailing edges 
 	    // Note this doesn't match SSP data format document, but appears correct for data...
 	    
 	    double timeOverThreshold = 0.;
@@ -98,7 +98,7 @@ jerror_t DDIRCPmtHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	    const DDIRCTDCDigiHit *digihit_trail = NULL;
 	    for (unsigned int j=0; j < digihits.size(); j++) {
 		    digihit_trail = digihits[j];
-		    if(i==j || digihit_trail->edge == 0) continue; // remove leading edges
+		    if(i==j || digihit_trail->edge == 1) continue; // remove leading edges
 		    // Note this doesn't match SSP data format document, but appears correct for data...
 		    
 		    // discard hits from different channels

--- a/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.cc
+++ b/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.cc
@@ -108,9 +108,9 @@ jerror_t JEventProcessor_DIRC_online::init(void) {
 	hHit_TimeOverThreshold[i] = new TH1I("Hit_TimeOverThreshold"+strN,"DIRCPmtHit time-over-threshold"+strT+"; time-over-threshold (ns); hits",100,0.0,100.);
 	hHit_TimeOverThresholdVsChannel[i] = new TH2I("Hit_TimeOverThresholdVsChannel"+strN,"DIRCPmtHit time-over-threshold vs channel"+strT+"; channel; time-over-threshold [ns]",Nchannels,-0.5,-0.5+Nchannels,100,0.0,100.);
 	hHit_TimeOverThresholdVsTime[i] = new TH2I("Hit_TimeOverThresholdVsTime"+strN,"DIRCPmtHit time-over-threshold vs time"+strT+"; time; time-over-threshold [ns]",300,0,300,100,0.0,100.);
-	hHit_tdcTime[i] = new TH1I("Hit_Time"+strN,"DIRCPmtHit time"+strT+";time [ns]; hits",500,0.0,500.0);
+	hHit_tdcTime[i] = new TH1I("Hit_Time"+strN,"DIRCPmtHit time"+strT+";time [ns]; hits",300,0.0,300.0);
 	hHit_tdcTimeVsChannel[i] = new TH2I("Hit_TimeVsChannel"+strN,"DIRCPmtHit time vs. channel"+strT+"; channel;time [ns]",Nchannels,-0.5,-0.5+Nchannels,300,0.0,300.0);
-	hHit_tdcTimeDiffVsChannel[i] = new TH2I("Hit_TimeDiffVsChannel"+strN,"DIRCPmtHit time vs. channel"+strT+"; channel;time [ns]",Nchannels,-0.5,-0.5+Nchannels,500,-300.0,300.0);
+	hHit_tdcTimeDiffVsChannel[i] = new TH2I("Hit_TimeDiffVsChannel"+strN,"DIRCPmtHit time vs. channel"+strT+"; channel;time [ns]",Nchannels,-0.5,-0.5+Nchannels,300,-300.0,300.0);
         hitDir->cd();
     }
 


### PR DESCRIPTION
With new DIRC LED data using BLOCKLEVEL=40 there was a segfault in the EVIO parser.  A commit in this PR https://github.com/JeffersonLab/halld_recon/commit/b138af4851fa09cb2595bc63f63f8df9d477af34 appears to fix the problem, but should be checked by David.