### PR TITLE
Add option to write skims to HDDM

### DIFF
--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
@@ -26,6 +26,7 @@
 #include "BCAL/DBCALShower.h"
 #include "RF/DRFTime.h"
 #include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
 
 #include "DLorentzVector.h"
 #include "TTree.h"
@@ -50,10 +51,12 @@ JEventProcessor_pi0bcalskim::JEventProcessor_pi0bcalskim()
   MIN_SH2_E = 0.2;
 
   WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
 
   gPARMS->SetDefaultParameter( "PI0BCALSKIM:WRITE_EVIO", WRITE_EVIO );
-  gPARMS->SetDefaultParameter("PI0BCALSKIM:MIN_SH1_E" , MIN_SH1_E );
-  gPARMS->SetDefaultParameter("PI0BCALSKIM:MIN_SH2_E" , MIN_SH2_E );
+  gPARMS->SetDefaultParameter( "PI0BCALSKIM:WRITE_HDDM", WRITE_HDDM );
+  gPARMS->SetDefaultParameter( "PI0BCALSKIM:MIN_SH1_E" , MIN_SH1_E );
+  gPARMS->SetDefaultParameter( "PI0BCALSKIM:MIN_SH2_E" , MIN_SH2_E );
 
   num_epics_events = 0;
   
@@ -227,14 +230,20 @@ jerror_t JEventProcessor_pi0bcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
         }
 	}
   }
-  	if(Candidate){
-	        if( WRITE_EVIO ) {
-                //	cout << " inv mass = " << inv_mass << " sh1 E = " << sh1_E << " sh2 E = " << sh2_E << " event num = " << eventnumber << endl;
-                //cout << "writing out " << eventnumber << endl;
-                locEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim", locObjectsToSave );
-  		  }
-			}
 
+  if(Candidate){
+    if( WRITE_EVIO ) {
+      //	cout << " inv mass = " << inv_mass << " sh1 E = " << sh1_E << " sh2 E = " << sh2_E << " event num = " << eventnumber << endl;
+      //cout << "writing out " << eventnumber << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "pi0bcalskim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+  }
+  
 
   //japp->RootUnLock();
   

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
@@ -37,6 +37,7 @@ class JEventProcessor_pi0bcalskim:public jana::JEventProcessor{
   double MIN_SH2_E;
  
   int WRITE_EVIO;
+  int WRITE_HDDM;
   int num_epics_events;
 
 };

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
@@ -22,6 +22,7 @@ using namespace jana;
 #include "ANALYSIS/DAnalysisUtilities.h"
 #include "PID/DVertex.h"
 #include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
 
 #include "GlueX.h"
 #include <vector>
@@ -46,7 +47,13 @@ extern "C"{
 JEventProcessor_pi0fcalskim::JEventProcessor_pi0fcalskim()
 {
 
- WRITE_EVIO = 1;
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_HDDM", WRITE_HDDM );
+
+
 /*
   MIN_MASS   = 0.03; // GeV
   MAX_MASS   = 0.30; // GeV
@@ -67,7 +74,6 @@ JEventProcessor_pi0fcalskim::JEventProcessor_pi0fcalskim()
   gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_ETOT", MAX_ETOT );
   gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_BLOCKS", MIN_BLOCKS );
   gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_ROOT", WRITE_ROOT );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_EVIO", WRITE_EVIO );
   */
 }
 
@@ -280,9 +286,14 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
  if( Candidate ){
 
     if( WRITE_EVIO ){
-
         locEventWriterEVIO->Write_EVIOEvent( loop, "pi0fcalskim", locObjectsToSave );
     }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+
  }
  
  

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
@@ -44,6 +44,7 @@ class JEventProcessor_pi0fcalskim:public jana::JEventProcessor{
 
   int WRITE_ROOT;
   int WRITE_EVIO;
+  int WRITE_HDDM;
 
   TTree* m_tree;
   int m_nClus;


### PR DESCRIPTION
For pi0 skims to be run over simulated data.  The following switches should be used in that case:

-PPI0BCALSKIM:WRITE_EVIO=0 -PPI0BCALSKIM:WRITE_HDDM=1