### PR TITLE
CDAQ + BOR and DIRC emails

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -505,8 +505,14 @@ void DEVIOWorkerThread::ParseBORbank(uint32_t* &iptr, uint32_t *iend)
 	iend = &iptr[borevent_len]; // in case they give us too much data!
 	
 	// Make sure BOR header word is right
+	// n.b. CODA writes bor_header = 0x700e01
+	// CDAQ replaces the last "01" with the number of crates.
+	// Prior to Fall 2019 this was 0x700e34 and then 2 more crates
+	// were added to make it 0x700e36. Now we just ignore those
+	// lower 8 bits so this doesn't break in the future.
 	uint32_t bor_header = *iptr++;
-	if( (bor_header!=0x700e01) && (bor_header!=0x700e34) ){
+//	if( (bor_header!=0x700e01) && (bor_header!=0x700e34) ){
+	if( (bor_header>>8) != 0x700e ){
 		stringstream ss;
 		ss << "Bad BOR header: 0x" << hex << bor_header;
 		_DBG_<< ss.str() << endl;

--- a/src/plugins/monitoring/DIRC_online/DIRC_North_hit.C
+++ b/src/plugins/monitoring/DIRC_online/DIRC_North_hit.C
@@ -8,6 +8,11 @@
 // hnamepath: /DIRC_online/Hit/NorthUpperBox/Hit_Time_LED
 // hnamepath: /DIRC_online/Hit/NorthUpperBox/Hit_PixelOccupancy_LED
 // hnamepath: /DIRC_online/Hit/NorthUpperBox/Hit_PixelOccupancy_NonLED
+//
+// e-mail: davidl@jlab.org
+// e-mail: jrsteven@jlab.org
+// e-mail: billlee@jlab.org
+// e-mail: tbritton@jlab.org
 
 
 {  

--- a/src/plugins/monitoring/DIRC_online/DIRC_digihit.C
+++ b/src/plugins/monitoring/DIRC_online/DIRC_digihit.C
@@ -8,6 +8,11 @@
 // hnamepath: /DIRC_online/DigiHit/SouthLowerBox/TDCDigiHit_Time_NonLED
 // hnamepath: /DIRC_online/DigiHit/NorthUpperBox/TDCDigiHit_Time_LED
 // hnamepath: /DIRC_online/DigiHit/NorthUpperBox/TDCDigiHit_Time_NonLED
+//
+// e-mail: davidl@jlab.org
+// e-mail: jrsteven@jlab.org
+// e-mail: billlee@jlab.org
+// e-mail: tbritton@jlab.org
 
 
 {  

--- a/src/plugins/monitoring/DIRC_online/DIRC_hit.C
+++ b/src/plugins/monitoring/DIRC_online/DIRC_hit.C
@@ -9,6 +9,11 @@
 // hnamepath: /DIRC_online/LEDRefAdcTime
 // hnamepath: /DIRC_online/LEDRefTdcTime
 // hnamepath: /DIRC_online/LEDRefAdcVsTdcTime
+//
+// e-mail: davidl@jlab.org
+// e-mail: jrsteven@jlab.org
+// e-mail: billlee@jlab.org
+// e-mail: tbritton@jlab.org
 
 {  
   TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("DIRC_online");


### PR DESCRIPTION
This fixes the check on the BOR header word so that it will accept CDAQ data from Spring2019-11. CDAQ differs in how it formats this word in that it puts the number of crates in the EVIO "num" field whereas hdBOR just puts 01 there. This had been fixed for previous run periods where CDAQ was used. For the current run period, 2 more crates were added. The check now ignores the 8 bit "num" field.

Also included in this pull request are adding the e-mail addresses for DIRC experts to the DIRC_online monitoring macro. It probably be a second pull request, but that would be a pain to do now so it was left in this one.