### PR TITLE
Comment out fcalGeom to supress warning about unused variable.

### DIFF
--- a/src/plugins/Calibration/FCAL_TimingOffsets/JEventProcessor_FCAL_TimingOffsets.cc
+++ b/src/plugins/Calibration/FCAL_TimingOffsets/JEventProcessor_FCAL_TimingOffsets.cc
@@ -133,7 +133,8 @@ jerror_t JEventProcessor_FCAL_TimingOffsets::evnt(JEventLoop *eventLoop,
     return RESOURCE_UNAVAILABLE;
   }
 
-  auto fcalGeom = geomVec[0];
+  // next line commented out to suppress warning, variable unused
+  //  auto fcalGeom = geomVec[0];
 
 
   double FCAL_C_EFFECTIVE = 15.0;


### PR DESCRIPTION
Requested a review from @sdobbs for this one.