### PR TITLE
change location of timing peaks and cuts around those peaks

### DIFF
--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
@@ -58,11 +58,11 @@ jerror_t JEventProcessor_TOF_calib::init(void)
   BINTDC_2_TIME = 0.0234375;
   BINADC_2_TIME = 0.0625; // is 4ns/64
 
-  TDCTLOC = 385.;
-  ADCTLOC = 115.;
+  TDCTLOC = 420.;
+  ADCTLOC = 130.;
 
-  ADCTimeCut = 50.;
-  TDCTimeCut = 60.;
+  ADCTimeCut = 70.;
+  TDCTimeCut = 70.;
 
   first = 1;
   MakeHistograms();


### PR DESCRIPTION
this move will hopefully make the plugin less dependent on timing shifts
within the TOF as long as these shifts are not too large (more than 20ns)