### PR TITLE
DIRC EVIO updates

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -2133,8 +2133,9 @@ void DEVIOWorkerThread::ParseSSPBank(uint32_t rocid, uint32_t* &iptr, uint32_t *
 			case 2:  // Event Header
 				slot       = ((*iptr)>>22) & 0x1F;
 				itrigger   = ((*iptr)>> 0) & 0x3FFFFF;
-				if(itrigger != last_itrigger) pe = *pe_iter++;
-				last_itrigger = itrigger;
+				pe = *pe_iter++;
+				//if(itrigger != last_itrigger) pe = *pe_iter++;
+				//last_itrigger = itrigger;
 				if(VERBOSE>7) cout << "     SSP/DIRC Event Header:  slot=" << slot << " itrigger=" << itrigger << endl;
 				if( slot != slot_bh ){
 					jerr << "Slot from SSP/DIRC event header does not match slot from last block header (" <<slot<<" != " << slot_bh << ")" <<endl;

--- a/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.h
+++ b/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.h
@@ -27,6 +27,8 @@
 #include <DAQ/DF1TDCConfig.h>
 #include <DAQ/DCAEN1290TDCConfig.h>
 #include <DAQ/DCAEN1290TDCHit.h>
+#include <DAQ/DDIRCTDCHit.h>
+#include <DAQ/DDIRCTriggerTime.h>
 #include <DAQ/DEPICSvalue.h>
 #include <DAQ/DEventTag.h>
 #include <DAQ/DCODAROCInfo.h>
@@ -115,6 +117,11 @@ class DEVIOBufferWriter
                            vector<const Df125TriggerTime*>   &f125tts,
                            vector<const Df125WindowRawData*> &f125wrds,
                            vector<const Df125Config*>        &f125configs,
+                           unsigned int Nevents) const;
+
+		void WriteDircData(vector<uint32_t> &buff,
+                           vector<const DDIRCTDCHit*> &dirctdchits,
+                           vector<const DDIRCTriggerTime*>   &dirctts,
                            unsigned int Nevents) const;
 
 		void WriteEPICSData(vector<uint32_t> &buff,


### PR DESCRIPTION
-  Add ability to write out DIRC TDC hits to evio_writer. now they will actually be part of skims!
- Change to EVIO parsing so that it works with these events which have 1 block per event.  Doesn't seem to affect multi block data.   