### PR TITLE
Store some tracking info. for Millepede alignment/calibration

### DIFF
--- a/src/libraries/TRACKING/DTrackFitter.h
+++ b/src/libraries/TRACKING/DTrackFitter.h
@@ -120,6 +120,7 @@ class DTrackFitter:public jana::JObject{
 		    double tcorr; // drift time with correction for B
 		    double resic; // residual for FDC cathode measuremtns
 		    double errc;
+		    int left_right;  // left-right info. of the wire plane (-1: left or +1: right)
           vector<double> trackDerivatives;
           inline void AddTrackDerivatives(vector<double> d){ trackDerivatives = d;}
              

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -7884,11 +7884,13 @@ jerror_t DTrackFitterKalmanSIMD::SmoothForward(vector<pull_t>&forward_pulls){
                double drift_time=my_fdchits[id]->t-mT0
                   -forward_traj[m].t*TIME_UNIT_CONVERSION;
                double drift = 0.0;
-               if (USE_FDC_DRIFT_TIMES){
-                  drift=(du>0.0?1.:-1.)*fdc_drift_distance(drift_time,forward_traj[m].B);
+               int left_right = -999;
+               if (USE_FDC_DRIFT_TIMES) {
+                 drift = (du > 0.0 ? 1.0 : -1.0) * fdc_drift_distance(drift_time, forward_traj[m].B);
+                 left_right = (du > 0.0 ? +1 : -1);
                }
 
-               double resi_a=drift-doca;
+               double resi_a = drift - doca;
 
                // Variance from filter step
                // This V is really "R" in Fruhwirths notation, in the case that the track is used in the fit.
@@ -8070,6 +8072,7 @@ jerror_t DTrackFitterKalmanSIMD::SmoothForward(vector<pull_t>&forward_pulls){
 						      forward_traj[m].z,
 						      cosThetaRel,0.,
 						      resi,sqrt(V(1,1)));
+               thisPull.left_right = left_right;
                thisPull.AddTrackDerivatives(alignmentDerivatives);
                forward_pulls.push_back(thisPull);
             }

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -1688,14 +1688,16 @@ DTrackFitterStraightTrack::Smooth(vector<fdc_update_t>&fdc_updates,
       // Difference between measurement and projection for the cathodes
       double tv=tx*sina+ty*cosa;
       double resi_c=v-vpred;
-      
+
       // Difference between measurement and projection perpendicular to the wire
-      double drift=0.; // assume hit at wire position
-      if (fit_type==kTimeBased){
-	double drift_time=fdc_updates[id].tdrift;
-	drift=(du>0.0?1.:-1.)*fdc_drift_distance(drift_time);
+      double drift = 0.0;  // assume hit at wire position
+      int left_right = -999;
+      if (fit_type == kTimeBased) {
+        double drift_time = fdc_updates[id].tdrift;
+        drift = (du > 0.0 ? 1.0 : -1.0) * fdc_drift_distance(drift_time);
+        left_right = (du > 0.0 ? +1 : -1);
       }
-      double resi_a=drift-doca;
+      double resi_a = drift - doca;
 
       // Variance from filter step
       DMatrix2x2 V=fdc_updates[id].V;
@@ -1760,7 +1762,8 @@ DTrackFitterStraightTrack::Smooth(vector<fdc_update_t>&fdc_updates,
 				    0.0, //tcorr
 				    resi_c, sqrt(V(1,1))
 				    );
-	 
+      thisPull.left_right = left_right;
+
       if (fdchits[id]->wire->layer!=PLANE_TO_SKIP){
 	vector<double> derivatives;
 	derivatives.resize(FDCTrackD::size);

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -1692,8 +1692,8 @@ DTrackFitterStraightTrack::Smooth(vector<fdc_update_t>&fdc_updates,
       // Difference between measurement and projection perpendicular to the wire
       double drift = 0.0;  // assume hit at wire position
       int left_right = -999;
+      double drift_time = fdc_updates[id].tdrift;
       if (fit_type == kTimeBased) {
-        double drift_time = fdc_updates[id].tdrift;
         drift = (du > 0.0 ? 1.0 : -1.0) * fdc_drift_distance(drift_time);
         left_right = (du > 0.0 ? +1 : -1);
       }
@@ -1796,6 +1796,18 @@ DTrackFitterStraightTrack::Smooth(vector<fdc_update_t>&fdc_updates,
 
 	// dDOCAW/dty
 	derivatives[FDCTrackD::dDOCAW_dty] = (sina*(-(tx*cosa) + ty*sina)*(u - x*cosa + y*sina))/pow(1 + pow(tx*cosa - ty*sina,2),1.5); 
+
+    // dDOCAW/dt0
+    double t0shift = 4.0;  // ns
+    double drift_shift = 0.0;
+    if (drift_time < 0.0) {
+      drift_shift = drift;
+    } else {
+      drift_shift =
+          (du > 0.0 ? 1.0 : -1.0) *
+          fdc_drift_distance(drift_time + t0shift);
+    }
+    derivatives[FDCTrackD::dW_dt0] = (drift_shift - drift) / t0shift;
 
 	// And the cathodes
 	//dDOCAW/ddeltax


### PR DESCRIPTION
I added a member variable in 'pull_t' class to store the left-right information of the wire plane (first commit).

I also added the derivative calculation part that is necessary for the Millepede calibration of the 't0' parameter (second commit).

This pull request does not contain the plugin-update for the Millepede alignment.
(I will push my modifications of the plugins after cleaning up the code.)