### PR TITLE
improve on the online plotter for the beam condition histograms

### DIFF
--- a/src/plugins/monitoring/BEAM_online/BEAM_overview.C
+++ b/src/plugins/monitoring/BEAM_online/BEAM_overview.C
@@ -29,10 +29,12 @@
 
   TCanvas *cBEAM = new TCanvas("cBEAM","Beam Conditions TAGGER-PS Matches", 900, 600 );
 
-  cBEAM->Divide(1,3);
+  cBEAM->Divide(1,4);
 
   cBEAM->cd(1);
   dtp->Draw();
+  dtp->GetXaxis()->SetLabelSize(0.1);
+  dtp->GetYaxis()->SetLabelSize(0.1);
 
   int binl = dtp->FindBin(0.0-2.004);
   int binh = dtp->FindBin(0.0+2.004);
@@ -50,10 +52,43 @@
   t0->SetNDC();
   t0->Draw();
 
+  double Y[50];
+  double X[50];
+  int counter = 0;
+  for (int k=1;k<15;k++){
+    int bin2 = dtp->FindBin(0.0+2.004 + k*4.008);
+    int bin1 = dtp->FindBin(0.0+2.004 + (k-1)*4.008);
+    Il = dtp->Integral(bin1, bin2);
+    Y[counter] = (double)Ic / (double)Il;
+    X[counter] =  k*4.008;
+    counter++;
+  }
+  for (int k=1;k<15;k++){
+    int bin2 = dtp->FindBin(0.0-2.004 - k*4.008);
+    int bin1 = dtp->FindBin(0.0-2.004 - (k-1)*4.008);
+    Il = dtp->Integral(bin2, bin1);
+    Y[counter] = (double)Ic / (double)Il ;
+    X[counter] =  -k*4.008;
+    counter++;
+  }
 
   cBEAM->cd(2);
+  TGraphErrors *gr = new TGraphErrors(counter, X, Y, NULL, NULL);
+  gr->SetTitle("Peak Integrals normalized Icenter/Iside");
+  gr->SetMarkerStyle(33);
+  gr->SetMarkerColor(4);
+  gr->Draw("AP");
+  gPad->SetGrid();
+  gr->GetYaxis()->SetRangeUser(0.8, 1.2);
+  gr->GetXaxis()->SetLabelSize(0.1);
+  gr->GetYaxis()->SetLabelSize(0.1);
+  gPad->Update();
+
+  cBEAM->cd(3);
   PStagmEnergyOutOfTime->Scale(1./20.);
   PStagmEnergyInTime->Draw();
+  PStagmEnergyInTime->GetXaxis()->SetLabelSize(0.1);
+  PStagmEnergyInTime->GetYaxis()->SetLabelSize(0.1);
 
   double ISignalL = PStagmEnergyInTime->Integral(700, 750);
   double IBackgrL = PStagmEnergyOutOfTime->Integral(700, 750);
@@ -79,9 +114,11 @@
   t1->Draw();
 
 
-  cBEAM->cd(3);
+  cBEAM->cd(4);
   PStaghEnergyOutOfTime->Scale(1./20.);
   PStaghEnergyInTime->Draw();
+  PStaghEnergyInTime->GetXaxis()->SetLabelSize(0.1);
+  PStaghEnergyInTime->GetYaxis()->SetLabelSize(0.1);
   PStaghEnergyOutOfTime->SetLineColor(7);
   PStaghEnergyOutOfTime->Draw("same");
   gPad->SetLogy(1);


### PR DESCRIPTION
Add an additional graph to the plots that shows the accidental ratios between the side peaks
and the prompt peak for the first 15 peaks to the left and right of the prompt peak.