### PR TITLE
Kin fit update july19

### DIFF
--- a/src/libraries/KINFITTER/DKinFitter.h
+++ b/src/libraries/KINFITTER/DKinFitter.h
@@ -145,7 +145,7 @@ class DKinFitter //purely virtual: cannot directly instantiate class, can only i
 		void Calc_dF_Vertex_NotDecaying(size_t locFIndex, const DKinFitParticle* locKinFitParticle);
 		void Calc_dF_Vertex_Decaying_Accel(size_t locFIndex, const DKinFitParticle* locKinFitParticle, const DKinFitParticle* locKinFitParticle_DecayingSource, double locStateSignMultiplier);
 		void Calc_dF_Vertex_Decaying_NonAccel(size_t locFIndex, const DKinFitParticle* locKinFitParticle, const DKinFitParticle* locKinFitParticle_DecayingSource, double locStateSignMultiplier);
-		void Calc_Vertex_Params(const DKinFitParticle* locKinFitParticle, double& locJ, TVector3& locQ, TVector3& locM, TVector3& locD);
+		bool Calc_Vertex_Params(const DKinFitParticle* locKinFitParticle, double& locJ, TVector3& locQ, TVector3& locM, TVector3& locD);
 		TVector3 Calc_VertexParams_P4DerivedAtCommonVertex(const DKinFitParticle* locKinFitParticle);
 
 		/************************************************************* UPDATE & FINAL ***************************************************************/

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -103,9 +103,19 @@ unsigned int DTrackFitterKalmanSIMD::locate(vector<double>&xx,double x){
 // Crude approximation for the variance in drift distance due to smearing
 double DTrackFitterKalmanSIMD::fdc_drift_variance(double t) const {
    //return FDC_ANODE_VARIANCE;
-   if (t<5.) t=5.;
+  double dt=0.;
+  double t_lo=DRIFT_RES_PARMS[3];
+  double t_hi=DRIFT_RES_PARMS[4];
+   if (t<t_lo) t=t_lo;
+   if (t>t_hi){
+     t=t_hi;
+     dt=t-t_hi;
+   }
    double sigma=DRIFT_RES_PARMS[0]/(t+1.)+DRIFT_RES_PARMS[1]+DRIFT_RES_PARMS[2]*t*t;
-
+   if (dt>0){
+     sigma+=DRIFT_RES_PARMS[5]*dt;
+   }
+  
    return sigma*sigma;
 }
 
@@ -550,7 +560,12 @@ DTrackFitterKalmanSIMD::DTrackFitterKalmanSIMD(JEventLoop *loop):DTrackFitter(lo
    jcalib->Get("FDC/drift_resolution_parms",drift_res_parms); 
    DRIFT_RES_PARMS[0]=drift_res_parms["p0"];   
    DRIFT_RES_PARMS[1]=drift_res_parms["p1"];
-   DRIFT_RES_PARMS[2]=drift_res_parms["p2"]; 
+   DRIFT_RES_PARMS[2]=drift_res_parms["p2"];  
+   map<string,double>drift_res_ext;
+   jcalib->Get("FDC/drift_resolution_ext",drift_res_ext); 
+   DRIFT_RES_PARMS[3]=drift_res_ext["t_low"];   
+   DRIFT_RES_PARMS[4]=drift_res_ext["t_high"];
+   DRIFT_RES_PARMS[5]=drift_res_ext["res_slope"]; 
 
    // Time-to-distance function parameters for FDC
    map<string,double>drift_func_parms;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -527,7 +527,7 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
   double FDC_DRIFT_BSCALE_PAR1,FDC_DRIFT_BSCALE_PAR2;
 
   // Parameters for drift resolution
-  double DRIFT_RES_PARMS[3];
+  double DRIFT_RES_PARMS[6];
   // parameters for time-to-distance function for FDC
   double DRIFT_FUNC_PARMS[6];
 


### PR DESCRIPTION
Reverts back to the old vertex constraint equations, only using the alternate form if the first version has numerical problems due to the argument to arcsin going out of range.  Although the second version of the constraint equations  seemed to have the right behaviour for the means of the pulls, the error distributions looked much too narrow for vertex-only fits.