### PR TITLE
Add number of unused showers in ROOT tree format

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -950,7 +950,7 @@ DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DReaction* locReactio
 	return locFinalStateP4;
 }
 
-double DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo) const
+int DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers) const
 {
 	DVector3 locVertex(0.0, 0.0, dTargetZCenter);
 	const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
@@ -959,7 +959,8 @@ double DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, c
 	vector<const DNeutralShower*> locUnusedNeutralShowers;
 	Get_UnusedNeutralShowers(locEventLoop, locParticleCombo, locUnusedNeutralShowers);
 	
-	double locEnergy_UnusedShowers = 0.; 
+	locEnergy_UnusedShowers = 0.; 
+	int locNumber_UnusedShowers = 0;
 	for(size_t loc_i = 0; loc_i < locUnusedNeutralShowers.size(); ++loc_i) {
 		const DNeutralShower* locUnusedNeutralShower = locUnusedNeutralShowers[loc_i];
 
@@ -967,13 +968,14 @@ double DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, c
 		double locFlightTime = (locUnusedNeutralShower->dSpacetimeVertex.Vect() - locVertex).Mag()/SPEED_OF_LIGHT;
 		double locDeltaT = locUnusedNeutralShower->dSpacetimeVertex.T() - locFlightTime - locRFTime;
 		double locDetectorTheta = (locUnusedNeutralShower->dSpacetimeVertex.Vect()-locVertex).Theta()*180./TMath::Pi();
-		if(locDetectorTheta < 2.0 || fabs(locDeltaT) > 4.)
+		if(fabs(locDeltaT) > 4.)
 			continue;		
 
 		locEnergy_UnusedShowers += locUnusedNeutralShower->dEnergy;
+		locNumber_UnusedShowers++;
 	}
 	
-	return locEnergy_UnusedShowers;
+	return locNumber_UnusedShowers;
 }
 
 int DAnalysisUtilities::Calc_Momentum_UnusedTracks(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locSumPMag_UnusedTracks, TVector3 &locSumP3_UnusedTracks) const

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -120,7 +120,7 @@ class DAnalysisUtilities : public JObject
 		DLorentzVector Calc_FinalStateP4(const DReaction* locReaction, const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DReaction* locReaction, const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 
-		double Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo) const;
+		int Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers) const;
 		int Calc_Momentum_UnusedTracks(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locSumPMag_UnusedTracks, TVector3 &locSumP3_UnusedTracks) const;
 
 		// These routines use the MEAURED particle data.  For the kinfit-data result, just use the error matrix from the missing particle

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -764,6 +764,7 @@ void DEventWriterROOT::Create_Branches_Combo(DTreeBranchRegister& locBranchRegis
 		if((locKinFitType == d_SpacetimeFit) || (locKinFitType == d_P4AndSpacetimeFit))
 			locBranchRegister.Register_FundamentalArray<Float_t>("RFTime_KinFit", locNumComboString, dInitNumComboArraySize);
 	}
+	locBranchRegister.Register_FundamentalArray<UChar_t>("NumUnusedShowers", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>("Energy_UnusedShowers", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>("SumPMag_UnusedTracks", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_ClonesArray<TVector3>("SumP3_UnusedTracks", dInitNumComboArraySize);
@@ -1191,7 +1192,9 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		Fill_ComboData(locTreeFillData, locReaction, locParticleCombos[loc_i], loc_i, locObjectToArrayIndexMap);
 		
 		//ENERGY OF UNUSED SHOWERS (access to event loop required)
-		double locEnergy_UnusedShowers = dAnalysisUtilities->Calc_Energy_UnusedShowers(locEventLoop, locParticleCombos[loc_i]);
+		double locEnergy_UnusedShowers = 0.;
+		int locNumber_UnusedShowers = dAnalysisUtilities->Calc_Energy_UnusedShowers(locEventLoop, locParticleCombos[loc_i], locEnergy_UnusedShowers);
+		locTreeFillData->Fill_Array<UChar_t>("NumUnusedShowers", locNumber_UnusedShowers, loc_i);
 		locTreeFillData->Fill_Array<Float_t>("Energy_UnusedShowers", locEnergy_UnusedShowers, loc_i);
 
 		//MOMENTUM OF UNUSED TRACKS (access to event loop required)


### PR DESCRIPTION
To help with current skim studies and analyses, we probably need to look into this in more detail in the future.

The theta cut is removed since the list of showers that go into this calculation now has some fiducial cuts applied in the pre-select stage.