### PR TITLE
Fix bug in finding factories for event source and TTAB low-level objects

### DIFF
--- a/src/libraries/DAQ/DParsedEvent.h
+++ b/src/libraries/DAQ/DParsedEvent.h
@@ -212,7 +212,7 @@ class DParsedEvent{
 		// One of these is instantiated for each JEventLoop encountered.
 		// See comments below for CopyToFactories for details.
 		#define makefactoryptr(A) JFactory<A> *fac_##A;
-		#define copyfactoryptr(A) fac_##A = (JFactory<A>*)loop->GetFactory(#A);
+		#define copyfactoryptr(A) fac_##A = (JFactory<A>*)loop->GetFactory(#A, NULL, false);
 		class DFactoryPointers{
 			public:
 				JEventLoop *loop;

--- a/src/libraries/TTAB/DTranslationTable.h
+++ b/src/libraries/TTAB/DTranslationTable.h
@@ -402,7 +402,7 @@ class DTranslationTable:public jana::JObject{
 		MyTypes(makefactoryptr)
 		
 		// Method to initialize factory pointers
-		#define copyfactoryptr(A) fac_##A = (JFactory<A>*)loop->GetFactory(#A);
+		#define copyfactoryptr(A) fac_##A = (JFactory<A>*)loop->GetFactory(#A, NULL, false);
 		void InitFactoryPointers(JEventLoop *loop){ MyTypes(copyfactoryptr) }
 
 		// Method to clear each of the vectors at beginning of event


### PR DESCRIPTION
Do not allow DEFTAG when finding factories to place low-level and digihit objects into. This fix will allow tagged factories for these types of objects that can be used to filter them for special studies. Prior to this, the EVIO event source and TTAB would instead place the objects directly into the tagged factory which is not what was wanted.