### PR TITLE
Comment out "slot" declaration to avoid unused variable warning.

### DIFF
--- a/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
+++ b/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
@@ -118,7 +118,8 @@ jerror_t JEventProcessor_FCAL_LED_shifts::init(void)
   		uint32_t crate = firstCrate + i;
     	m_crateTimes[crate] = (new TH1I(Form("crate_times_%i",crate),Form("Hit Times for Crate %i",crate),NBINS_TIME,TIME_MIN,TIME_MAX));
 	  	for (int i = 0; i < numSlots; ++i) {
-	  		uint32_t slot = firstSlot + i;
+		  // next line commented out to avoid unused variable warning
+			//uint32_t slot = firstSlot + i;
 			//pair<uint32_t,uint32_t> crate_slot(crate,slot);
 		   	//m_slotTimes[crate_slot] = (new TH1I(Form("slot_times_c%i_s%i",crate,slot),
 		   	//							Form("Hit Times for Crate %i, Slot %i",crate,slot),200,60.,110.));


### PR DESCRIPTION
Warning suppression fix. @sdobbs should look at this one.