### PR TITLE
fix brace bug, only shows up on more recent compilers (e.g. gcc7)

### DIFF
--- a/src/libraries/CCAL/DCCALShower_factory.h
+++ b/src/libraries/CCAL/DCCALShower_factory.h
@@ -93,8 +93,8 @@ class DCCALShower_factory:public JFactory<DCCALShower>{
 		
 		//-----------------   Shower Profile Data & Channel Status  -----------------//
 		
-		double acell[501][501] = { { {0.} } };
-		double  ad2c[501][501] = { { {0.} } };
+		double acell[501][501] = { {0.} };
+		double  ad2c[501][501] = { {0.} };
 		
 		int stat_ch[MROW][MCOL];	
 		


### PR DESCRIPTION
The previous syntax is incorrect, too many braces.  Bad of gcc4.8.5 to allow it.

I thought that this fix had been already commited, but I guess not??

