### PR TITLE
Fill in daq_hits_per_event histogram.

### DIFF
--- a/src/programs/Utilities/hdevio_scan/DMapEVIOWords.h
+++ b/src/programs/Utilities/hdevio_scan/DMapEVIOWords.h
@@ -130,6 +130,7 @@ class DMapEVIOWords{
 
 		DMapEVIOWords();
 		~DMapEVIOWords();
+		void Finish(void);
 		void AddROCIDLabels(void);
 		void ParseEvent(uint32_t *buff);
 		void DataWordStats(uint32_t *iptr, uint32_t *iend, uint32_t *word_stats);
@@ -147,6 +148,8 @@ class DMapEVIOWords{
 
 		set<uint64_t> ts_history;
 		uint32_t max_history_buff_size;
+		
+		uint64_t Nphysics_events;
 
 	private:
 };

--- a/src/programs/Utilities/hdevio_scan/hdevio_scan.cc
+++ b/src/programs/Utilities/hdevio_scan/hdevio_scan.cc
@@ -277,6 +277,9 @@ void MapEVIOWords(void)
 		delete hdevio;
 	}
 	
+	// Allow some histograms to be scaled.
+	mapevio.Finish();
+	
 	// Flush and close ROOT file
 	rootfile->Write();
 	rootfile->Close();


### PR DESCRIPTION
This fills in a histogram hdevio_scan creates, but until now never actually filled. It is the daq_hits_per_event histo which plots hits as a function of rocid (system type). 