### PR TITLE
add two parameter to the TOF_calib plugin to overwrite the location o…

### DIFF
--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
@@ -67,6 +67,12 @@ jerror_t JEventProcessor_TOF_calib::init(void)
   ADCTimeCut = 70.;
   TDCTimeCut = 70.;
 
+  gPARMS->SetDefaultParameter("TOFCALIB:TDCTPEAK",TDCTLOC,
+                              "Define location of TOF TDC time-peak in Raw histogram");
+  gPARMS->SetDefaultParameter("TOFCALIB:ADCTPEAK",ADCTLOC,
+                              "Defin location of TOF ADC time-peak in Raw histogram");
+
+
   first = 1;
   MakeHistograms();
 


### PR DESCRIPTION
…f the ADC and TDC

timing peaks to accomodate poential changes during the run period in the readout window
location and size in order to make sure the propper timing peaks are usined in generating
the ADC TDC timing coincidences.

the two parameters are TOFCALIB:ADCTPEAK and TOFCALIB:TDCTPEAK