### PR TITLE
Implement suggested calorimeter fiducial cuts at analysis level

### DIFF
--- a/src/libraries/PID/DNeutralShower_factory_PreSelect.cc
+++ b/src/libraries/PID/DNeutralShower_factory_PreSelect.cc
@@ -13,13 +13,17 @@
 jerror_t DNeutralShower_factory_PreSelect::init(void)
 {
 	//Setting this flag makes it so that JANA does not delete the objects in _data.  This factory will manage this memory. 
-		//This is because some/all of these pointers are just copied from earlier objects, and should not be deleted.  
+	//This is because some/all of these pointers are just copied from earlier objects, and should not be deleted.  
 	SetFactoryFlag(NOT_OBJECT_OWNER);
 
 	dMinFCALE = 0.1;
 	dMinBCALE = 0.1;
 	dMinBCALNcell = 2;
-
+	dMaxFCALR = 105.5;
+	dMaxBCALZ = 393.0;
+	
+	dFCALInnerRingCut = true;
+	
 	return NOERROR;
 }
 
@@ -31,6 +35,39 @@ jerror_t DNeutralShower_factory_PreSelect::brun(jana::JEventLoop *locEventLoop, 
 	gPARMS->SetDefaultParameter("PRESELECT:MIN_FCAL_E", dMinFCALE);
 	gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_E", dMinBCALE);
 	gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_NCELL", dMinBCALNcell);
+	gPARMS->SetDefaultParameter("PRESELECT:MIN_FCAL_R", dMaxFCALR);
+	gPARMS->SetDefaultParameter("PRESELECT:MIN_BCAL_Z", dMaxBCALZ);
+	gPARMS->SetDefaultParameter("PRESELECT:FCAL_INNER_CUT", dFCALInnerRingCut);
+
+	// get FCAL Geometry object
+	vector< const DFCALGeometry * > fcalGeomVec;
+	locEventLoop->Get( fcalGeomVec );
+
+	if( fcalGeomVec.size() != 1 ){
+		cerr << "Could not load FCAL Geometry!" << endl;
+		return RESOURCE_UNAVAILABLE;
+	}
+  	dFCALGeometry = fcalGeomVec[0];		
+
+	// build list of channels in the inner ring.  Pick all channels which
+	// touch the beam hole (including corners!)
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 27, 27 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 27, 28 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 27, 29 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 27, 30 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 27, 31 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 31, 27 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 31, 28 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 31, 29 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 31, 30 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 31, 31 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 28, 27 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 29, 27 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 30, 27 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 28, 31 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 29, 31 ) );
+	dFCALInnerChannels.push_back( dFCALGeometry->channel( 30, 31 ) );
+
 
 	return NOERROR;
 }
@@ -54,10 +91,31 @@ jerror_t DNeutralShower_factory_PreSelect::evnt(jana::JEventLoop *locEventLoop, 
 		{
 			if(locNeutralShowers[loc_i]->dEnergy < dMinFCALE) 
 				continue;
+			// Fiducial cut: reject showers whose center is in the outer range of the FCAL,
+			//   which is partially shadowed by the BCAL
+			if(locNeutralShowers[loc_i]->dSpacetimeVertex.Rho() > dMaxFCALR)
+				continue;
+			// Fiducial cut: reject showers in the inner ring(s) which may leak into the beam hole 
+			if(dFCALInnerRingCut) {
+				// sanity check
+				if(dFCALGeometry == nullptr) 
+					jerr << "In DNeutralShower_factory_PreSelect::evnt(), no FCAL Geometry???" << endl;
+				int row = dFCALGeometry->row((float)locNeutralShowers[loc_i]->dSpacetimeVertex.Y());
+				int col = dFCALGeometry->column((float)locNeutralShowers[loc_i]->dSpacetimeVertex.X());
+				int channel = dFCALGeometry->channel(row,col);
+				
+				// is the center of shower in one of the channels outside of our fiducial cut?
+				if( find(dFCALInnerChannels.begin(), dFCALInnerChannels.end(), channel) 
+						!= dFCALInnerChannels.end() )
+					continue;
+			}
 		}
 		else if(locNeutralShowers[loc_i]->dDetectorSystem == SYS_BCAL)
 		{
 			if(locNeutralShowers[loc_i]->dEnergy < dMinBCALE)
+				continue;
+			// Fiducial cut: reject showers too close to the downstream face of the BCAL 
+			if(locNeutralShowers[loc_i]->dSpacetimeVertex.Z() > dMaxBCALZ)
 				continue;
 
 			const DBCALShower* locBCALShower = NULL;

--- a/src/libraries/PID/DNeutralShower_factory_PreSelect.h
+++ b/src/libraries/PID/DNeutralShower_factory_PreSelect.h
@@ -14,6 +14,7 @@
 #include <JANA/JFactory.h>
 #include <PID/DNeutralShower.h>
 #include <BCAL/DBCALShower.h>
+#include <FCAL/DFCALGeometry.h>
 
 using namespace std;
 using namespace jana;
@@ -32,10 +33,18 @@ class DNeutralShower_factory_PreSelect : public jana::JFactory<DNeutralShower>
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
+		const DFCALGeometry* dFCALGeometry = nullptr;
+
+
 		//Command-line values will override these
-                double dMinFCALE; //PRESELECT:MIN_FCAL_E 
-                double dMinBCALE; //PRESELECT:MIN_BCAL_E 
+        double dMinFCALE; //PRESELECT:MIN_FCAL_E 
+        double dMinBCALE; //PRESELECT:MIN_BCAL_E 
 		double dMinBCALNcell; //PRESELECT:MIN_BCAL_NCELL
+        double dMaxFCALR; //PRESELECT:MIN_FCAL_R
+        double dMaxBCALZ; //PRESELECT:MIN_BCAL_Z
+        double dFCALInnerRingCut; //PRESELECT:FCAL_INNER_CUT
+        
+        vector< int > dFCALInnerChannels;
 };
 
 #endif // _DNeutralShower_factory_PreSelect_


### PR DESCRIPTION
Implement the cuts suggested by Mark Dalton's studies:
- reject showers in the FCAL/BCAL transition region by cutting on BCAL z and FCAL R
- reject showers near the beampipe by making a list of crystals and rejecting showers who have a center inside of them 