### PR TITLE
Remove the RCDB mysql-connector from the path so the system one may be used

### DIFF
--- a/src/programs/Utilities/hdskims/hdmk_skims.py
+++ b/src/programs/Utilities/hdskims/hdmk_skims.py
@@ -84,6 +84,13 @@ ret = subprocess.call( cmd )
 # Update skininfo DB with any .sql files found in working directory
 sqlfiles = glob.glob('*.sql')
 if len(sqlfiles) > 0:
+
+	# We need to import mysql.connector but the RCDB version is
+	# not compatible with what is installed on the gluons. Thus,
+	# we need to make sure it is not in our path
+	mypath = sys.path.copy()  # loop over copy so we can change real list within loop
+	for p in mypath:
+		if '/rcdb/' in p: sys.path.remove(p)
 	import mysql.connector
 	mydb = mysql.connector.connect( host=MYSQL_HOST, user=MYSQL_USER, password=MYSQL_PASSWORD, database=MYSQL_DB)
 	mycursor = mydb.cursor()


### PR DESCRIPTION
This change only affects the hdmk_skims.py script.

As an aside, it is not clear at all that it is a good idea to distribute a version of mysql-connector with RCDB and especially to have that automatically added to PYTHONPATH in the environment setup scripts. The version shipped with RCDB is incompatible with python36 and moreover, automatically adding it to the environment blocks the system installed one (almost certainly more likely to be compatible). I think I've been bitten by this at least once before. This fix here is ugly and the time it takes to track down this problem and implement such a fix would be better spent elsewhere.