### PR TITLE
Make ANALYSIS library not crash when analyzing data from multiple runs in one program execution

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisAction.h
+++ b/src/libraries/ANALYSIS/DAnalysisAction.h
@@ -40,6 +40,7 @@ class DAnalysisAction
 				//when creating ROOT objects, call CreateAndChangeTo_ActionDirectory() to navigate to the proper directory
 			//if not creating any objects, just define the function but leave it empty
 		virtual void Initialize(JEventLoop* locEventLoop) = 0;
+		virtual void Run_Update(JEventLoop* locEventLoop) = 0;
 
 		//INHERITING CLASSES THAT OVERRIDE THIS METHOD MUST CALL THE BASE METHOD!!!
 		//Reset event (for clearing previously-histogrammed info (duplicate checking)

--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.h
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.h
@@ -66,13 +66,13 @@ class DAnalysisResults_factory : public jana::JFactory<DAnalysisResults>
 		DApplication* dApplication;
 		double dMinThrownMatchFOM;
 		DSourceComboer* dSourceComboer = nullptr;
-		DParticleComboCreator* dParticleComboCreator;
+		DParticleComboCreator* dParticleComboCreator = nullptr;
 		bool dIsMCFlag = false;
 
 		bool dRequireKinFitConvergence = true;
 		unsigned int dKinFitDebugLevel = 0;
-		DKinFitter* dKinFitter;
-		DKinFitUtils_GlueX* dKinFitUtils;
+		DKinFitter* dKinFitter = nullptr;
+		DKinFitUtils_GlueX* dKinFitUtils = nullptr;
 		map<pair<set<shared_ptr<DKinFitConstraint>>, bool>, DKinFitResults*> dConstraintResultsMap; //used for determining if kinfit results will be identical //bool: update cov matrix flag
 		map<tuple<const DParticleCombo*, DKinFitType, bool, set<size_t>>, const DParticleCombo*> dPreToPostKinFitComboMap; //set: no-mass-constrain steps //bool: update cov matrix flag
 

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -72,12 +72,13 @@ class DCutAction_MinTrackHits : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
 		unsigned int dMinTrackHits;
-		const DParticleID* dParticleID;
+		const DParticleID* dParticleID = nullptr;
 };
 
 class DCutAction_ThrownTopology : public DAnalysisAction
@@ -91,12 +92,13 @@ class DCutAction_ThrownTopology : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
 		bool dExclusiveMatchFlag; //if false: inclusive match
-		const DAnalysisUtilities* dAnalysisUtilities;
+		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
 };
 
 class DCutAction_AllTracksHaveDetectorMatch : public DAnalysisAction
@@ -106,6 +108,7 @@ class DCutAction_AllTracksHaveDetectorMatch : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_AllTracksHaveDetectorMatch", false, locActionUniqueString) {}
 
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -120,6 +123,7 @@ class DCutAction_PIDFOM : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -139,6 +143,7 @@ class DCutAction_EachPIDFOM : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -155,6 +160,7 @@ class DCutAction_CombinedPIDFOM : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -171,6 +177,7 @@ class DCutAction_CombinedTrackingFOM : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -185,6 +192,7 @@ class DCutAction_TrueBeamParticle : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_TrueBeamParticle", false, locActionUniqueString){}
 
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -200,6 +208,7 @@ class DCutAction_TrueCombo : public DAnalysisAction
 		dCutAction_ThrownTopology(NULL), dCutAction_TrueBeamParticle(NULL){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		~DCutAction_TrueCombo(void);
 
@@ -209,8 +218,8 @@ class DCutAction_TrueCombo : public DAnalysisAction
 		double dMinThrownMatchFOM;
 		bool dExclusiveMatchFlag;
 
-		DCutAction_ThrownTopology* dCutAction_ThrownTopology;
-		DCutAction_TrueBeamParticle* dCutAction_TrueBeamParticle;
+		DCutAction_ThrownTopology* dCutAction_ThrownTopology = nullptr;
+		DCutAction_TrueBeamParticle* dCutAction_TrueBeamParticle = nullptr;
 };
 
 class DCutAction_BDTSignalCombo : public DAnalysisAction
@@ -232,6 +241,7 @@ class DCutAction_BDTSignalCombo : public DAnalysisAction
 		dIncludeDecayingToReactionFlag(locIncludeDecayingToReactionFlag), dCutAction_TrueBeamParticle(NULL){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		~DCutAction_BDTSignalCombo(void);
 
@@ -242,8 +252,8 @@ class DCutAction_BDTSignalCombo : public DAnalysisAction
 		bool dExclusiveMatchFlag;
 		bool dIncludeDecayingToReactionFlag;
 
-		DCutAction_TrueBeamParticle* dCutAction_TrueBeamParticle;
-		const DAnalysisUtilities* dAnalysisUtilities;
+		DCutAction_TrueBeamParticle* dCutAction_TrueBeamParticle = nullptr;
+		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
 };
 
 class DCutAction_TruePID : public DAnalysisAction
@@ -254,6 +264,7 @@ class DCutAction_TruePID : public DAnalysisAction
 		dTruePID(locTruePID), dInitialPID(locInitialPID), dMinThrownMatchFOM(locMinThrownMatchFOM){}
 
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -271,6 +282,7 @@ class DCutAction_AllTruePID : public DAnalysisAction
 		dMinThrownMatchFOM(locMinThrownMatchFOM){}
 
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -286,6 +298,7 @@ class DCutAction_ProductionVertexZ : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -302,6 +315,7 @@ class DCutAction_AllVertexZ : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -318,6 +332,7 @@ class DCutAction_MaxTrackDOCA : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -335,6 +350,7 @@ class DCutAction_KinFitFOM : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -375,6 +391,7 @@ class DCutAction_MissingMass : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -419,6 +436,7 @@ class DCutAction_MissingMassSquared : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -446,6 +464,7 @@ class DCutAction_InvariantMass : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -468,6 +487,7 @@ class DCutAction_GoodEventRFBunch : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -485,6 +505,7 @@ class DCutAction_TransverseMomentum : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -510,6 +531,7 @@ class DCutAction_TrackHitPattern : public DAnalysisAction
 
 		string Get_ActionName(void) const;
 		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 
 		bool Cut_TrackHitPattern(const DParticleID* locParticleID, const DKinematicData* locTrack) const;
 
@@ -528,6 +550,7 @@ class DCutAction_dEdx : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_dEdx", false, locActionUniqueString){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 		bool Cut_dEdx(const DChargedTrackHypothesis* locChargedTrackHypothesis);
 
 		map<Particle_t, pair<TF1*, TF1*>> dCutMap; //pair: first is lower bound, second is upper bound
@@ -544,7 +567,8 @@ class DCutAction_BeamEnergy : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_BeamEnergy", locUseKinFitResultsFlag, locActionUniqueString),
 		dMinBeamEnergy(locMinBeamEnergy), dMaxBeamEnergy(locMaxBeamEnergy){}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -567,7 +591,8 @@ class DCutAction_TrackFCALShowerEOverP : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_TrackFCALShowerEOverP", locUseKinFitResultsFlag, locActionUniqueString),
 		dShowerEOverPCut(locShowerEOverPCut){}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -589,7 +614,8 @@ class DCutAction_TrackShowerEOverP : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_TrackShowerEOverP", locUseKinFitResultsFlag, locActionUniqueString),
 		dDetector(locDetector), dPID(locPID), dShowerEOverPCut(locShowerEOverPCut) {}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -612,7 +638,8 @@ class DCutAction_PIDDeltaT : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_PIDDeltaT", locUseKinFitResultsFlag, locActionUniqueString),
 		dDeltaTCut(locDeltaTCut), dPID(locPID), dSystem(locSystem){}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -636,7 +663,8 @@ class DCutAction_PIDTimingBeta : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_PIDTimingBeta", false, locActionUniqueString),
 		dMinBeta(locMinBeta), dMaxBeta(locMaxBeta), dPID(locPID), dSystem(locSystem){}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -659,7 +687,8 @@ class DCutAction_NoPIDHit : public DAnalysisAction
 		DAnalysisAction(locReaction, "Cut_NoPIDHit", false, locActionUniqueString),
 		dPID(locPID){}
 
-		void Initialize(JEventLoop* locEventLoop){};
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
 		string Get_ActionName(void) const;
 
 	private:
@@ -679,6 +708,7 @@ class DCutAction_OneVertexKinFit : public DAnalysisAction
 		dMinKinFitCL(locMinKinFitCL), dMinVertexZ(locMinVertexZ), dMaxVertexZ(locMaxVertexZ), dKinFitter(NULL), dKinFitUtils(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		~DCutAction_OneVertexKinFit(void);
 
@@ -690,9 +720,9 @@ class DCutAction_OneVertexKinFit : public DAnalysisAction
 		double dMinVertexZ;
 		double dMaxVertexZ;
 
-		DKinFitter* dKinFitter;
-		DKinFitUtils_GlueX* dKinFitUtils;
-		const DAnalysisUtilities* dAnalysisUtilities;
+		DKinFitter* dKinFitter = nullptr;
+		DKinFitUtils_GlueX* dKinFitUtils = nullptr;
+		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
 
 		TH1I* dHist_ConfidenceLevel;
 		TH1I* dHist_VertexZ;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -59,6 +59,25 @@ void DEventWriterROOT::Initialize(JEventLoop* locEventLoop)
 	}
 }
 
+void DEventWriterROOT::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//Get Target Center Z
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	dTargetCenterZ = 65.0;
+	locGeometry->GetTargetZ(dTargetCenterZ);
+
+	// update run-dependent info/objects
+	for(auto& locMapPair : dCutActionMap_ThrownTopology)
+		locMapPair.second->Run_Update(locEventLoop);
+	for(auto& locMapPair : dCutActionMap_TrueCombo)
+		locMapPair.second->Run_Update(locEventLoop);
+	for(auto& locMapPair : dCutActionMap_BDTSignalCombo)
+		locMapPair.second->Run_Update(locEventLoop);
+}
+
 DEventWriterROOT::~DEventWriterROOT(void)
 {
 	//Delete tree interface objects

--- a/src/libraries/ANALYSIS/DEventWriterROOT.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.h
@@ -49,6 +49,7 @@ class DEventWriterROOT : public JObject
 
 		virtual ~DEventWriterROOT(void);
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		void Create_ThrownTree(JEventLoop* locEventLoop, string locOutputFileName) const;
 

--- a/src/libraries/ANALYSIS/DEventWriterROOT_factory.h
+++ b/src/libraries/ANALYSIS/DEventWriterROOT_factory.h
@@ -11,24 +11,49 @@ class DEventWriterROOT_factory : public jana::JFactory<DEventWriterROOT>
 	public:
 		DEventWriterROOT_factory(){use_factory = 1;}; //prevents JANA from searching the input file for these objects
 		~DEventWriterROOT_factory(){};
+		
+		DEventWriterROOT *dROOTEventWriter = nullptr;
 
 	private:
-		jerror_t brun(jana::JEventLoop *locEventLoop, int locRunNumber)
+	
+		//------------------
+		// brun
+		//------------------
+		jerror_t brun(JEventLoop *loop, int32_t runnumber)
 		{
-			// Create single DEventWriterROOT object and marks the factory as persistent so it doesn't get deleted every event.
-			SetFactoryFlag(PERSISTANT);
+			// (See DTAGHGeometry_factory.h)
+			SetFactoryFlag(NOT_OBJECT_OWNER);
 			ClearFactoryFlag(WRITE_TO_OUTPUT);
+			
+			if( dROOTEventWriter == nullptr ) {
+				dROOTEventWriter = new DEventWriterROOT();
+				dROOTEventWriter->Initialize(loop);
+			} else {
+				dROOTEventWriter->Run_Update(loop);
+			}
 
-			_data.push_back(new DEventWriterROOT());
-			_data.back()->Initialize(locEventLoop);
 			return NOERROR;
 		}
 
+		//------------------
+		// evnt
+		//------------------
+		 jerror_t evnt(JEventLoop *loop, uint64_t eventnumber)
+		 {
+			// Reuse existing DBCALGeometry object.
+			if( dROOTEventWriter ) _data.push_back( dROOTEventWriter );
+			 
+			return NOERROR;
+		 }
+
+
+		//------------------
+		// fini
+		//------------------
 		jerror_t fini(void)
 		{
 			// Delete object: Must be "this" thread so that interfaces deleted properly
-			delete _data[0];
-			_data.clear();
+			delete dROOTEventWriter;
 			return NOERROR;
 		}
 };

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -308,21 +308,15 @@ void DHistogramAction_Reconstruction::Initialize(JEventLoop* locEventLoop)
 	//Check if is REST event (high-level objects only)
 	bool locIsRESTEvent = locEventLoop->GetJEvent().GetStatusBit(kSTATUS_REST);
 
+	Run_Update(locEventLoop);
+
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
-
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-	double locTargetZCenter = 0.0;
-	locGeometry->GetTargetZ(locTargetZCenter);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
-		if(dTargetCenter.Z() < -9.8E9)
-			dTargetCenter.SetXYZ(0.0, 0.0, locTargetZCenter);
-
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
@@ -482,6 +476,17 @@ void DHistogramAction_Reconstruction::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_Reconstruction::Run_Update(JEventLoop* locEventLoop)
+{
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	double locTargetZCenter = 0.0;
+	locGeometry->GetTargetZ(locTargetZCenter);
+	
+	if(dTargetCenter.Z() < -9.8E9)
+		dTargetCenter.SetXYZ(0.0, 0.0, locTargetZCenter);
 }
 
 bool DHistogramAction_Reconstruction::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -791,14 +796,12 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 
 	bool locIsRESTEvent = locEventLoop->GetJEvent().GetStatusBit(kSTATUS_REST);
 
-	map<string, double> tofparms;
-	locEventLoop->GetCalib("TOF/tof_parms", tofparms);
+	Run_Update(locEventLoop);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
-		TOF_E_THRESHOLD = tofparms["TOF_E_THRESHOLD"];
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 
@@ -944,11 +947,11 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 
 			locHistName = "TrackTOF2DPaddles_HasHit";
 			locHistTitle = locTrackString + string(", Has Other Match, TOF Has Hit;Projected Vertical TOF Paddle;Projected Horizontal TOF Paddle");
-			dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, 44, 0.5, 44.5);
+			dHistMap_TrackTOF2DPaddles_HasHit[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, 46, 0.5, 46.5);
 
 			locHistName = "TrackTOF2DPaddles_NoHit";
 			locHistTitle = locTrackString + string(", Has Other Match, TOF No Hit;Projected Vertical TOF Paddle;Projected Horizontal TOF Paddle");
-			dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, 44, 0.5, 44.5);
+			dHistMap_TrackTOF2DPaddles_NoHit[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, 46, 0.5, 46.5);
 
 			locHistName = "TrackTOFP_HasHit";
 			locHistTitle = locTrackString + string(", Has Other Match, TOF Has Hit;p (GeV/c)");
@@ -976,19 +979,19 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 
 			locHistName = "TOFTrackDeltaXVsHorizontalPaddle";
 			locHistTitle = locTrackString + string(";TOF Horizontal Paddle;TOF / Track #DeltaX (cm)");
-			dHistMap_TOFPointTrackDeltaXVsHorizontalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
+			dHistMap_TOFPointTrackDeltaXVsHorizontalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
 
 			locHistName = "TOFTrackDeltaXVsVerticalPaddle";
 			locHistTitle = locTrackString + string(";TOF Vertical Paddle;TOF / Track #DeltaX (cm)");
-			dHistMap_TOFPointTrackDeltaXVsVerticalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
+			dHistMap_TOFPointTrackDeltaXVsVerticalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
 
 			locHistName = "TOFTrackDeltaYVsHorizontalPaddle";
 			locHistTitle = locTrackString + string(";TOF Horizontal Paddle;TOF / Track #DeltaY (cm)");
-			dHistMap_TOFPointTrackDeltaYVsHorizontalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
+			dHistMap_TOFPointTrackDeltaYVsHorizontalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
 
 			locHistName = "TOFTrackDeltaYVsVerticalPaddle";
 			locHistTitle = locTrackString + string(";TOF Vertical Paddle;TOF / Track #DeltaY (cm)");
-			dHistMap_TOFPointTrackDeltaYVsVerticalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 44, 0.5, 44.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
+			dHistMap_TOFPointTrackDeltaYVsVerticalPaddle[locIsTimeBased] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, 46, 0.5, 46.5, dNum2DTrackDOCABins, -1.0*dMaxTrackMatchDOCA, dMaxTrackMatchDOCA);
 
 			locHistName = "TOFTrackDistance_BothPlanes";
 			locHistTitle = locTrackString + string("TOF Hit in Both Planes;TOF / Track Distance (cm)");
@@ -1093,6 +1096,13 @@ void DHistogramAction_DetectorMatching::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_DetectorMatching::Run_Update(JEventLoop* locEventLoop)
+{
+	map<string, double> tofparms;
+	locEventLoop->GetCalib("TOF/tof_parms", tofparms);
+	TOF_E_THRESHOLD = tofparms["TOF_E_THRESHOLD"];
 }
 
 bool DHistogramAction_DetectorMatching::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -2183,12 +2193,9 @@ void DHistogramAction_Neutrals::Initialize(JEventLoop* locEventLoop)
 	//When creating a reaction-independent action, only modify member variables within a ROOT lock.
 		//Objects created within a plugin (such as reaction-independent actions) can be accessed by many threads simultaneously.
 
-	string locHistName;
+	Run_Update(locEventLoop);
 
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-	double locTargetZCenter = 0.0;
-	locGeometry->GetTargetZ(locTargetZCenter);
+	string locHistName;
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
@@ -2198,8 +2205,6 @@ void DHistogramAction_Neutrals::Initialize(JEventLoop* locEventLoop)
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
 
-		if(dTargetCenter.Z() < -9.8E9)
-			dTargetCenter.SetXYZ(0.0, 0.0, locTargetZCenter);
 
 		//BCAL
 		locHistName = "BCALTrackDOCA";
@@ -2231,6 +2236,17 @@ void DHistogramAction_Neutrals::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_Neutrals::Run_Update(JEventLoop* locEventLoop)
+{
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	double locTargetZCenter = 0.0;
+	locGeometry->GetTargetZ(locTargetZCenter);
+
+	if(dTargetCenter.Z() < -9.8E9)
+		dTargetCenter.SetXYZ(0.0, 0.0, locTargetZCenter);
 }
 
 bool DHistogramAction_Neutrals::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -2303,7 +2319,6 @@ bool DHistogramAction_Neutrals::Perform_Action(JEventLoop* locEventLoop, const D
 	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
 }
 
-
 void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 {
 	//Create any histograms/trees/etc. within a ROOT lock.
@@ -2313,14 +2328,11 @@ void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 		//Objects created within a plugin (such as reaction-independent actions) can be accessed by many threads simultaneously.
 
 	string locHistName, locHistTitle;
+	
+	Run_Update(locEventLoop);
 
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
-
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-	double locTargetZCenter = 0.0;
-	locGeometry->GetTargetZ(locTargetZCenter);
 
 	string locTrackSelectionTag = "NotATag";
 	if(gPARMS->Exists("COMBO:TRACK_SELECT_TAG"))
@@ -2339,9 +2351,6 @@ void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it.
 		CreateAndChangeTo_ActionDirectory();
-
-		if(dTargetCenterZ < -9.8E9)
-			dTargetCenterZ = locTargetZCenter; //only set if not already set
 
 		//Track Matched to Hit
 		for(int locTruePIDFlag = 0; locTruePIDFlag < 2; ++locTruePIDFlag)
@@ -2420,6 +2429,17 @@ void DHistogramAction_DetectorMatchParams::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_DetectorMatchParams::Run_Update(JEventLoop* locEventLoop)
+{
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	double locTargetZCenter = 0.0;
+	locGeometry->GetTargetZ(locTargetZCenter);
+	
+	if(dTargetCenterZ < -9.8E9)
+		dTargetCenterZ = locTargetZCenter; //only set if not already set
 }
 
 bool DHistogramAction_DetectorMatchParams::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -103,6 +103,7 @@ class DHistogramAction_ObjectMemory : public DAnalysisAction
 		dMaxNumEvents(50000), dEventCounter(0) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 		void Read_MemoryUsage(double& vm_usage, double& resident_set);
 
@@ -142,12 +143,12 @@ class DHistogramAction_ObjectMemory : public DAnalysisAction
 		DResourcePool<DKinFitConstraint_Vertex> dResourcePool_VertexConstraint;
 		DResourcePool<DKinFitConstraint_Spacetime> dResourcePool_SpacetimeConstraint;
 
-		TH2I* dHist_NumObjects;
-		TH2F* dHist_Memory;
+		TH2I* dHist_NumObjects = nullptr;
+		TH2F* dHist_Memory = nullptr;
 
-		TH1F* dVirtualMemoryVsEventNumber;
-		TH1F* dResidentMemoryVsEventNumber;
-		TH1F* dHist_TotalMemory;
+		TH1F* dVirtualMemoryVsEventNumber = nullptr;
+		TH1F* dResidentMemoryVsEventNumber = nullptr;
+		TH1F* dHist_TotalMemory = nullptr;
 };
 
 class DHistogramAction_Reconstruction : public DAnalysisAction
@@ -189,6 +190,7 @@ class DHistogramAction_Reconstruction : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		unsigned int dNumFCALTOFXYBins, dNumShowerEnergyBins, dNumPhiBins, dNum2DBCALZBins, dNum2DPhiBins;
 		unsigned int dNumHitEnergyBins, dNum2DHitEnergyBins, dNum2DThetaBins, dNumFOMBins, dNum2DFOMBins, dNum2DPBins, dNum2DDeltaTBins;
@@ -202,35 +204,35 @@ class DHistogramAction_Reconstruction : public DAnalysisAction
 
 		DVector3 dTargetCenter;
 
-		TH2I* dHist_FCALShowerYVsX;
-		TH1I* dHist_FCALShowerEnergy;
+		TH2I* dHist_FCALShowerYVsX = nullptr;
+		TH1I* dHist_FCALShowerEnergy = nullptr;
 
-		TH1I* dHist_BCALShowerEnergy;
-		TH1I* dHist_BCALShowerPhi;
-		TH2I* dHist_BCALShowerPhiVsZ;
+		TH1I* dHist_BCALShowerEnergy = nullptr;
+		TH1I* dHist_BCALShowerPhi = nullptr;
+		TH2I* dHist_BCALShowerPhiVsZ = nullptr;
 
-		TH1I* dHist_TOFPointEnergy;
-		TH2I* dHist_TOFPointYVsX;
+		TH1I* dHist_TOFPointEnergy = nullptr;
+		TH2I* dHist_TOFPointYVsX = nullptr;
 
-		TH1I* dHist_SCHitSector;
-		TH1I* dHist_SCHitEnergy;
-		TH2I* dHist_SCHitEnergyVsSector;
-		TH2I *dHist_SCRFDeltaTVsSector;
+		TH1I* dHist_SCHitSector = nullptr;
+		TH1I* dHist_SCHitEnergy = nullptr;
+		TH2I* dHist_SCHitEnergyVsSector = nullptr;
+		TH2I *dHist_SCRFDeltaTVsSector = nullptr;
 
-		TH2I *dHist_TAGMRFDeltaTVsColumn;
-		TH2I *dHist_TAGHRFDeltaTVsCounter;
+		TH2I *dHist_TAGMRFDeltaTVsColumn = nullptr;
+		TH2I *dHist_TAGHRFDeltaTVsCounter = nullptr;
 
-		TH1I* dHist_NumDCHitsPerTrack;
-		TH1I* dHist_NumPossDCHitsPerTrack;
-		TH1I* dHist_TrackHitFraction;
-		TH2I* dHist_NumDCHitsPerTrackVsTheta;
-		TH2I* dHist_NumPossDCHitsPerTrackVsTheta;
-		TH2I* dHist_TrackHitFractionVsTheta;
-		TH1I* dHist_TrackingFOM;
-		TH1I* dHist_TrackingFOM_WireBased;
-		TH2I* dHist_TrackingFOMVsTheta;
-		TH2I* dHist_TrackingFOMVsP;
-		TH2I* dHist_TrackingFOMVsNumHits;
+		TH1I* dHist_NumDCHitsPerTrack = nullptr;
+		TH1I* dHist_NumPossDCHitsPerTrack = nullptr;
+		TH1I* dHist_TrackHitFraction = nullptr;
+		TH2I* dHist_NumDCHitsPerTrackVsTheta = nullptr;
+		TH2I* dHist_NumPossDCHitsPerTrackVsTheta = nullptr;
+		TH2I* dHist_TrackHitFractionVsTheta = nullptr;
+		TH1I* dHist_TrackingFOM = nullptr;
+		TH1I* dHist_TrackingFOM_WireBased = nullptr;
+		TH2I* dHist_TrackingFOMVsTheta = nullptr;
+		TH2I* dHist_TrackingFOMVsP = nullptr;
+		TH2I* dHist_TrackingFOMVsNumHits = nullptr;
 		map<int, TH2I*> dHistMap_PVsTheta_Candidates; //int is charge
 		map<int, TH2I*> dHistMap_PVsTheta_WireBased; //int is charge
 		map<int, TH2I*> dHistMap_PVsTheta_TimeBased; //int is charge
@@ -241,17 +243,17 @@ class DHistogramAction_Reconstruction : public DAnalysisAction
 		map<int, TH2I*> dHistMap_PVsTheta_GoodWireBased_GoodTimeBased; //int is charge
 		map<int, TH2I*> dHistMap_PVsTheta_GoodWireBased_BadTimeBased; //int is charge
 
-		TH2I* dHist_CDCRingVsTheta_Candidates;
-		TH2I* dHist_CDCRingVsTheta_WireBased;
-		TH2I* dHist_CDCRingVsTheta_TimeBased;
-		TH2I* dHist_CDCRingVsTheta_TimeBased_GoodTrackFOM;
-		TH2I* dHist_FDCPlaneVsTheta_Candidates;
-		TH2I* dHist_FDCPlaneVsTheta_WireBased;
-		TH2I* dHist_FDCPlaneVsTheta_TimeBased;
-		TH2I* dHist_FDCPlaneVsTheta_TimeBased_GoodTrackFOM;
+		TH2I* dHist_CDCRingVsTheta_Candidates = nullptr;
+		TH2I* dHist_CDCRingVsTheta_WireBased = nullptr;
+		TH2I* dHist_CDCRingVsTheta_TimeBased = nullptr;
+		TH2I* dHist_CDCRingVsTheta_TimeBased_GoodTrackFOM = nullptr;
+		TH2I* dHist_FDCPlaneVsTheta_Candidates = nullptr;
+		TH2I* dHist_FDCPlaneVsTheta_WireBased = nullptr;
+		TH2I* dHist_FDCPlaneVsTheta_TimeBased = nullptr;
+		TH2I* dHist_FDCPlaneVsTheta_TimeBased_GoodTrackFOM = nullptr;
 
-		TH2I* dHist_MCMatchedHitsVsTheta;
-		TH2I* dHist_MCMatchedHitsVsP;
+		TH2I* dHist_MCMatchedHitsVsTheta = nullptr;
+		TH2I* dHist_MCMatchedHitsVsP = nullptr;
 };
 
 class DHistogramAction_DetectorMatching : public DAnalysisAction
@@ -284,6 +286,7 @@ class DHistogramAction_DetectorMatching : public DAnalysisAction
 		dMinTrackingFOM(0.0027), dMinTOFPaddleMatchDistance(9.0), dMinHitRingsPerCDCSuperlayer(2), dMinHitPlanesPerFDCPackage(4) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		unsigned int dNum2DThetaBins, dNumPBins, dNum2DPBins, dNum2DPhiBins, dNum2DDeltaPhiBins, dNum2DDeltaZBins;
 		unsigned int dNum2DTrackDOCABins, dNumTrackDOCABins, dNumFCALTOFXYBins, dNum2DBCALZBins, dNum2DSCZBins, dNumTOFRBins;
@@ -438,6 +441,7 @@ class DHistogramAction_DetectorPID : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 		unsigned int dNum2DPBins, dNum2DdEdxBins, dNum2DBetaBins, dNum2DBCALThetaBins, dNum2DFCALThetaBins;
 		unsigned int dNum2DEOverPBins, dNum2DDeltaBetaBins, dNum2DDeltadEdxBins, dNum2DDeltaTBins, dNum2DPullBins, dNum2DFOMBins;
@@ -512,6 +516,7 @@ class DHistogramAction_Neutrals : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		unsigned int dNumTrackDOCABins, dNumDeltaPhiBins, dNumShowerEnergyBins, dNumDeltaTBins, dNum2DShowerEnergyBins, dNum2DDeltaTBins, dNum2DBCALZBins;
 		double dMinTrackDOCA, dMaxTrackDOCA, dMinDeltaPhi, dMaxDeltaPhi, dMinShowerEnergy, dMaxShowerEnergy, dMaxBCALP, dMinDeltaT, dMaxDeltaT;
@@ -521,18 +526,18 @@ class DHistogramAction_Neutrals : public DAnalysisAction
 
 		DVector3 dTargetCenter;
 
-		TH1I* dHist_BCALTrackDOCA;
-		TH1I* dHist_BCALTrackDeltaPhi;
-		TH1I* dHist_BCALTrackDeltaZ;
-		TH1I* dHist_BCALNeutralShowerEnergy;
-		TH1I* dHist_BCALNeutralShowerDeltaT;
-		TH2I* dHist_BCALNeutralShowerDeltaTVsE;
-		TH2I* dHist_BCALNeutralShowerDeltaTVsZ;
+		TH1I* dHist_BCALTrackDOCA = nullptr;
+		TH1I* dHist_BCALTrackDeltaPhi = nullptr;
+		TH1I* dHist_BCALTrackDeltaZ = nullptr;
+		TH1I* dHist_BCALNeutralShowerEnergy = nullptr;
+		TH1I* dHist_BCALNeutralShowerDeltaT = nullptr;
+		TH2I* dHist_BCALNeutralShowerDeltaTVsE = nullptr;
+		TH2I* dHist_BCALNeutralShowerDeltaTVsZ = nullptr;
 
-		TH1I* dHist_FCALTrackDOCA;
-		TH1I* dHist_FCALNeutralShowerEnergy;
-		TH1I* dHist_FCALNeutralShowerDeltaT;
-		TH2I* dHist_FCALNeutralShowerDeltaTVsE;
+		TH1I* dHist_FCALTrackDOCA = nullptr;
+		TH1I* dHist_FCALNeutralShowerEnergy = nullptr;
+		TH1I* dHist_FCALNeutralShowerDeltaT = nullptr;
+		TH2I* dHist_FCALNeutralShowerDeltaTVsE = nullptr;
 };
 
 class DHistogramAction_DetectorMatchParams : public DAnalysisAction
@@ -577,6 +582,7 @@ class DHistogramAction_DetectorMatchParams : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 		unsigned int dNumShowerEnergyBins, dNumShowerDepthBins, dNum2DPBins, dNum2DThetaBins, dNum2DHitEnergyBins;
 		double dMinShowerEnergy, dMaxShowerEnergy, dMaxBCALP, dMinShowerDepth, dMaxShowerDepth, dMinP, dMaxP;
@@ -646,20 +652,21 @@ class DHistogramAction_EventVertex : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
-		TH1I* dRFTrackDeltaT;
-		TH1I* dEventVertexZ_AllEvents;
-		TH2I* dEventVertexYVsX_AllEvents;
-		TH1I* dEventVertexT_AllEvents;
+		TH1I* dRFTrackDeltaT = nullptr;
+		TH1I* dEventVertexZ_AllEvents = nullptr;
+		TH2I* dEventVertexYVsX_AllEvents = nullptr;
+		TH1I* dEventVertexT_AllEvents = nullptr;
 
-		TH1I* dEventVertexZ_2OrMoreGoodTracks;
-		TH2I* dEventVertexYVsX_2OrMoreGoodTracks;
-		TH1I* dEventVertexT_2OrMoreGoodTracks;
+		TH1I* dEventVertexZ_2OrMoreGoodTracks = nullptr;
+		TH2I* dEventVertexYVsX_2OrMoreGoodTracks = nullptr;
+		TH1I* dEventVertexT_2OrMoreGoodTracks = nullptr;
 
-		TH1I* dHist_KinFitConfidenceLevel;
+		TH1I* dHist_KinFitConfidenceLevel = nullptr;
 		map<Particle_t, map<DKinFitPullType, TH1I*> > dHistMap_KinFitPulls;
 };
 
@@ -715,11 +722,12 @@ class DHistogramAction_DetectedParticleKinematics : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
 
-		TH1I* dBeamParticle_P;
+		TH1I* dBeamParticle_P = nullptr;
 
 		//PID
 		map<int, TH2I*> dHistMap_QBetaVsP; //int is charge: -1, 1
@@ -782,6 +790,7 @@ class DHistogramAction_TrackShowerErrors : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -851,53 +860,54 @@ class DHistogramAction_NumReconstructedObjects : public DAnalysisAction
 		unsigned int dMaxNumBeamPhotons;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 
-		TH2D* dHist_NumHighLevelObjects;
+		TH2D* dHist_NumHighLevelObjects = nullptr;
 
-		TH1D* dHist_NumChargedTracks;
-		TH1D* dHist_NumPosChargedTracks;
-		TH1D* dHist_NumNegChargedTracks;
+		TH1D* dHist_NumChargedTracks = nullptr;
+		TH1D* dHist_NumPosChargedTracks = nullptr;
+		TH1D* dHist_NumNegChargedTracks = nullptr;
 
-		TH1D* dHist_NumTimeBasedTracks;
-		TH1D* dHist_NumPosTimeBasedTracks;
-		TH1D* dHist_NumNegTimeBasedTracks;
-		TH1D* dHist_NumWireBasedTracks;
-		TH1D* dHist_NumPosWireBasedTracks;
-		TH1D* dHist_NumNegWireBasedTracks;
-		TH1D* dHist_NumTrackCandidates;
-		TH1D* dHist_NumPosTrackCandidates;
-		TH1D* dHist_NumNegTrackCandidates;
-		TH1D* dHist_NumPosTrackCandidates_CDC;
-		TH1D* dHist_NumNegTrackCandidates_CDC;
-		TH1D* dHist_NumPosTrackCandidates_FDC;
-		TH1D* dHist_NumNegTrackCandidates_FDC;
+		TH1D* dHist_NumTimeBasedTracks = nullptr;
+		TH1D* dHist_NumPosTimeBasedTracks = nullptr;
+		TH1D* dHist_NumNegTimeBasedTracks = nullptr;
+		TH1D* dHist_NumWireBasedTracks = nullptr;
+		TH1D* dHist_NumPosWireBasedTracks = nullptr;
+		TH1D* dHist_NumNegWireBasedTracks = nullptr;
+		TH1D* dHist_NumTrackCandidates = nullptr;
+		TH1D* dHist_NumPosTrackCandidates = nullptr;
+		TH1D* dHist_NumNegTrackCandidates = nullptr;
+		TH1D* dHist_NumPosTrackCandidates_CDC = nullptr;
+		TH1D* dHist_NumNegTrackCandidates_CDC = nullptr;
+		TH1D* dHist_NumPosTrackCandidates_FDC = nullptr;
+		TH1D* dHist_NumNegTrackCandidates_FDC = nullptr;
 
-		TH1D* dHist_NumBeamPhotons;
-		TH1D* dHist_NumFCALShowers;
-		TH1D* dHist_NumBCALShowers;
-		TH1D* dHist_NumNeutralShowers;
-		TH1D* dHist_NumTOFPoints;
-		TH1D* dHist_NumSCHits;
-		TH1D* dHist_NumTAGMHits;
-		TH1D* dHist_NumTAGHHits;
+		TH1D* dHist_NumBeamPhotons = nullptr;
+		TH1D* dHist_NumFCALShowers = nullptr;
+		TH1D* dHist_NumBCALShowers = nullptr;
+		TH1D* dHist_NumNeutralShowers = nullptr;
+		TH1D* dHist_NumTOFPoints = nullptr;
+		TH1D* dHist_NumSCHits = nullptr;
+		TH1D* dHist_NumTAGMHits = nullptr;
+		TH1D* dHist_NumTAGHHits = nullptr;
 
-		TH1D* dHist_NumTrackBCALMatches;
-		TH1D* dHist_NumTrackFCALMatches;
-		TH1D* dHist_NumTrackTOFMatches;
-		TH1D* dHist_NumTrackSCMatches;
+		TH1D* dHist_NumTrackBCALMatches = nullptr;
+		TH1D* dHist_NumTrackFCALMatches = nullptr;
+		TH1D* dHist_NumTrackTOFMatches = nullptr;
+		TH1D* dHist_NumTrackSCMatches = nullptr;
 
-		TH1I* dHist_NumCDCHits;
-		TH1I* dHist_NumFDCWireHits;
-		TH1I* dHist_NumFDCCathodeHits;
-		TH1I* dHist_NumFDCPseudoHits;
-		TH1I* dHist_NumTOFHits;
-		TH1I* dHist_NumBCALHits;
-		TH1I* dHist_NumFCALHits;
+		TH1I* dHist_NumCDCHits = nullptr;
+		TH1I* dHist_NumFDCWireHits = nullptr;
+		TH1I* dHist_NumFDCCathodeHits = nullptr;
+		TH1I* dHist_NumFDCPseudoHits = nullptr;
+		TH1I* dHist_NumTOFHits = nullptr;
+		TH1I* dHist_NumBCALHits = nullptr;
+		TH1I* dHist_NumFCALHits = nullptr;
 
-		TH1I* dHist_NumRFSignals; //all sources
+		TH1I* dHist_NumRFSignals = nullptr; //all sources
 };
 
 class DHistogramAction_TrackMultiplicity : public DAnalysisAction
@@ -942,12 +952,13 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 
-		TH2D* dHist_NumReconstructedParticles;
-		TH2D* dHist_NumGoodReconstructedParticles;
+		TH2D* dHist_NumReconstructedParticles = nullptr;
+		TH2D* dHist_NumGoodReconstructedParticles = nullptr;
 };
 
 #endif // _DHistogramActions_Independent_

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -6,23 +6,18 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 	string locParticleName, locParticleName2, locParticleROOTName, locParticleROOTName2;
 	Particle_t locPID, locPID2;
 
-	vector<const DParticleID*> locParticleIDs;
-	locEventLoop->Get(locParticleIDs);
+	Run_Update(locEventLoop);
+
 	auto locDesiredPIDs = Get_Reaction()->Get_FinalPIDs(-1, false, false, d_AllCharges, false);
 
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
-
-	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
-	locEventLoop->Get(locAnalysisUtilitiesVector);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		CreateAndChangeTo_ActionDirectory();
-		dParticleID = locParticleIDs[0];
-		dAnalysisUtilities = locAnalysisUtilitiesVector[0];
 		for(size_t loc_i = 0; loc_i < locDesiredPIDs.size(); ++loc_i)
 		{
 			locPID = locDesiredPIDs[loc_i];
@@ -350,6 +345,18 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
+void DHistogramAction_PID::Run_Update(JEventLoop* locEventLoop)
+{
+	vector<const DParticleID*> locParticleIDs;
+	locEventLoop->Get(locParticleIDs);
+
+	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
+	locEventLoop->Get(locAnalysisUtilitiesVector);
+
+	dParticleID = locParticleIDs[0];
+	dAnalysisUtilities = locAnalysisUtilitiesVector[0];
+}
+
 bool DHistogramAction_PID::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	vector<const DMCThrownMatching*> locMCThrownMatchingVector;
@@ -582,8 +589,7 @@ void DHistogramAction_TrackVertexComparison::Initialize(JEventLoop* locEventLoop
 	Particle_t locPID, locHigherMassPID, locLowerMassPID;
 	string locHigherMassParticleName, locLowerMassParticleName, locHigherMassParticleROOTName, locLowerMassParticleROOTName;
 
-	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
-	locEventLoop->Get(locAnalysisUtilitiesVector);
+	Run_Update(locEventLoop);
 
 	size_t locNumSteps = Get_Reaction()->Get_NumReactionSteps();
 	dHistDeque_TrackZToCommon.resize(locNumSteps);
@@ -598,7 +604,6 @@ void DHistogramAction_TrackVertexComparison::Initialize(JEventLoop* locEventLoop
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
-		dAnalysisUtilities = locAnalysisUtilitiesVector[0];
 		CreateAndChangeTo_ActionDirectory();
 		for(size_t loc_i = 0; loc_i < locNumSteps; ++loc_i)
 		{
@@ -697,6 +702,13 @@ void DHistogramAction_TrackVertexComparison::Initialize(JEventLoop* locEventLoop
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_TrackVertexComparison::Run_Update(JEventLoop* locEventLoop)
+{
+	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
+	locEventLoop->Get(locAnalysisUtilitiesVector);
+	dAnalysisUtilities = locAnalysisUtilitiesVector[0];
 }
 
 bool DHistogramAction_TrackVertexComparison::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -818,11 +830,10 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 		return; //no fit performed, but kinfit data requested!!
 	}
 
-	vector<const DParticleID*> locParticleIDs;
-	locEventLoop->Get(locParticleIDs);
-
 	string locHistName, locHistTitle, locStepROOTName, locParticleName, locParticleROOTName;
 	Particle_t locPID;
+	
+	Run_Update(locEventLoop);
 
 	size_t locNumSteps = Get_Reaction()->Get_NumReactionSteps();
 	dHistDeque_PVsTheta.resize(locNumSteps);
@@ -835,11 +846,6 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 	dHistDeque_VertexZ.resize(locNumSteps);
 	dHistDeque_VertexYVsX.resize(locNumSteps);
 
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
-	locEventLoop->Get(locAnalysisUtilitiesVector);
-
 	auto locIsFirstStepBeam = DAnalysis::Get_IsFirstStepBeam(Get_Reaction());
 
 	//CREATE THE HISTOGRAMS
@@ -847,11 +853,7 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		CreateAndChangeTo_ActionDirectory();
-
-		dParticleID = locParticleIDs[0];
-		dAnalysisUtilities = locAnalysisUtilitiesVector[0];
-		locGeometry->GetTargetZ(dTargetZCenter);
-
+		
 		//beam particle
 		locPID = Get_Reaction()->Get_ReactionStep(0)->Get_InitialPID();
 		if(locIsFirstStepBeam)
@@ -1068,6 +1070,22 @@ void DHistogramAction_ParticleComboKinematics::Initialize(JEventLoop* locEventLo
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
 }
 
+void DHistogramAction_ParticleComboKinematics::Run_Update(JEventLoop* locEventLoop)
+{
+	vector<const DParticleID*> locParticleIDs;
+	locEventLoop->Get(locParticleIDs);
+
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
+	locEventLoop->Get(locAnalysisUtilitiesVector);
+	
+	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	locGeometry->GetTargetZ(dTargetZCenter);
+
+	dParticleID = locParticleIDs[0];
+	dAnalysisUtilities = locAnalysisUtilitiesVector[0];
+}
+
 bool DHistogramAction_ParticleComboKinematics::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
 {
 	if(Get_UseKinFitResultsFlag() && (Get_Reaction()->Get_KinFitType() == d_NoFit))
@@ -1242,7 +1260,8 @@ void DHistogramAction_InvariantMass::Initialize(JEventLoop* locEventLoop)
 {
 	string locHistName, locHistTitle;
 	double locMassPerBin = 1000.0*(dMaxMass - dMinMass)/((double)dNumMassBins);
-	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	Run_Update(locEventLoop);
 
 	string locParticleNamesForHist = "";
 	if(dInitialPID != Unknown)
@@ -1281,6 +1300,11 @@ void DHistogramAction_InvariantMass::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_InvariantMass::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
 }
 
 bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1347,7 +1371,7 @@ void DHistogramAction_MissingMass::Initialize(JEventLoop* locEventLoop)
 	auto locChainPIDs = DAnalysis::Get_ChainPIDs(Get_Reaction(), Get_Reaction()->Get_ReactionStep(0)->Get_InitialPID(), dMissingMassOffOfStepIndex, locMissingMassOffOfPIDs, !Get_UseKinFitResultsFlag(), true);
 	string locFinalParticlesROOTName = DAnalysis::Convert_PIDsToROOTName(locChainPIDs);
 
-	locEventLoop->GetSingle(dAnalysisUtilities);
+	Run_Update(locEventLoop);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
@@ -1378,6 +1402,11 @@ void DHistogramAction_MissingMass::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_MissingMass::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
 }
 
 bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1427,7 +1456,7 @@ void DHistogramAction_MissingMassSquared::Initialize(JEventLoop* locEventLoop)
 	auto locChainPIDs = DAnalysis::Get_ChainPIDs(Get_Reaction(), Get_Reaction()->Get_ReactionStep(0)->Get_InitialPID(), dMissingMassOffOfStepIndex, locMissingMassOffOfPIDs, !Get_UseKinFitResultsFlag(), true);
 	string locFinalParticlesROOTName = DAnalysis::Convert_PIDsToROOTName(locChainPIDs);
 
-	locEventLoop->GetSingle(dAnalysisUtilities);
+	Run_Update(locEventLoop);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
@@ -1458,6 +1487,11 @@ void DHistogramAction_MissingMassSquared::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_MissingMassSquared::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
 }
 
 bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1502,7 +1536,8 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 void DHistogramAction_2DInvariantMass::Initialize(JEventLoop* locEventLoop)
 {
 	string locHistName, locHistTitle;
-	locEventLoop->GetSingle(dAnalysisUtilities);
+	
+	Run_Update(locEventLoop);
 
 	string locParticleNamesForHistX = "";
 	for(size_t loc_i = 0; loc_i < dXPIDs.size(); ++loc_i)
@@ -1528,6 +1563,11 @@ void DHistogramAction_2DInvariantMass::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_2DInvariantMass::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
 }
 
 bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1587,7 +1627,8 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 void DHistogramAction_Dalitz::Initialize(JEventLoop* locEventLoop)
 {
 	string locHistName, locHistTitle;
-	locEventLoop->GetSingle(dAnalysisUtilities);
+	
+	Run_Update(locEventLoop);
 
 	string locParticleNamesForHistX = "";
 	for(size_t loc_i = 0; loc_i < dXPIDs.size(); ++loc_i)
@@ -1613,6 +1654,11 @@ void DHistogramAction_Dalitz::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_Dalitz::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
 }
 
 bool DHistogramAction_Dalitz::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1676,8 +1722,6 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 	if(locKinFitType == d_NoFit)
 		return;
 
-	locEventLoop->GetSingle(dAnalysisUtilities);
-
 	//Get the DReactionVertexInfo for this reaction
 	vector<const DReactionVertexInfo*> locReactionVertexInfos;
 	locEventLoop->Get(locReactionVertexInfos);
@@ -1693,6 +1737,7 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 	}
 
 	dKinFitUtils = new DKinFitUtils_GlueX(locEventLoop);
+	Run_Update(locEventLoop);
 
 	size_t locNumConstraints = 0, locNumUnknowns = 0;
 	string locConstraintString = dKinFitUtils->Get_ConstraintInfo(locReactionVertexInfo, Get_Reaction(), locNumConstraints, locNumUnknowns);
@@ -1846,6 +1891,12 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_KinFitResults::Run_Update(JEventLoop* locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
+	dKinFitUtils->Set_RunDependent_Data(locEventLoop);
 }
 
 void DHistogramAction_KinFitResults::Create_ParticlePulls(string locFullROOTName, bool locIsChargedFlag, bool locIsInVertexFitFlag, bool locIsNeutralShowerFlag, int locStepIndex, Particle_t locPID)
@@ -2210,14 +2261,12 @@ void DHistogramAction_MissingTransverseMomentum::Initialize(JEventLoop* locEvent
 	string locHistName, locHistTitle;
 	double locPtPerBin = 1000.0*(dMaxPt - dMinPt)/((double)dNumPtBins);
 
-	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
-	locEventLoop->Get(locAnalysisUtilitiesVector);
+	Run_Update(locEventLoop);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
-		dAnalysisUtilities = locAnalysisUtilitiesVector[0];
 		CreateAndChangeTo_ActionDirectory();
 
 		locHistName = "MissingTransverseMomentum";
@@ -2230,6 +2279,13 @@ void DHistogramAction_MissingTransverseMomentum::Initialize(JEventLoop* locEvent
 		ChangeTo_BaseDirectory();
 	}
 	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+}
+
+void DHistogramAction_MissingTransverseMomentum::Run_Update(JEventLoop* locEventLoop)
+{
+	vector<const DAnalysisUtilities*> locAnalysisUtilitiesVector;
+	locEventLoop->Get(locAnalysisUtilitiesVector);
+	dAnalysisUtilities = locAnalysisUtilitiesVector[0];
 }
 
 bool DHistogramAction_MissingTransverseMomentum::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -100,6 +100,7 @@ class DHistogramAction_PID : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -174,6 +175,7 @@ class DHistogramAction_TrackVertexComparison : public DAnalysisAction
 		double dMinDeltaVertexZ, dMaxDeltaVertexZ, dMinDeltaVertexT, dMaxDeltaVertexT, dMinDOCA, dMaxDOCA, dMinP, dMaxP, dMinTheta, dMaxTheta;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -215,6 +217,7 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 		double dMinBeta, dMaxBeta, dMinDeltaBeta, dMaxDeltaBeta, dMinDeltaTRF, dMaxDeltaTRF, dMaxPathLength, dMaxLifetime;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -286,6 +289,7 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -360,6 +364,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -431,6 +436,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -467,6 +473,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -497,6 +504,7 @@ class DHistogramAction_Dalitz : public DAnalysisAction
 		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -540,6 +548,7 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 		double dMinPull, dMaxPull, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinBeamE, dMaxBeamE;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
@@ -588,6 +597,7 @@ class DHistogramAction_MissingTransverseMomentum : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();

--- a/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Thrown.h
@@ -92,6 +92,7 @@ class DHistogramAction_ParticleComboGenReconComparison : public DAnalysisAction
 		double dMinP, dMaxP, dMinTheta, dMaxTheta, dMinRFDeltaT, dMaxRFDeltaT;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -109,11 +110,11 @@ class DHistogramAction_ParticleComboGenReconComparison : public DAnalysisAction
 		deque<DKinFitPullType> dPullTypes;
 		double dTargetZCenter;
 
-		TH1I* dRFBeamBunchDeltaT_Hist;
+		TH1I* dRFBeamBunchDeltaT_Hist = nullptr;
 
-		TH1I* dBeamParticleHist_DeltaPOverP;
-		TH2I* dBeamParticleHist_DeltaPOverPVsP;
-		TH1I* dBeamParticleHist_DeltaT;
+		TH1I* dBeamParticleHist_DeltaPOverP = nullptr;
+		TH2I* dBeamParticleHist_DeltaPOverPVsP = nullptr;
+		TH1I* dBeamParticleHist_DeltaT = nullptr;
 
 		deque<map<Particle_t, TH1I*> > dHistDeque_DeltaPOverP;
 		deque<map<Particle_t, TH1I*> > dHistDeque_DeltaTheta;
@@ -196,6 +197,7 @@ class DHistogramAction_ThrownParticleKinematics : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop){}
 
 //so: in multi-thread, make direct call. in the main func, no check!
 	//in single-thread, call pre-func to check flag
@@ -270,13 +272,14 @@ class DHistogramAction_ReconnedThrownKinematics : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 
-		TH1I* 	dBeamParticle_P;
+		TH1I* 	dBeamParticle_P = nullptr;
 
 		//PID
 		map<int, TH2I*> dHistMap_QBetaVsP; //int is charge: -1, 1
@@ -350,13 +353,14 @@ class DHistogramAction_GenReconTrackComparison : public DAnalysisAction
 		deque<Particle_t> dFinalStatePIDs;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo = NULL);
 
 		deque<DKinFitPullType> dPullTypes;
 		double dTargetZCenter;
-		TH1I* dRFBeamBunchDeltaT_Hist;
+		TH1I* dRFBeamBunchDeltaT_Hist = nullptr;
 
 		map<Particle_t, TH1I*> dHistMap_MatchFOM;
 		map<Particle_t, TH1I*> dHistMap_DeltaPOverP;
@@ -413,6 +417,7 @@ class DHistogramAction_TruePID : public DAnalysisAction
 		double dMinP, dMaxP, dMinTheta, dMaxTheta;
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void)
 		{
 			DAnalysisAction::Reset_NewEvent();
@@ -425,7 +430,7 @@ class DHistogramAction_TruePID : public DAnalysisAction
 //		double dMinThrownMatchFOM;
 		const DAnalysisUtilities* dAnalysisUtilities;
 
-		TH1I* dHist_TruePIDStatus;
+		TH1I* dHist_TruePIDStatus = nullptr;
 		deque<map<Particle_t, TH1I*> > dHistDeque_P_CorrectID;
 		deque<map<Particle_t, TH1I*> > dHistDeque_P_IncorrectID;
 		deque<map<Particle_t, TH2I*> > dHistDeque_PVsTheta_CorrectID;

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.cc
@@ -14,15 +14,21 @@ dMagneticFieldMap(locMagneticFieldMap), dAnalysisUtilities(locAnalysisUtilities)
 
 DKinFitUtils_GlueX::DKinFitUtils_GlueX(JEventLoop* locEventLoop)
 {
-	locEventLoop->GetSingle(dAnalysisUtilities);
-
-	dApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	dMagneticFieldMap = dApplication->GetBfield(locEventLoop->GetJEvent().GetRunNumber());
+	Set_RunDependent_Data(locEventLoop);
 
 	gPARMS->SetDefaultParameter("KINFIT:LINKVERTICES", dLinkVerticesFlag);
 	dWillBeamHaveErrorsFlag = false; //Until fixed!
 	dIncludeBeamlineInVertexFitFlag = false;
 }
+
+void DKinFitUtils_GlueX::Set_RunDependent_Data(JEventLoop *locEventLoop)
+{
+	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	dApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	dMagneticFieldMap = dApplication->GetBfield(locEventLoop->GetJEvent().GetRunNumber());
+}
+
 
 /*********************************************************** OVERRIDE BASE CLASS FUNCTIONS *********************************************************/
 

--- a/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
+++ b/src/libraries/ANALYSIS/DKinFitUtils_GlueX.h
@@ -47,6 +47,7 @@ class DKinFitUtils_GlueX : public DKinFitUtils
 		DKinFitUtils_GlueX(const DMagneticFieldMap* locMagneticFieldMap, const DAnalysisUtilities* locAnalysisUtilities);
 
 		void Reset_NewEvent(void);
+		void Set_RunDependent_Data(JEventLoop *locEventLoop);
 		void Set_IncludeBeamlineInVertexFitFlag(bool locIncludeBeamlineInVertexFitFlag){dIncludeBeamlineInVertexFitFlag = locIncludeBeamlineInVertexFitFlag;}
 
 		/************************************************************** CREATE PARTICLES ************************************************************/

--- a/src/libraries/ANALYSIS/DParticleComboCreator.cc
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.cc
@@ -11,15 +11,8 @@ DParticleComboCreator::DParticleComboCreator(JEventLoop* locEventLoop, const DSo
 	gPARMS->SetDefaultParameter("COMBO:DEBUG_LEVEL", dDebugLevel);
 	dKinFitUtils = new DKinFitUtils_GlueX(locEventLoop);
 
-	//GET THE GEOMETRY
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-
-	//TARGET INFORMATION
-	double locTargetCenterZ = 65.0;
-	locGeometry->GetTargetZ(locTargetCenterZ);
-	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);
-
+	Set_RunDependent_Data(locEventLoop);
+	
 	dResourcePool_KinematicData.Set_ControlParams(20, 20, 200, 1000, 0);
 	dResourcePool_ParticleCombo.Set_ControlParams(100, 20, 1000, 3000, 0);
 	dResourcePool_ParticleComboStep.Set_ControlParams(100, 50, 1500, 4000, 0);
@@ -36,8 +29,6 @@ DParticleComboCreator::DParticleComboCreator(JEventLoop* locEventLoop, const DSo
 	locEventLoop->Get(locBeamPhotons); //make sure that brun() is called for the default factory!!!
 	dBeamPhotonfactory = static_cast<DBeamPhoton_factory*>(locEventLoop->GetFactory("DBeamPhoton"));
 
-	locEventLoop->GetSingle(dParticleID);
-
 	//error matrix //too lazy to compute properly right now ... need to hack DAnalysisUtilities::Calc_DOCA()
 	dVertexCovMatrix.ResizeTo(4, 4);
 	dVertexCovMatrix.Zero();
@@ -46,6 +37,22 @@ DParticleComboCreator::DParticleComboCreator(JEventLoop* locEventLoop, const DSo
 	dVertexCovMatrix(2, 2) = 1.5; //z variance //a guess, semi-guarding against the worst case scenario //ugh
 	dVertexCovMatrix(3, 3) = 0.0; //t variance //not used
 }
+
+void DParticleComboCreator::Set_RunDependent_Data(JEventLoop *locEventLoop)
+{
+	//GET THE GEOMETRY
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+
+	//TARGET INFORMATION
+	double locTargetCenterZ = 65.0;
+	locGeometry->GetTargetZ(locTargetCenterZ);
+	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);
+
+	locEventLoop->GetSingle(dParticleID);
+		
+	dKinFitUtils->Set_RunDependent_Data(locEventLoop);
+}		
 
 void DParticleComboCreator::Reset(void)
 {

--- a/src/libraries/ANALYSIS/DParticleComboCreator.h
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.h
@@ -39,6 +39,7 @@ class DParticleComboCreator
 		const DParticleCombo* Build_ThrownCombo(JEventLoop* locEventLoop, const DReaction* locThrownReaction, deque<pair<const DMCThrown*, deque<const DMCThrown*> > >& locThrownSteps);
 
 		void Reset(void);
+		void Set_RunDependent_Data(JEventLoop *locEventLoop);
 		void Set_DebugLevel(int locDebugLevel){dDebugLevel = locDebugLevel;}
 
 	private:

--- a/src/libraries/ANALYSIS/DSourceComboP4Handler.h
+++ b/src/libraries/ANALYSIS/DSourceComboP4Handler.h
@@ -39,6 +39,7 @@ class DSourceComboP4Handler
 		DSourceComboP4Handler(DSourceComboer* locSourceComboer, bool locCreateHistsFlag = true);
 		~DSourceComboP4Handler(void){Fill_Histograms();}
 		void Set_DebugLevel(int locDebugLevel){dDebugLevel = locDebugLevel;}
+		void Set_RunDependent_Data(JEventLoop *locEventLoop) {}
 
 		//SET HANDLERS
 		void Set_SourceComboVertexer(const DSourceComboVertexer* locSourceComboVertexer){dSourceComboVertexer = locSourceComboVertexer;}

--- a/src/libraries/ANALYSIS/DSourceComboTimeHandler.h
+++ b/src/libraries/ANALYSIS/DSourceComboTimeHandler.h
@@ -40,6 +40,7 @@ class DSourceComboTimeHandler
 		DSourceComboTimeHandler(void) = delete;
 		DSourceComboTimeHandler(JEventLoop* locEventLoop, DSourceComboer* locSourceComboer, const DSourceComboVertexer* locSourceComboVertexer);
 		~DSourceComboTimeHandler(void){Fill_Histograms();}
+		void Set_RunDependent_Data(JEventLoop *locEventLoop);
 
 		//SETUP
 		void Reset(void);
@@ -128,6 +129,7 @@ class DSourceComboTimeHandler
 		double dTargetLength = 30.0;
 		double dBeamBunchPeriod = 1000.0/249.5;
 		bool dUseSigmaForRFSelectionFlag = false;
+
 
 		//VERTEX-DEPENDENT PHOTON INFORMATION
 		//For every 10cm in vertex-z, calculate the photon p4 & time for placing mass & delta-t cuts

--- a/src/libraries/ANALYSIS/DSourceComboVertexer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboVertexer.cc
@@ -9,6 +9,13 @@ namespace DAnalysis
 DSourceComboVertexer::DSourceComboVertexer(JEventLoop* locEventLoop, DSourceComboer* locSourceComboer, DSourceComboP4Handler* locSourceComboP4Handler) :
 dSourceComboer(locSourceComboer), dSourceComboP4Handler(locSourceComboP4Handler)
 {
+	Set_RunDependent_Data(locEventLoop);
+
+	gPARMS->SetDefaultParameter("COMBO:DEBUG_LEVEL", dDebugLevel);
+}
+
+void DSourceComboVertexer::Set_RunDependent_Data(JEventLoop *locEventLoop)
+{
 	locEventLoop->GetSingle(dAnalysisUtilities);
 
 	//GET THE GEOMETRY
@@ -19,8 +26,6 @@ dSourceComboer(locSourceComboer), dSourceComboP4Handler(locSourceComboP4Handler)
 	double locTargetCenterZ = 65.0;
 	locGeometry->GetTargetZ(locTargetCenterZ);
 	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);
-
-	gPARMS->SetDefaultParameter("COMBO:DEBUG_LEVEL", dDebugLevel);
 }
 
 vector<signed char> DSourceComboVertexer::Get_VertexZBins(const DReactionVertexInfo* locReactionVertexInfo, const DSourceCombo* locReactionCombo, const DKinematicData* locBeamParticle, bool locComboIsFullyCharged) const

--- a/src/libraries/ANALYSIS/DSourceComboVertexer.h
+++ b/src/libraries/ANALYSIS/DSourceComboVertexer.h
@@ -39,8 +39,10 @@ class DSourceComboVertexer
 		//CONSTRUCTORS
 		DSourceComboVertexer(void) = delete;
 		DSourceComboVertexer(JEventLoop* locEventLoop, DSourceComboer* locSourceComboer, DSourceComboP4Handler* locSourceComboP4Handler);
+		void Set_RunDependent_Data(JEventLoop *locEventLoop);
 		void Reset(void);
-void Set_Vertex(const DVertex* locVertex){dVertex = locVertex;} //COMPARE
+		void Set_Vertex(const DVertex* locVertex){dVertex = locVertex;} //COMPARE
+		
 		//SETUP
 		void Set_SourceComboTimeHandler(const DSourceComboTimeHandler* locSourceComboTimeHandler){dSourceComboTimeHandler = locSourceComboTimeHandler;}
 		void Set_DebugLevel(int locDebugLevel){dDebugLevel = locDebugLevel;}

--- a/src/libraries/ANALYSIS/DSourceComboer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboer.cc
@@ -448,6 +448,25 @@ void DSourceComboer::Create_CutFunctions(void)
 
 /********************************************************************* CONSTRUCTOR **********************************************************************/
 
+void DSourceComboer::Set_RunDependent_Data(JEventLoop *locEventLoop)
+{
+	// Set member data
+	//GET THE GEOMETRY
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+
+	//TARGET INFORMATION
+	double locTargetCenterZ = 65.0;
+	locGeometry->GetTargetZ(locTargetCenterZ);
+	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);	
+
+	// Update linked objects
+	dSourceComboP4Handler->Set_RunDependent_Data(locEventLoop);
+	dSourceComboVertexer->Set_RunDependent_Data(locEventLoop);
+	dSourceComboTimeHandler->Set_RunDependent_Data(locEventLoop);
+	dParticleComboCreator->Set_RunDependent_Data(locEventLoop);	
+}
+
 DSourceComboer::DSourceComboer(JEventLoop* locEventLoop)
 {
 	dResourcePool_SourceCombo.Set_ControlParams(100, 50, 1000, 20000, 0);
@@ -461,14 +480,6 @@ DSourceComboer::DSourceComboer(JEventLoop* locEventLoop)
 	gPARMS->SetDefaultParameter("COMBO:PRINT_CUTS", dPrintCutFlag);
 	gPARMS->SetDefaultParameter("COMBO:MAX_NEUTRALS", dMaxNumNeutrals);
 
-	//GET THE GEOMETRY
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	DGeometry* locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
-
-	//TARGET INFORMATION
-	double locTargetCenterZ = 65.0;
-	locGeometry->GetTargetZ(locTargetCenterZ);
-	dTargetCenter.SetXYZ(0.0, 0.0, locTargetCenterZ);
 
 	//SETUP CUTS
 	Define_DefaultCuts();
@@ -498,6 +509,8 @@ DSourceComboer::DSourceComboer(JEventLoop* locEventLoop)
 	dSourceComboP4Handler->Set_SourceComboVertexer(dSourceComboVertexer);
 	dSourceComboVertexer->Set_SourceComboTimeHandler(dSourceComboTimeHandler);
 	dParticleComboCreator = new DParticleComboCreator(locEventLoop, this, dSourceComboTimeHandler, dSourceComboVertexer);
+
+	Set_RunDependent_Data(locEventLoop);
 
 	//save rf bunch cuts
 	if(gPARMS->Exists("COMBO:NUM_PLUSMINUS_RF_BUNCHES"))

--- a/src/libraries/ANALYSIS/DSourceComboer.h
+++ b/src/libraries/ANALYSIS/DSourceComboer.h
@@ -100,6 +100,8 @@ class DSourceComboer : public JObject
 
 		//RESET
 		void Reset_NewEvent(JEventLoop* locEventLoop);
+		
+		void Set_RunDependent_Data(JEventLoop *locEventLoop);
 
 		//BUILD COMBOS (what should be called from the outside to do all of the work)
 		DCombosByReaction Build_ParticleCombos(const DReactionVertexInfo* locReactionVertexInfo);

--- a/src/libraries/KINFITTER/DKinFitUtils.h
+++ b/src/libraries/KINFITTER/DKinFitUtils.h
@@ -10,6 +10,8 @@
 #include "TLorentzVector.h"
 #include "TMatrixFSym.h"
 
+#include "JANA/JEventLoop.h"
+
 #include "DResourcePool.h"
 
 #include "DKinFitter.h"
@@ -22,6 +24,7 @@
 #include "DKinFitConstraint_Spacetime.h"
 
 using namespace std;
+using namespace jana;
 
 class DKinFitUtils //contains pure-virtual functions: cannot directly instantiate class, can only inherit from it
 {
@@ -34,10 +37,12 @@ class DKinFitUtils //contains pure-virtual functions: cannot directly instantiat
 		//STRUCTORS
 		DKinFitUtils(void);
 		virtual ~DKinFitUtils(void){};
-
+		
 		//RESET: IF YOU OVERRIDE THESE IN THE DERIVED CLASS, BE SURE TO CALL THE BASE CLASS FUNCTIONS!
 		virtual void Reset_NewEvent(void);
 		virtual void Reset_NewFit(void){};
+		
+		virtual void Set_RunDependent_Data(JEventLoop *locEventLoop) {}
 
 		/************************************************************ CONTROL AND MAPPING ***********************************************************/
 

--- a/src/libraries/KINFITTER/DKinFitter.h
+++ b/src/libraries/KINFITTER/DKinFitter.h
@@ -17,6 +17,8 @@
 #include "TMath.h"
 #include "TDecompLU.h"
 
+#include "JANA/JEventLoop.h"
+
 #include "DKinFitParticle.h"
 #include "DKinFitConstraint.h"
 #include "DKinFitConstraint_Mass.h"
@@ -25,6 +27,7 @@
 #include "DKinFitConstraint_Spacetime.h"
 
 using namespace std;
+using namespace jana;
 
 enum DKinFitStatus
 {
@@ -45,6 +48,8 @@ class DKinFitter //purely virtual: cannot directly instantiate class, can only i
 
 		//CONSTRUCTOR
 		DKinFitter(DKinFitUtils* locKinFitUtils);
+
+		void Set_RunDependent_Data(JEventLoop *locEventLoop) {}
 
 		//RESET
 		void Reset_NewEvent(void);

--- a/src/plugins/Analysis/ReactionFilter/DEventProcessor_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DEventProcessor_ReactionFilter.cc
@@ -69,10 +69,11 @@ jerror_t DEventProcessor_ReactionFilter::evnt(jana::JEventLoop* locEventLoop, ui
 		//If no cuts are performed by the analysis actions added to a DReaction, then this saves all of its particle combinations. 
 		//The event writer gets the DAnalysisResults objects from JANA, performing the analysis. 
 	// string is DReaction factory tag: will fill trees for all DReactions that are defined in the specified factory
+  
 	const DEventWriterROOT* locEventWriterROOT = NULL;
 	locEventLoop->GetSingle(locEventWriterROOT);
 	locEventWriterROOT->Fill_DataTrees(locEventLoop, "ReactionFilter");
-
+  
 	/******************************************************** OPTIONAL: SKIMS *******************************************************/
 
 	/*

--- a/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.cc
+++ b/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.cc
@@ -18,7 +18,8 @@ void DCustomAction_HistMass_X_2000::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		//locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.h
+++ b/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_X_2000.h
@@ -32,6 +32,7 @@ class DCustomAction_HistMass_X_2000 : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_HistMass_X_2000", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 
 	private:
 

--- a/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_b1_1235.cc
+++ b/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_b1_1235.cc
@@ -18,7 +18,8 @@ void DCustomAction_HistMass_b1_1235::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		//locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_b1_1235.h
+++ b/src/plugins/Analysis/b1pi_hists/DCustomAction_HistMass_b1_1235.h
@@ -32,6 +32,7 @@ class DCustomAction_HistMass_b1_1235 : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_HistMass_b1_1235", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 
 	private:
 

--- a/src/plugins/Analysis/dirc_reactions/DCustomAction_dirc_reactions.cc
+++ b/src/plugins/Analysis/dirc_reactions/DCustomAction_dirc_reactions.cc
@@ -5,6 +5,23 @@
 
 #include "DCustomAction_dirc_reactions.h"
 
+void DCustomAction_dirc_reactions::Run_Update(JEventLoop* locEventLoop)
+{
+	// get PID algos
+	const DParticleID* locParticleID = NULL;
+	locEventLoop->GetSingle(locParticleID);
+	dParticleID = locParticleID;
+
+	locEventLoop->GetSingle(dDIRCLut);
+	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	// get DIRC geometry
+	vector<const DDIRCGeometry*> locDIRCGeometry;
+	locEventLoop->Get(locDIRCGeometry);
+	dDIRCGeometry = locDIRCGeometry[0];
+
+}
+
 void DCustomAction_dirc_reactions::Initialize(JEventLoop* locEventLoop)
 {
 	DIRC_TRUTH_BARHIT = false;
@@ -13,19 +30,8 @@ void DCustomAction_dirc_reactions::Initialize(JEventLoop* locEventLoop)
 
 	DIRC_FILL_BAR_MAP = false;
 	gPARMS->SetDefaultParameter("DIRC:FILL_BAR_MAP",DIRC_FILL_BAR_MAP);
-
-	// get PID algos
-        const DParticleID* locParticleID = NULL;
-        locEventLoop->GetSingle(locParticleID);
-        dParticleID = locParticleID;
-
-        locEventLoop->GetSingle(dDIRCLut);
-	locEventLoop->GetSingle(dAnalysisUtilities);
-
-	// get DIRC geometry
-	vector<const DDIRCGeometry*> locDIRCGeometry;
-        locEventLoop->Get(locDIRCGeometry);
-        dDIRCGeometry = locDIRCGeometry[0];
+	
+	Run_Update(locEventLoop);
 
 	// set PID for different passes in debuging histograms
 	dFinalStatePIDs.push_back(Positron);

--- a/src/plugins/Analysis/dirc_reactions/DCustomAction_dirc_reactions.h
+++ b/src/plugins/Analysis/dirc_reactions/DCustomAction_dirc_reactions.h
@@ -33,6 +33,7 @@ class DCustomAction_dirc_reactions : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_dirc_reactions", locUseKinFitResultsFlag, locActionUniqueString), dParticleComboStepIndex(locParticleComboStepIndex), dParticleIndex(locParticleIndex), dPID(locPID) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_cuts.h
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_cuts.h
@@ -32,6 +32,7 @@ class DCustomAction_p2gamma_cuts : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_p2gamma_cuts", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.cc
@@ -7,7 +7,8 @@
 
 #include "DCustomAction_p2gamma_hists.h"
 
-void DCustomAction_p2gamma_hists::Initialize(JEventLoop* locEventLoop)
+
+void DCustomAction_p2gamma_hists::Run_Update(JEventLoop* locEventLoop)
 {
 	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 	JCalibration *jcalib = dapp->GetJCalibration((locEventLoop->GetJEvent()).GetRunNumber());
@@ -27,7 +28,12 @@ void DCustomAction_p2gamma_hists::Initialize(JEventLoop* locEventLoop)
 		cohmin_energy = photon_beam_param["cohmin_energy"];
 		cohedge_energy = photon_beam_param["cohedge_energy"];
 	}
+}
 
+void DCustomAction_p2gamma_hists::Initialize(JEventLoop* locEventLoop)
+{
+	Run_Update(locEventLoop);
+	
 	dEdxCut = 2.2;
         minMM2Cut = -0.05;
         maxMM2Cut = 0.05;

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.h
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_hists.h
@@ -32,6 +32,7 @@ class DCustomAction_p2gamma_hists : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_p2gamma_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 		void Reset_NewEvent(void){dPreviousSourceObjects.clear();}
 
 	private:

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.cc
@@ -9,11 +9,7 @@
 
 void DCustomAction_p2gamma_unusedHists::Initialize(JEventLoop* locEventLoop)
 {
-
-	// get PID algos
-	const DParticleID* locParticleID = NULL;
-        locEventLoop->GetSingle(locParticleID);
-	dParticleID = locParticleID;
+	Run_Update(locEventLoop);
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock

--- a/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.h
+++ b/src/plugins/Analysis/p2gamma_hists/DCustomAction_p2gamma_unusedHists.h
@@ -36,6 +36,12 @@ class DCustomAction_p2gamma_unusedHists : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p2gamma_unusedHists", locUseKinFitResultsFlag, locActionUniqueString){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {
+			// get PID algos
+			const DParticleID* locParticleID = NULL;
+			locEventLoop->GetSingle(locParticleID);
+			dParticleID = locParticleID;
+		}
 
 	private:
 

--- a/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.cc
@@ -7,31 +7,37 @@
 
 #include "DCustomAction_p2k_hists.h"
 
-void DCustomAction_p2k_hists::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_p2k_hists::Run_Update(JEventLoop* locEventLoop)
 {
 	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-        JCalibration *jcalib = dapp->GetJCalibration((locEventLoop->GetJEvent()).GetRunNumber());
+	JCalibration *jcalib = dapp->GetJCalibration((locEventLoop->GetJEvent()).GetRunNumber());
 
-        // Parameters for event selection to fill histograms
-        endpoint_energy = 12.;
-        map<string, double> photon_endpoint_energy;
-        if(jcalib->Get("/PHOTON_BEAM/endpoint_energy", photon_endpoint_energy) == false) {
-                endpoint_energy = photon_endpoint_energy["PHOTON_BEAM_ENDPOINT_ENERGY"];
-        }
-        endpoint_energy_bins = (int)(20*endpoint_energy);
+	// Parameters for event selection to fill histograms
+	endpoint_energy = 12.;
+	map<string, double> photon_endpoint_energy;
+	if(jcalib->Get("/PHOTON_BEAM/endpoint_energy", photon_endpoint_energy) == false) {
+			endpoint_energy = photon_endpoint_energy["PHOTON_BEAM_ENDPOINT_ENERGY"];
+	}
+	endpoint_energy_bins = (int)(20*endpoint_energy);
 
-        cohmin_energy = 0.;
-        cohedge_energy = 12.;
-        map<string, double> photon_beam_param;
-        if(jcalib->Get("/ANALYSIS/beam_asymmetry/coherent_energy", photon_beam_param) == false) {
-                cohmin_energy = photon_beam_param["cohmin_energy"];
-                cohedge_energy = photon_beam_param["cohedge_energy"];
-        }
+	cohmin_energy = 0.;
+	cohedge_energy = 12.;
+	map<string, double> photon_beam_param;
+	if(jcalib->Get("/ANALYSIS/beam_asymmetry/coherent_energy", photon_beam_param) == false) {
+			cohmin_energy = photon_beam_param["cohmin_energy"];
+			cohedge_energy = photon_beam_param["cohedge_energy"];
+	}
+}
 
-        dEdxCut = 2.2;
-        minMM2Cut = -0.01;
-        maxMM2Cut = 0.01;
-        maxPhiMassCut = 1.05;
+
+void DCustomAction_p2k_hists::Initialize(JEventLoop* locEventLoop)
+{
+	Run_Update(locEventLoop);
+
+	dEdxCut = 2.2;
+	minMM2Cut = -0.01;
+	maxMM2Cut = 0.01;
+	maxPhiMassCut = 1.05;
 
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock

--- a/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.h
+++ b/src/plugins/Analysis/p2k_hists/DCustomAction_p2k_hists.h
@@ -32,6 +32,7 @@ class DCustomAction_p2k_hists : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p2k_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 

--- a/src/plugins/Analysis/p2pi0_hists/DCustomAction_p2pi0_hists.h
+++ b/src/plugins/Analysis/p2pi0_hists/DCustomAction_p2pi0_hists.h
@@ -37,6 +37,7 @@ class DCustomAction_p2pi0_hists : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_p2pi0_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_cuts.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_cuts.h
@@ -33,6 +33,7 @@ class DCustomAction_p2pi_cuts : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p2pi_cuts", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.cc
@@ -7,7 +7,7 @@
 
 #include "DCustomAction_p2pi_hists.h"
 
-void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
+void DCustomAction_p2pi_hists::Run_Update(JEventLoop* locEventLoop)
 {
 	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 	JCalibration *jcalib = dapp->GetJCalibration((locEventLoop->GetJEvent()).GetRunNumber());
@@ -34,6 +34,17 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 		jout<<"No /ANALYSIS/beam_asymmetry/coherent_energy for this run number: using default range of 0-12 GeV"<<endl;
 	}
 
+	// get PID algos
+	const DParticleID* locParticleID = NULL;
+	locEventLoop->GetSingle(locParticleID);
+	dParticleID = locParticleID;
+
+	locEventLoop->GetSingle(dAnalysisUtilities);
+
+}
+
+void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
+{
 	dEdxCut = 2.2;
 	minMMCut = 0.8;
 	maxMMCut = 1.05;
@@ -43,12 +54,7 @@ void DCustomAction_p2pi_hists::Initialize(JEventLoop* locEventLoop)
 	minRhoMassCut = 0.6;
 	maxRhoMassCut = 0.88;
 
-	// get PID algos
-        const DParticleID* locParticleID = NULL;
-        locEventLoop->GetSingle(locParticleID);
-        dParticleID = locParticleID;
-
-	locEventLoop->GetSingle(dAnalysisUtilities);
+	Run_Update(locEventLoop);
 
 	// check if a particle is missing
 	auto locMissingPIDs = Get_Reaction()->Get_MissingPIDs();

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_hists.h
@@ -33,6 +33,7 @@ class DCustomAction_p2pi_hists : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p2pi_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.cc
@@ -7,9 +7,9 @@
 
 #include "DCustomAction_p2pi_unusedHists.h"
 
-void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
-{
 
+void DCustomAction_p2pi_unusedHists::Run_Update(JEventLoop* locEventLoop)
+{
 	// get PID algos
 	const DParticleID* locParticleID = NULL;
         locEventLoop->GetSingle(locParticleID);
@@ -22,6 +22,11 @@ void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
 	vector<const DTrackFitter*>locFitters;
 	locEventLoop->Get(locFitters);
 	dFitter=locFitters[0];
+}
+	
+void DCustomAction_p2pi_unusedHists::Initialize(JEventLoop* locEventLoop)
+{
+	Run_Update(locEventLoop);
 	
 	//CREATE THE HISTOGRAMS
 	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock

--- a/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.h
+++ b/src/plugins/Analysis/p2pi_hists/DCustomAction_p2pi_unusedHists.h
@@ -37,6 +37,7 @@ class DCustomAction_p2pi_unusedHists : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p2pi_unusedHists", locUseKinFitResultsFlag, locActionUniqueString){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop);
 
 	private:
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.cc
@@ -14,7 +14,7 @@ void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraPi0.h
@@ -31,6 +31,7 @@ class DCustomAction_CutExtraPi0 : public DAnalysisAction
 		dLowMassCut(locLowMassCut), dHighMassCut(locHighMassCut) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 		void Reset_NewEvent(void){dPreviousSourceObjects.clear();}
 
 	private:

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.cc
@@ -9,14 +9,14 @@
 
 void DCustomAction_CutExtraTrackPID::Initialize(JEventLoop* locEventLoop)
 {
-	locEventLoop->GetSingle(dAnalysisUtilities);
-
 	dPIDCuts[SYS_TOF] = 1.0;
 	dPIDCuts[SYS_BCAL] = 1.0;
 	dPIDCuts[SYS_FCAL] = 2.0;
 
 	ddEdxCutAction = new DCutAction_dEdx(Get_Reaction());
 	ddEdxCutAction->Initialize(locEventLoop);
+	
+	Run_Update(locEventLoop);
 }
 
 bool DCustomAction_CutExtraTrackPID::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_CutExtraTrackPID.h
@@ -32,6 +32,10 @@ class DCustomAction_CutExtraTrackPID : public DAnalysisAction
 		dExtraTrackTargetPID(locExtraTrackTargetPID) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {
+			locEventLoop->GetSingle(dAnalysisUtilities);
+			ddEdxCutAction->Run_Update(locEventLoop);
+		}
 
 	private:
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.cc
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.cc
@@ -18,7 +18,7 @@ void DCustomAction_HistOmegaVsMissProton::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_HistOmegaVsMissProton.h
@@ -32,6 +32,7 @@ class DCustomAction_HistOmegaVsMissProton : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_HistOmegaVsMissProton", false, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 
 	private:
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_Pi0Cuts.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_Pi0Cuts.h
@@ -30,6 +30,7 @@ class DCustomAction_p3pi_Pi0Cuts : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_p3pi_Pi0Cuts", locUseKinFitResultsFlag, locActionUniqueString), dMinFCAL(locMinFCAL){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.h
+++ b/src/plugins/Analysis/p3pi_hists/DCustomAction_p3pi_hists.h
@@ -37,6 +37,7 @@ class DCustomAction_p3pi_hists : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_p3pi_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.cc
@@ -14,7 +14,7 @@ void DCustomAction_CutExtraPi0::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.h
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraPi0.h
@@ -31,6 +31,7 @@ class DCustomAction_CutExtraPi0 : public DAnalysisAction
 		dLowMassCut(locLowMassCut), dHighMassCut(locHighMassCut) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 		void Reset_NewEvent(void){dPreviousSourceObjects.clear();}
 
 	private:

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraTrackPID.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraTrackPID.cc
@@ -9,14 +9,14 @@
 
 void DCustomAction_CutExtraTrackPID::Initialize(JEventLoop* locEventLoop)
 {
-	locEventLoop->GetSingle(dAnalysisUtilities);
-
 	dPIDCuts[SYS_TOF] = 1.0;
 	dPIDCuts[SYS_BCAL] = 1.0;
 	dPIDCuts[SYS_FCAL] = 2.0;
 
 	ddEdxCutAction = new DCutAction_dEdx(Get_Reaction());
 	ddEdxCutAction->Initialize(locEventLoop);
+	
+	Run_Update(locEventLoop);
 }
 
 bool DCustomAction_CutExtraTrackPID::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraTrackPID.h
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_CutExtraTrackPID.h
@@ -32,6 +32,10 @@ class DCustomAction_CutExtraTrackPID : public DAnalysisAction
 		dExtraTrackTargetPID(locExtraTrackTargetPID) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {
+			locEventLoop->GetSingle(dAnalysisUtilities);
+			ddEdxCutAction->Run_Update(locEventLoop);
+		}
 
 	private:
 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.cc
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.cc
@@ -18,7 +18,7 @@ void DCustomAction_HistOmegaVsMissProton::Initialize(JEventLoop* locEventLoop)
 	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 	{
 		// Optional: Useful utility functions.
-		locEventLoop->GetSingle(dAnalysisUtilities);
+		Run_Update(locEventLoop);
 
 		//Required: Create a folder in the ROOT output file that will contain all of the output ROOT objects (if any) for this action.
 			//If another thread has already created the folder, it just changes to it. 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.h
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_HistOmegaVsMissProton.h
@@ -32,6 +32,7 @@ class DCustomAction_HistOmegaVsMissProton : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_HistOmegaVsMissProton", false, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) { locEventLoop->GetSingle(dAnalysisUtilities); }
 
 	private:
 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_Pi0Cuts.h
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_Pi0Cuts.h
@@ -30,6 +30,7 @@ class DCustomAction_ppi0gamma_Pi0Cuts : public DAnalysisAction
 	        DAnalysisAction(locReaction, "Custom_ppi0gamma_Pi0Cuts", locUseKinFitResultsFlag, locActionUniqueString), dMinFCAL(locMinFCAL){}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.h
+++ b/src/plugins/Analysis/ppi0gamma_hists/DCustomAction_ppi0gamma_hists.h
@@ -37,6 +37,7 @@ class DCustomAction_ppi0gamma_hists : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_ppi0gamma_hists", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Utilities/exclusivepi0skim/DCustomAction_CutPhotonKin.h
+++ b/src/plugins/Utilities/exclusivepi0skim/DCustomAction_CutPhotonKin.h
@@ -30,6 +30,7 @@ class DCustomAction_CutPhotonKin : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_CutPhotonKin", false, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Utilities/exclusivepi0skim/DCustomAction_p2gamma_cuts.h
+++ b/src/plugins/Utilities/exclusivepi0skim/DCustomAction_p2gamma_cuts.h
@@ -32,7 +32,8 @@ class DCustomAction_p2gamma_cuts : public DAnalysisAction
 		DAnalysisAction(locReaction, "Custom_p2gamma_cuts", locUseKinFitResultsFlag, locActionUniqueString) {}
 
 		void Initialize(JEventLoop* locEventLoop);
-
+		void Run_Update(JEventLoop* locEventLoop) {}
+ 
 	private:
 
 		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);

--- a/src/plugins/Utilities/track_skimmer/DCustomAction_ee_ShowerEoverP_cut.h
+++ b/src/plugins/Utilities/track_skimmer/DCustomAction_ee_ShowerEoverP_cut.h
@@ -37,6 +37,7 @@ class DCustomAction_ee_ShowerEoverP_cut : public DAnalysisAction
 
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {}
 
 	private:
 

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.cc
@@ -19,9 +19,7 @@ void DCustomAction_CutNoDetectorHit::Initialize(JEventLoop* locEventLoop)
 	if(locMissingPIDs.size() != 1)
 		return; //invalid reaction setup
 
-	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
-	dMagneticFieldMap = locApplication->GetBfield(locEventLoop->GetJEvent().GetRunNumber());
-	locEventLoop->GetSingle(dParticleID);
+	Run_Update(locEventLoop);
 
 	string locHistName, locHistTitle;
 	string locTrackString = string("Missing ") + ParticleName_ROOT(dMissingPID);

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_CutNoDetectorHit.h
@@ -42,6 +42,11 @@ class DCustomAction_CutNoDetectorHit : public DAnalysisAction
 		dSCMatchMinDeltaPhi(-180.0), dSCMatchMaxDeltaPhi(180.0), dMinTrackDOCA(0.0), dMaxTrackMatchDOCA(200.0), dMinDeltaZ(-60.0), dMaxDeltaZ(60.0) {}
 
 		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {
+			DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+			dMagneticFieldMap = locApplication->GetBfield(locEventLoop->GetJEvent().GetRunNumber());
+			locEventLoop->GetSingle(dParticleID);		
+		}
 		void Reset_NewEvent(void){}; //RESET HISTOGRAM DUPLICATE-CHECK TRACKING HERE!!
 
 	private:

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.cc
@@ -20,8 +20,7 @@ void DCustomAction_TrackingEfficiency::Initialize(JEventLoop* locEventLoop)
 	if(locMissingPIDs.size() != 1)
 		return; //invalid reaction setup
 
-	locEventLoop->GetSingle(dAnalysisUtilities);
-	locEventLoop->GetSingle(dParticleID);
+	Run_Update(locEventLoop);
 
 	//CREATE TTREE, TFILE
 	dTreeInterface = DTreeInterface::Create_DTreeInterface(locReaction->Get_ReactionName(), "tree_trackeff.root");

--- a/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.h
+++ b/src/plugins/Utilities/trackeff_missing/DCustomAction_TrackingEfficiency.h
@@ -40,7 +40,10 @@ class DCustomAction_TrackingEfficiency : public DAnalysisAction
 		}
 
 		void Initialize(JEventLoop* locEventLoop);
-
+		void Run_Update(JEventLoop* locEventLoop) {
+			locEventLoop->GetSingle(dAnalysisUtilities);
+			locEventLoop->GetSingle(dParticleID);
+		}
 		~DCustomAction_TrackingEfficiency(void)
 		{
 			if(dTreeInterface != NULL)


### PR DESCRIPTION
This pull request is a follow-up to PR #174 and addresses issues such as #111 

The root cause is the same problem - classes like DAnalysisUtilities would be recreated every time a new run is encountered and not correctly propagated to all of the classes which kept pointers to them (which suggests an overarching problem to consider at another time!).  The class structure in this library is more complicated than other libraries, with many of the classes not being directly created in factories, so the required changes were a little more complicated.  I basically started with DAnalysisResults_factory, and worked out from there.

The main change for developers to note that is that DAnalysisAction now has an additional empty virtual method called Run_Update(), which doesn't do a full set of initialization but would be
called at brun(), for example, to update any run dependent quantities.

One could do a more thorough overhaul but that is left for future work.