### PR TITLE
Fix to allow builds using clang.

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -2376,7 +2376,9 @@ void DEVIOWorkerThread::MakeDGEMSRSWindowRawData(DParsedEvent *pe, uint32_t roci
 	///////////////////////////////////////////////////////////////////////
 	// loop over time bins and store samples in map for all APV channels //
 	///////////////////////////////////////////////////////////////////////
-	vector<uint16_t> windowDataAPV[NCH];
+	//vector<uint16_t> windowDataAPV[NCH];
+	std::shared_ptr< vector<uint16_t> > sptr_windowDataAPV( new vector<uint16_t>[NCH] );
+	vector<uint16_t>* windowDataAPV = sptr_windowDataAPV.get();
 	//for(int i=0; i<NCH; i++) windowDataAPV[i].resize(fNbOfTimeSamples);
 
 	for(Int_t timebin = 0; timebin < fNbOfTimeSamples; timebin++) {

--- a/src/libraries/TRD/DGEMHit_factory.cc
+++ b/src/libraries/TRD/DGEMHit_factory.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <memory>
 using namespace std;
 
 #include "TRD/DGEMHit_factory.h"
@@ -91,7 +92,9 @@ jerror_t DGEMHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     uint nAPV = srswindow->apv_id + 1;
 
     // vector of each time slice for given APV
-    vector<double> pedestalAPV[nAPV]; 
+    //vector<double> pedestalAPV[nAPV]; 
+	std::shared_ptr< vector<double> > sptr_pedestalAPV( new vector<double>[nAPV] );
+	vector<double>* pedestalAPV = sptr_pedestalAPV.get();
     for(uint i=0; i<nAPV; i++) pedestalAPV[i].resize(nSamples);
     
     for (const auto& window : windowrawdata) {


### PR DESCRIPTION
Fix issue relating to initializing array with non-POD element type. This was an error for the clang compiler.

This replaces a stack declaration of an array of vector containers whose size is given by a variable. The fix allocates from the heap instead of the stack and wraps the pointer in a shared_ptr so that it is properly deleted when it falls out of scope.

This pattern appeared twice in the code.