### PR TITLE
Fix crash in ST matching

### DIFF
--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.cc
@@ -81,23 +81,6 @@ jerror_t JEventProcessor_ST_Tresolution::init(void)
 jerror_t JEventProcessor_ST_Tresolution::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
 	// This is called whenever the run number changes
-  // Get the particleID object for each run
-  vector<const DParticleID *> dParticleID_algos;
-  eventLoop->Get(dParticleID_algos);
-  if(dParticleID_algos.size() < 1)
-    {
-      _DBG_<<"Unable to get a DParticleID object! NO PID will be done!"<<endl;
-      return RESOURCE_UNAVAILABLE;
-    }
-  dParticleID = dParticleID_algos[0];
-  
-  // We want to be use some of the tools available in the RFTime factory 
-  // Specifically steping the RF back to a chosen time
-  dRFTimeFactory = static_cast<DRFTime_factory*>(eventLoop->GetFactory("DRFTime"));
-  
-  // Be sure that DRFTime_factory::init() and brun() are called
-  vector<const DRFTime*> locRFTimes;
-  eventLoop->Get(locRFTimes);
   
   //RF Period
   vector<double> locRFPeriodVector;
@@ -169,10 +152,10 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
   vector<const DSCHit *> scHitVector;
   loop->Get(scHitVector);
 
-  // RF time object
+  // RF time object (and factory)
   const DRFTime* thisRFTime = NULL;
   vector <const DRFTime*> RFTimeVector;
-  loop->Get(RFTimeVector);
+  auto dRFTimeFactory = static_cast<DRFTime_factory*>(loop->Get(RFTimeVector));
   if (RFTimeVector.size() != 0)
     thisRFTime = RFTimeVector[0];
 
@@ -187,6 +170,10 @@ jerror_t JEventProcessor_ST_Tresolution::evnt(JEventLoop *loop, uint64_t eventnu
   // Grab the associated RF bunch object
   const DEventRFBunch *thisRFBunch = NULL;
   loop->GetSingle(thisRFBunch);
+  
+  // Grab DParticleID object
+  const DParticleID *dParticleID = NULL;
+  loop->GetSingle(dParticleID);
 
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
     {   

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
@@ -56,8 +56,6 @@ class JEventProcessor_ST_Tresolution:public jana::JEventProcessor{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
-		const DParticleID* dParticleID;
-		DRFTime_factory *dRFTimeFactory;
 		double z_target_center;  // Target center along z
 		double dRFBunchPeriod;   // RF bunch period from CCDBr
 		//////////////////////////////////


### PR DESCRIPTION
This addresses issue #71. It fixes one instance of a problematic pattern that may cause similar crashes in other plugins. See comments in issue #71 for details.

