### PR TITLE
Add optional data field for "user defined" data in HDDM

### DIFF
--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -26,8 +26,9 @@
         <origin t="float" vx="float" vy="float" vz="float"/>
       </vertex>
       <random minOccurs="0" maxOccurs="1" seed1="int" seed2="int" seed3="int" seed4="int"/>
-      <userData>
-	<userDataField data="float" minOccurs="0" maxOccurs="unlimited"/>
+      <userData minOccurs="0" maxOccurs="unbounded">
+	<userDataFloat data="float" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
+	<userDataInt data="int" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
       </userData>
     </reaction>
     <hitView minOccurs="0" version="2.0">

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -26,6 +26,9 @@
         <origin t="float" vx="float" vy="float" vz="float"/>
       </vertex>
       <random minOccurs="0" maxOccurs="1" seed1="int" seed2="int" seed3="int" seed4="int"/>
+      <userData>
+	<userDataField data="float" minOccurs="0" maxOccurs="unlimited"/>
+      </userData>
     </reaction>
     <hitView minOccurs="0" version="2.0">
       <centralDC minOccurs="0">

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -26,9 +26,9 @@
         <origin t="float" vx="float" vy="float" vz="float"/>
       </vertex>
       <random minOccurs="0" maxOccurs="1" seed1="int" seed2="int" seed3="int" seed4="int"/>
-      <userData minOccurs="0" maxOccurs="unbounded">
-	<userDataFloat data="float" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
-	<userDataInt data="int" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
+      <userData minOccurs="0" maxOccurs="unbounded" description="string">
+        <userDataFloat data="float" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
+        <userDataInt data="int" meaning="string" minOccurs="0" maxOccurs="unbounded"/>
       </userData>
     </reaction>
     <hitView minOccurs="0" version="2.0">
@@ -120,9 +120,9 @@
       <DIRC minOccurs="0">
         <dircTruthBarHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float" px="float" py="float" pz="float" E="float" pdg="int" bar="int" track="int"/>
         <dircTruthPmtHit maxOccurs="unbounded" minOccurs="0" t="float" x="float" y="float" z="float" E="float" ch="int" key_bar="int">
-	  <dircTruthPmtHitExtra maxOccurs="unbounded" minOccurs="0" t_fixed="float" path="long" refl="int" bbrefl="boolean"/>
-	</dircTruthPmtHit>
-	<dircPmtHit maxOccurs="unbounded" minOccurs="0" t="float" ch="int"/>
+      <dircTruthPmtHitExtra maxOccurs="unbounded" minOccurs="0" t_fixed="float" path="long" refl="int" bbrefl="boolean"/>
+    </dircTruthPmtHit>
+    <dircPmtHit maxOccurs="unbounded" minOccurs="0" t="float" ch="int"/>
       </DIRC>
       <forwardTOF minOccurs="0">
         <ftofCounter bar="int" maxOccurs="unbounded" minOccurs="0" plane="int">
@@ -185,27 +185,27 @@
           <psHit dE="float" t="float" maxOccurs="unbounded"/>
           <psTruthHit dE="float" t="float" maxOccurs="unbounded" itrack="int" ptype="int"/>
         </psTile>
-	    <psTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" column="int" arm="int" t="float" track="int" x="float" y="float" z="float">
-	      <trackID minOccurs="0" itrack="int"/>
-	    </psTruthPoint>
+        <psTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" column="int" arm="int" t="float" track="int" x="float" y="float" z="float">
+          <trackID minOccurs="0" itrack="int"/>
+        </psTruthPoint>
       </pairSpectrometerFine>
       <pairSpectrometerCoarse minOccurs="0">
         <pscPaddle maxOccurs="unbounded" minOccurs="0" module="int" arm="int">
           <pscHit dE="float" t="float" maxOccurs="unbounded"/>
           <pscTruthHit dE="float" t="float" maxOccurs="unbounded" itrack="int" ptype="int"/>
         </pscPaddle>
-	    <pscTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" module="int" t="float" arm="int" track="int" x="float" y="float" z="float">
-	      <trackID minOccurs="0" itrack="int"/>
-	    </pscTruthPoint>
+        <pscTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" module="int" t="float" arm="int" track="int" x="float" y="float" z="float">
+          <trackID minOccurs="0" itrack="int"/>
+        </pscTruthPoint>
       </pairSpectrometerCoarse>
       <tripletPolarimeter minOccurs="0">
         <tpolSector maxOccurs="unbounded" minOccurs="0" ring="int" sector="int">
           <tpolHit dE="float" t="float" maxOccurs="unbounded"/>
           <tpolTruthHit dE="float" t="float" maxOccurs="unbounded" itrack="int" ptype="int"/>
         </tpolSector>
-	    <tpolTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" r="float" t="float" track="int">
-	      <trackID minOccurs="0" itrack="int"/>
-	    </tpolTruthPoint>
+        <tpolTruthPoint E="float" dEdx="float" maxOccurs="unbounded" minOccurs="0" phi="float" primary="boolean" ptype="int" px="float" py="float" pz="float" r="float" t="float" track="int">
+          <trackID minOccurs="0" itrack="int"/>
+        </tpolTruthPoint>
       </tripletPolarimeter>
       <mcTrajectory minOccurs="0">
         <mcTrajectoryPoint E="float" dE="float" maxOccurs="unbounded" mech="int" minOccurs="0" part="int" primary_track="int" px="float" py="float" pz="float" radlen="float" step="float" t="float" track="int" x="float" y="float" z="float"/>
@@ -214,14 +214,14 @@
          <RFsubsystem maxOccurs="unbounded" minOccurs="0" jtag="string" tsync="float" tunit="ns"/>
       </RFtime>
       <forwardMWPC minOccurs="0">
-	    <fmwpcChamber layer="int" maxOccurs="unbounded" minOccurs="0" wire="int">
-		  <fmwpcTruthHit dE="float" dx="float" maxOccurs="unbounded" t="float"/>
-	      <fmwpcHit dE="float" maxOccurs="unbounded" t="float"/>
+        <fmwpcChamber layer="int" maxOccurs="unbounded" minOccurs="0" wire="int">
+          <fmwpcTruthHit dE="float" dx="float" maxOccurs="unbounded" t="float"/>
+          <fmwpcHit dE="float" maxOccurs="unbounded" t="float"/>
         </fmwpcChamber>
         <fmwpcTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
           <trackID minOccurs="0" itrack="int"/>
         </fmwpcTruthPoint>
-	  </forwardMWPC>
+      </forwardMWPC>
 
     </hitView>
     <reconView minOccurs="0" version="1.0">


### PR DESCRIPTION
This is due to a request from Eugene to add a field for optional generator-specific data which can be propagated through the analysis chain.