### PR TITLE
Skim changes

### DIFF
--- a/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.cc
+++ b/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.cc
@@ -52,6 +52,7 @@ void DEVIOBufferWriter::WriteEventToBuffer(JEventLoop *loop, vector<uint32_t> &b
 	vector<const DCODAEventInfo*>     coda_events;
 	vector<const DCODAROCInfo*>       coda_rocinfos;
     vector<const DL1Info*>            l1_info;
+    vector<const Df250Scaler*>        f250scalars;
 
     // Optionally, allow the user to only save hits from specific objects
     if(objects_to_save.size()==0) {

--- a/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.h
+++ b/src/plugins/Utilities/evio_writer/DEVIOBufferWriter.h
@@ -44,6 +44,8 @@
 #include <DAQ/DDAQConfig.h>
 #include <DAQ/DF1TDCBORConfig.h>
 #include <DAQ/Df250Config.h>
+#include <DAQ/Df250Scaler.h>
+#include <DAQ/Df250AsyncPedestal.h>
 
 #include <DANA/DStatusBits.h>
 #include <TTAB/DTranslationTable.h>

--- a/src/plugins/Utilities/trigger_skims/JEventProcessor_trigger_skims.cc
+++ b/src/plugins/Utilities/trigger_skims/JEventProcessor_trigger_skims.cc
@@ -156,11 +156,11 @@ jerror_t JEventProcessor_trigger_skims::evnt(JEventLoop *locEventLoop, uint64_t 
 			// FCAL LED trigger fired
 			is_FCAL_LED_trigger = true;
 		}
-		if (trig->fp_trig_mask & 0x020) {   // Trigger front-panel bit 5
+		if (trig->fp_trig_mask & 0x010) {   // Trigger front-panel bit 5
 			// CCAL LED trigger fired
 			is_CCAL_LED_trigger = true;
 		}
-		if (trig->fp_trig_mask & 0x040) {   // Trigger front-panel bit 6
+		if (trig->fp_trig_mask & 0x020) {   // Trigger front-panel bit 6
 			// CCAL LED trigger fired
 			is_CCAL_LED_trigger = true;
 		}


### PR DESCRIPTION
1) use correct CCAL trigger bits (zero-counting error)
2) write out Df250Scaler objects

Note that currently the software does not read in or write out Df250AsyncPedestal
objects.  If Sasha provides the information for these banks, they can be implemented.