### PR TITLE
Add for bcal skimmer&ntuple analyzer correct initial vertex position …

### DIFF
--- a/src/plugins/Calibration/FCAL_Pi0TOF/JEventProcessor_FCAL_Pi0TOF.h
+++ b/src/plugins/Calibration/FCAL_Pi0TOF/JEventProcessor_FCAL_Pi0TOF.h
@@ -40,7 +40,7 @@ class JEventProcessor_FCAL_Pi0TOF:public jana::JEventProcessor{
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 		
-		vector<const DTOFPoint*> tof_points;
+		//vector<const DTOFPoint*> tof_points;
 		double bar2x( int bar );
 		int TOF_Match(double kinVertexX, double kinVertexY, double kinVertexZ, double x, double y, double z);
                 double m_beamSpotX;

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.cc
@@ -94,7 +94,20 @@ jerror_t JEventProcessor_pi0bcalskim::brun(JEventLoop *eventLoop, int32_t runnum
         locEventWriterEVIO->SetDetectorsToWriteOut("BCAL","pi0bcalskim");
     }
     */
-
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
 
     return NOERROR;
 }
@@ -144,7 +157,10 @@ jerror_t JEventProcessor_pi0bcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
   const DTrackFitter *fitter = fitters[0];
 
 	bool Candidate = false;
-	double sh1_E, sh2_E, inv_mass, kinfitVertexZ=0.0, kinfitVertexX=0.0, kinfitVertexY=0.0;
+	double sh1_E, sh2_E, inv_mass;
+	double kinfitVertexX=m_beamSpotX;
+	double kinfitVertexY=m_beamSpotY;
+	double kinfitVertexZ=m_targetZ;
 	vector <const DBCALShower *> matchedShowers;
 	DVector3 mypos(0.0,0.0,0.0);
 	for(unsigned int i = 0 ; i < locTrackTimeBased.size() ; ++i)

--- a/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
+++ b/src/plugins/Utilities/pi0bcalskim/JEventProcessor_pi0bcalskim.h
@@ -40,6 +40,9 @@ class JEventProcessor_pi0bcalskim:public jana::JEventProcessor{
   int WRITE_HDDM;
   int num_epics_events;
 
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
 };
 #endif // _JEventProcessor_pi0bcalskim_
 


### PR DESCRIPTION
1/ Set the initial vertex values to the beam spot (x,y) and target z for the bcal skimmer and gain matrix
2/ Correct a bug appearing only during multi-thread usage in FCAL_Pi0TOF