### PR TITLE
Pid update jun19

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -3326,17 +3326,17 @@ void DParticleID::Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHyp
 	  shared_ptr<const DBCALShowerMatchParams>bcalparms=locChargedTrackHypothesis->Get_BCALShowerMatchParams(); 
 	  shared_ptr<const DFCALShowerMatchParams>fcalparms=locChargedTrackHypothesis->Get_FCALShowerMatchParams();
 	  if (bcalparms!=NULL){
-	    double E_over_p_mean=1.;
+	    double E_over_p_mean=GetEOverPMean(SYS_BCAL,p);
 	    double diff=bcalparms->dBCALShower->E/p-E_over_p_mean;
-	    double sigma=0.1; 
+	    double sigma=GetEOverPSigma(SYS_BCAL,p);
 	    double chisq=diff*diff/(sigma*sigma);
 	    locChiSq_Total+=chisq;
 	    locNDF_Total+=1;
 	  } 
 	  if (fcalparms!=NULL){
-	    double E_over_p_mean=1.;
+	    double E_over_p_mean=GetEOverPMean(SYS_FCAL,p);
 	    double diff=fcalparms->dFCALShower->getEnergy()/p-E_over_p_mean;
-	    double sigma=0.1;
+	    double sigma=GetEOverPSigma(SYS_FCAL,p);
 	    double chisq=diff*diff/(sigma*sigma);
 	    locChiSq_Total+=chisq;
 	    locNDF_Total+=1;

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -99,7 +99,10 @@ class DParticleID:public jana::JObject
 		virtual double GetTimeVariance(DetectorSystem_t detector,
 					       Particle_t particle,
 					       double p) const=0;
-
+		virtual double GetEOverPMean(DetectorSystem_t detector,
+					     double p) const=0;
+		virtual double GetEOverPSigma(DetectorSystem_t detector,
+					      double p) const=0;
 
 		/****************************************************** DISTANCE TO TRACK ******************************************************/
 

--- a/src/libraries/PID/DParticleID_PID1.cc
+++ b/src/libraries/PID/DParticleID_PID1.cc
@@ -234,19 +234,19 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
       }
     }
   } 
-  /*
+  
   if (jcalib->Get("BCAL/EOverPSigma",vals)==false){  
     map<string,double> &row = vals[0];
     dEOverPSigmaParams_BCAL.push_back(row["s0"]);
     dEOverPSigmaParams_BCAL.push_back(row["s1"]);
     dEOverPSigmaParams_BCAL.push_back(row["s2"]);
-   }
+  }
   if (jcalib->Get("BCAL/EOverPMean",vals)==false){
     map<string,double> &row = vals[0];
     dEOverPMeanParams_BCAL.push_back(row["m0"]);
     dEOverPMeanParams_BCAL.push_back(row["m1"]);
     dEOverPMeanParams_BCAL.push_back(row["m2"]);
-   }
+  }
 
 
   if (jcalib->Get("FCAL/EOverPSigma",vals)==false){  
@@ -254,14 +254,14 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     dEOverPSigmaParams_FCAL.push_back(row["s0"]);
     dEOverPSigmaParams_FCAL.push_back(row["s1"]);
     dEOverPSigmaParams_FCAL.push_back(row["s2"]);
-   }
+  }
   if (jcalib->Get("FCAL/EOverPMean",vals)==false){
     map<string,double> &row = vals[0];
     dEOverPMeanParams_FCAL.push_back(row["m0"]);
     dEOverPMeanParams_FCAL.push_back(row["m1"]);
     dEOverPMeanParams_FCAL.push_back(row["m2"]);
-   }
-  */
+  }
+  
   if (jcalib->Get("FCAL/TimeSigmas",vals)==false){ 
     for(unsigned int i=0; i<vals.size(); i++){
       map<string,double> &row = vals[i];
@@ -304,7 +304,7 @@ DParticleID_PID1::~DParticleID_PID1()
 {
 
 }
-/*
+
 double DParticleID_PID1::GetEOverPMean(DetectorSystem_t detector,
 				       double p) const{
   double mean=0;
@@ -340,7 +340,7 @@ double DParticleID_PID1::GetEOverPSigma(DetectorSystem_t detector,
   }
   return mean;
 }
-*/
+
 
 double DParticleID_PID1::GetProtondEdxMean_SC(double locBeta) const{
   double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);

--- a/src/libraries/PID/DParticleID_PID1.h
+++ b/src/libraries/PID/DParticleID_PID1.h
@@ -22,6 +22,8 @@ class DParticleID_PID1:public DParticleID{
 	jerror_t GetdEdxSigma_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const;
 	double GetProtondEdxMean_SC(double locBeta) const;
 	double GetProtondEdxSigma_SC(double locBeta) const;
+	double GetEOverPMean(DetectorSystem_t detector,double p) const;
+	double GetEOverPSigma(DetectorSystem_t detector,double p) const;
 	double GetTimeVariance(DetectorSystem_t detector,Particle_t particle,double p) const;
 
 	jerror_t CalcDCdEdxChiSq(DChargedTrackHypothesis *locChargedTrackHypothesis) const;
@@ -39,6 +41,9 @@ class DParticleID_PID1:public DParticleID{
 	vector<float> ddEdxMeanParams_CDC_PiPlus;
 	vector<float> ddEdxMeanParams_CDC_Electron;
 	vector<float> ddEdxMeanParams_SC_Proton;
+
+	vector<float> dEOverPMeanParams_BCAL;
+	vector<float> dEOverPMeanParams_FCAL;
 
 	vector<float> ddEdxSigmaParams_FDC_Proton;
 	vector<float> ddEdxSigmaParams_FDC_KPlus;
@@ -58,12 +63,14 @@ class DParticleID_PID1:public DParticleID{
 	vector<float> dTimeSigmaParams_BCAL_Proton;
 	vector<float> dTimeSigmaParams_BCAL_KPlus;
 	vector<float> dTimeSigmaParams_BCAL_PiPlus;
-	vector<float> dTimeSigmaParams_BCAL_Positron;	
+	vector<float> dTimeSigmaParams_BCAL_Positron;
+	vector<float> dEOverPSigmaParams_BCAL;
 
 	vector<float> dTimeSigmaParams_FCAL_Proton;
 	vector<float> dTimeSigmaParams_FCAL_KPlus;
 	vector<float> dTimeSigmaParams_FCAL_PiPlus;
 	vector<float> dTimeSigmaParams_FCAL_Positron;
+	vector<float> dEOverPSigmaParams_FCAL;
 
  private:
   int DEBUG_LEVEL;


### PR DESCRIPTION
Reformulates vertex constraints for charged particles in the magnetic field to avoid conditions that lead to NaNs in the kinematic fitting matrices, which were quite common for topologies with detached vertices.
Also adds calibrations for E/p for use with PIDFOM.