### PR TITLE
Davidl cdaq run number

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -1400,6 +1400,8 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 	uint32_t slot = 0;
 	uint32_t itrigger = -1;
 
+	uint32_t *istart_pulse_data = iptr;
+
     // Loop over data words
     for(; iptr<iend; iptr++){
 
@@ -1509,7 +1511,7 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					
 						if( (*iptr>>30) != 0x01) {
 							jerr << "Bad f250 Pulse Data for rocid="<<rocid<<" slot="<<slot<<" channel="<<channel<<endl;
-							DumpBinary(&iptr[-2], iend, 128, iptr);
+							DumpBinary(istart_pulse_data, iend, ((uint64_t)&iptr[3]-(uint64_t)istart_pulse_data)/4, iptr);
 							throw JException("Bad f250 Pulse Data!", __FILE__, __LINE__);
 						}
  
@@ -1523,7 +1525,7 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 
 						iptr++;
 						if( (*iptr>>30) != 0x00){
-							DumpBinary(&iptr[-3], iend, 128, iptr);
+							DumpBinary(istart_pulse_data, iend, 128, iptr);
 							throw JException("Bad f250 Pulse Data!", __FILE__, __LINE__);
 						}
  
@@ -1630,6 +1632,11 @@ void DEVIOWorkerThread::MakeDf250WindowRawData(DParsedEvent *pe, uint32_t rocid,
         wrd->invalid_samples |= invalid_2;
         wrd->overflow |= (sample_2>>12) & 0x1;
     }
+	 
+	 if(VERBOSE>7) cout << "      FADC250 Window Raw Data: size from header=" << window_width << " Nsamples found=" << wrd->samples.size() << endl;
+	 if( window_width != wrd->samples.size() ){
+	 	jerr <<" FADC250 Window Raw Data number of samples does not match header! (" <<wrd->samples.size() << " != " << window_width << ") for rocid=" << rocid << " slot=" << slot << " channel=" << channel << endl;
+	 }
 }
 
 //----------------

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -801,6 +801,12 @@ void HDEVIO::MapBlocks(bool print_ticker)
 				br.first_event += ((uint64_t)bh.physics.first_event_hi)<<32;
 				br.last_event   = br.first_event + (uint64_t)M - 1;
 				break;
+			case 0xFF33:                                        // CDAQ
+				//M = eh->cdaqphysics.roc1_bank_header&0xFF;
+				br.block_type   = kBT_PHYSICS;
+				br.first_event  = bh.cdaqphysics.first_event;
+				br.last_event   = br.first_event + (uint64_t)M - 1; // M is probably wrong here! (see MapEvents below)
+				break;
 			default:
 				br.block_type   = kBT_UNKNOWN;
 				_DBG_ << "Uknown tag: " << hex << tag << dec << endl;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -820,12 +820,16 @@ uint64_t JEventSource_EVIOpp::SearchFileForRunNumber(void)
 			if( (*iptr & 0xffffffff) ==  0x00700E01) continue;
 			
 			// BOR event from CDAQ ER
-			if( (*iptr & 0xffffffff) ==  0x00700e34){
+			// Prior to Fall 2019 this was 0x00700e34 where the 34 represented the number of crates
+			// Two crates were added in Fall 2019 so this changed to 0x00700e36. To future-proof
+			// this, we ignore the last 8 bits and hope this is unique enough not to get confused!
+			//if( (*iptr & 0xffffffff) ==  0x00700e34){
+			if( (*iptr & 0xffffff00) ==  0x00700e00){
 				iptr++;
 				uint32_t crate_len    = iptr[0];
 				uint32_t crate_header = iptr[1];
 				uint32_t *iend_crate  = &iptr[crate_len];
-			
+
 				// Make sure crate tag is right
 				if( (crate_header>>16) == 0x71 ){
 
@@ -846,7 +850,7 @@ uint64_t JEventSource_EVIOpp::SearchFileForRunNumber(void)
 					}
 					iptr = iend_crate; // ensure we're pointing past this crate
 				}
-				
+
 				continue; // didn't find it in this CDAQ BOR. Keep looking
 			}
 


### PR DESCRIPTION
This fixes two issues with parsing CDAQ data using standard tools.

1. The run number is now found in Fall2019 and later data
2. hdevio_scan understands the ff33 tag so skips printing tons of errors.

This also improves some information in error messages when corrupt fADC250 data is encountered.