### PR TITLE
Add PRIMEXD skimmer

### DIFF
--- a/src/plugins/Utilities/SConscript
+++ b/src/plugins/Utilities/SConscript
@@ -5,7 +5,7 @@ Import('*')
 
 # Default targets (always built)
 subdirs = ['danarest', 'evio_writer', 'evio-hddm']
-subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim','single_neutral_skim','comptron_neutral_skim','eta2g_primexd_skim','eta6g_primexd_skim','etapi0_primexd_skim'])
+subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim','single_neutral_skim','compton_neutral_skim','eta2g_primexd_skim','eta6g_primexd_skim','etapi0_primexd_skim'])
 subdirs.extend(['EventTagPi0','es_test','omega_skim','cal_high_energy_skim'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 

--- a/src/plugins/Utilities/SConscript
+++ b/src/plugins/Utilities/SConscript
@@ -5,7 +5,7 @@ Import('*')
 
 # Default targets (always built)
 subdirs = ['danarest', 'evio_writer', 'evio-hddm']
-subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim'])
+subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim','single_neutral_skim','comptron_neutral_skim','eta2g_primexd_skim','eta6g_primexd_skim','etapi0_primexd_skim'])
 subdirs.extend(['EventTagPi0','es_test','omega_skim','cal_high_energy_skim'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 

--- a/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.cc
+++ b/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.cc
@@ -293,7 +293,8 @@ jerror_t JEventProcessor_compton_neutral_skim::evnt(JEventLoop *loop, uint64_t e
   if( Candidate ){
     
     if( WRITE_EVIO ){
-      locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim", locObjectsToSave );
+      //locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim", locObjectsToSave );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim");
     }
     if( WRITE_HDDM ) {
       vector<const DEventWriterHDDM*> locEventWriterHDDMVector;

--- a/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.cc
+++ b/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.cc
@@ -1,0 +1,328 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include <math.h>
+
+#include "JEventProcessor_compton_neutral_skim.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include "JANA/JApplication.h"
+#include <TLorentzVector.h>
+#include "TMath.h"
+#include "JANA/JApplication.h"
+#include "DANA/DApplication.h"
+#include "FCAL/DFCALShower.h"
+#include "BCAL/DBCALShower.h"
+#include "CCAL/DCCALShower.h"
+#include "FCAL/DFCALCluster.h"
+#include "FCAL/DFCALHit.h"
+#include "START_COUNTER/DSCHit.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+#include "PID/DVertex.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+#include <HDGEOMETRY/DGeometry.h>
+#include <TOF/DTOFPoint.h>
+
+#include "GlueX.h"
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_compton_neutral_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_compton_neutral_skim (Constructor)
+//------------------
+JEventProcessor_compton_neutral_skim::JEventProcessor_compton_neutral_skim()
+{
+
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:WRITE_HDDM", WRITE_HDDM );
+
+
+  /*
+  MIN_MASS   = 0.03; // GeV
+  MAX_MASS   = 0.30; // GeV
+  MIN_E      =  1.0; // GeV (photon energy cut)
+  MIN_R      =   20; // cm  (cluster distance to beam line)
+  MAX_DT     =   10; // ns  (cluster time diff. cut)
+  MAX_ETOT   =   12; // GeV (max total FCAL energy)
+  MIN_BLOCKS =    2; // minumum blocks per cluster
+
+  WRITE_ROOT = 0;
+  WRITE_EVIO = 1;
+
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MIN_MASS", MIN_MASS );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MAX_MASS", MAX_MASS );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MIN_E", MIN_E );                
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MAX_DT", MAX_DT );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MAX_ETOT", MAX_ETOT );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:MIN_BLOCKS", MIN_BLOCKS );
+  gPARMS->SetDefaultParameter( "COMPTON_NEUTRAL_SKIM:WRITE_ROOT", WRITE_ROOT );
+  */
+}
+
+//------------------
+// ~JEventProcessor_compton_neutral_skim (Destructor)
+//------------------
+JEventProcessor_compton_neutral_skim::~JEventProcessor_compton_neutral_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_compton_neutral_skim::init(void)
+{
+  num_epics_events = 0;
+/*
+  if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
+
+    cerr << "No output mechanism has been specified." << endl;
+    return UNRECOVERABLE_ERROR;
+  }
+
+  if( WRITE_ROOT ){
+
+    japp->RootWriteLock();
+
+    m_tree = new TTree( "cluster", "Cluster Tree for Pi0 Calibration" );
+    m_tree->Branch( "nClus", &m_nClus, "nClus/I" );
+    m_tree->Branch( "hit0", m_hit0, "hit0[nClus]/I" );
+    m_tree->Branch( "px", m_px, "px[nClus]/F" );
+    m_tree->Branch( "py", m_py, "py[nClus]/F" );
+    m_tree->Branch( "pz", m_pz, "pz[nClus]/F" );
+
+    m_tree->Branch( "nHit", &m_nHit, "nHit/I" );
+    m_tree->Branch( "chan", m_chan, "chan[nHit]/I" );
+    m_tree->Branch( "e", m_e, "e[nHit]/F" );
+
+    japp->RootUnLock();
+  }
+*/
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_compton_neutral_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
+
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_compton_neutral_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+ 
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DBCALShower* > locBCALShowers;
+  vector< const DCCALShower* > locCCALShowers;
+  vector< const DVertex* > kinfitVertex;
+  vector<const DTOFPoint*> tof_points;
+  vector< const DBeamPhoton* > locBeamPhotons;
+  vector< const DSCHit* > locSCHit;
+
+  loop->Get(locFCALShowers);
+  loop->Get(locBCALShowers);
+  loop->Get(locCCALShowers);
+  loop->Get(kinfitVertex);
+  loop->Get(tof_points);
+  loop->Get(locBeamPhotons);
+  loop->Get(locSCHit);
+  
+  vector<const DTrackCandidate*> locTrackCandidate;
+  loop->Get(locTrackCandidate);
+
+  vector< const DTrackTimeBased* > locTrackTimeBased;
+  loop->Get(locTrackTimeBased);
+
+  
+
+  vector < const DFCALShower * > matchedShowers;
+  
+  const DEventWriterEVIO* locEventWriterEVIO = NULL;
+  loop->GetSingle(locEventWriterEVIO);
+
+  // always write out BOR events
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+      //jout << "Found BOR!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim" );
+      return NOERROR;
+  }
+
+  // write out the first few EPICS events to save run number & other meta info
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+      //jout << "Found EPICS!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim" );
+      num_epics_events++;
+      return NOERROR;
+  }
+
+  
+  vector< const JObject* > locObjectsToSave;  
+
+  bool Candidate = false;
+  
+  DVector3 vertex;
+  vertex.SetXYZ(m_beamSpotX, m_beamSpotY, m_targetZ);
+  for (unsigned int i = 0 ; i < tof_points.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(tof_points[i]));
+  }
+  for (unsigned int i = 0 ; i < locBCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locFCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locCCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locCCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackCandidate.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackCandidate[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackTimeBased.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackTimeBased[i]));
+  }
+  for (unsigned int i = 0 ; i < locBeamPhotons.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBeamPhotons[i]));
+  }
+  for (unsigned int i = 0 ; i < locSCHit.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locSCHit[i]));
+  }
+  //Use kinfit when available
+  double kinfitVertexX = m_beamSpotX;
+  double kinfitVertexY = m_beamSpotY;
+  double kinfitVertexZ = m_targetZ;
+  for (unsigned int i = 0 ; i < kinfitVertex.size(); i++) {
+    if(i==0)
+      locObjectsToSave.push_back(static_cast<const JObject *>(kinfitVertex[0]));
+  }
+  
+  vector<const DEventRFBunch*> locEventRFBunches;
+  loop->Get(locEventRFBunches);
+  if(locEventRFBunches.size() > 0) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locEventRFBunches[0]));
+  }
+  
+  int photon_nb = locFCALShowers.size() + locCCALShowers.size();
+  for (unsigned int i = 0; i < locFCALShowers.size(); i ++) {
+    double e1 = locFCALShowers[i]->getEnergy();
+    double x1 = locFCALShowers[i]->getPosition().X() - kinfitVertexX;
+    double y1 = locFCALShowers[i]->getPosition().Y() - kinfitVertexY;
+    double z1 = locFCALShowers[i]->getPosition().Z() - kinfitVertexZ;
+    DVector3 vertex1(x1, y1, z1);
+    double r1 = vertex1.Mag();
+    double t1 = locFCALShowers[i]->getTime() - (r1 / TMath::C());
+
+    double p1 = e1;
+    double px1 = p1 * sin(vertex1.Theta()) * cos(vertex1.Phi());
+    double py1 = p1 * sin(vertex1.Theta()) * sin(vertex1.Phi());
+    double pz1 = p1 * cos(vertex1.Theta());
+    TLorentzVector Photon1Vec(px1, py1, pz1, e1);
+    double phi1 = Photon1Vec.Phi();
+    for (unsigned int j = 0; j < locCCALShowers.size(); j ++) {
+      double e2 =  locCCALShowers[j]->E;
+      double x2 =  locCCALShowers[j]->x - kinfitVertexX;
+      double y2 =  locCCALShowers[j]->y - kinfitVertexY;
+      double z2 =  locCCALShowers[j]->z - kinfitVertexZ;
+      DVector3 vertex2(x2, y2, z2);
+      double r2 = vertex2.Mag();
+      double t2 = locCCALShowers[j]->time - (r2 / TMath::C());
+      double p2 = e2;
+      double px2 = p2 * sin(vertex2.Theta()) * cos(vertex2.Phi());
+      double py2 = p2 * sin(vertex2.Theta()) * sin(vertex2.Phi());
+      double pz2 = p2 * cos(vertex2.Theta());
+      TLorentzVector Photon2Vec(px2, py2, pz2, e2);
+      double phi2 = Photon2Vec.Phi();
+      double copl = fabs(phi1 - phi2) * TMath::RadToDeg();
+      for (unsigned int k = 0; k < locBeamPhotons.size(); k ++) {
+	double eb = locBeamPhotons[k]->lorentzMomentum().E();
+	double tb = locBeamPhotons[k]->time();
+	double deltaE =  (e1 + e2) - (eb + me);
+	double bfdt = tb - t1;
+	double bcdt = tb - t2;
+	Candidate |= ((fabs(deltaE) < 3.0) && (130 < copl && copl < 230) && (fabs(bfdt) < 35) && locBCALShowers.size() == 0 && photon_nb < 3) ;
+      }
+    }
+  }
+
+  
+  if( Candidate ){
+    
+    if( WRITE_EVIO ){
+      locEventWriterEVIO->Write_EVIOEvent( loop, "compton_neutral_skim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+    
+ }
+ 
+
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_compton_neutral_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_compton_neutral_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}

--- a/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.h
+++ b/src/plugins/Utilities/compton_neutral_skim/JEventProcessor_compton_neutral_skim.h
@@ -1,0 +1,73 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#ifndef _JEventProcessor_compton_neutral_skim_
+#define _JEventProcessor_compton_neutral_skim_
+
+#include <JANA/JEventProcessor.h>
+#include "evio_writer/DEventWriterEVIO.h"
+
+class TTree;
+class DFCALCluster;
+
+#include <vector>
+
+class JEventProcessor_compton_neutral_skim:public jana::JEventProcessor{
+ public:
+
+  enum { kMaxHits = 500, kMaxClus = 20 };
+
+  JEventProcessor_compton_neutral_skim();
+  ~JEventProcessor_compton_neutral_skim();
+  const char* className(void){return "JEventProcessor_compton_neutral_skim";}
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
+
+  double MIN_MASS;
+  double MAX_MASS;
+  double MIN_E;
+  double MIN_R;
+  double MAX_DT;
+  double MAX_ETOT;
+  int    MIN_BLOCKS;
+
+  int WRITE_ROOT;
+  int WRITE_EVIO;
+  int WRITE_HDDM;
+
+  TTree* m_tree;
+  int m_nClus;
+  int m_hit0[kMaxClus];
+  float m_px[kMaxClus];
+  float m_py[kMaxClus];
+  float m_pz[kMaxClus];
+
+  int m_nHit;
+  int m_chan[kMaxHits];
+  float m_e[kMaxHits];
+
+  int num_epics_events;
+
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
+  const double me = 0.510998928e-3;
+};
+
+#endif // _JEventProcessor_compton_neutral_skim_
+

--- a/src/plugins/Utilities/compton_neutral_skim/SConscript
+++ b/src/plugins/Utilities/compton_neutral_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+

--- a/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.cc
+++ b/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.cc
@@ -1,0 +1,469 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include <math.h>
+
+#include "JEventProcessor_eta2g_primexd_skim.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include "JANA/JApplication.h"
+#include <TLorentzVector.h>
+#include "TMath.h"
+#include "JANA/JApplication.h"
+#include "DANA/DApplication.h"
+#include "FCAL/DFCALShower.h"
+#include "BCAL/DBCALShower.h"
+#include "CCAL/DCCALShower.h"
+#include "FCAL/DFCALCluster.h"
+#include "FCAL/DFCALHit.h"
+#include "START_COUNTER/DSCHit.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+#include "PID/DVertex.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+#include <HDGEOMETRY/DGeometry.h>
+#include <TOF/DTOFPoint.h>
+
+#include "GlueX.h"
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_eta2g_primexd_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_eta2g_primexd_skim (Constructor)
+//------------------
+JEventProcessor_eta2g_primexd_skim::JEventProcessor_eta2g_primexd_skim()
+{
+
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:WRITE_HDDM", WRITE_HDDM );
+
+
+/*
+  MIN_MASS   = 0.03; // GeV
+  MAX_MASS   = 0.30; // GeV
+  MIN_E      =  1.0; // GeV (photon energy cut)
+  MIN_R      =   20; // cm  (cluster distance to beam line)
+  MAX_DT     =   10; // ns  (cluster time diff. cut)
+  MAX_ETOT   =   12; // GeV (max total FCAL energy)
+  MIN_BLOCKS =    2; // minumum blocks per cluster
+
+  WRITE_ROOT = 0;
+  WRITE_EVIO = 1;
+
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MIN_MASS", MIN_MASS );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MAX_MASS", MAX_MASS );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MIN_E", MIN_E );                
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MAX_DT", MAX_DT );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MAX_ETOT", MAX_ETOT );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:MIN_BLOCKS", MIN_BLOCKS );
+  gPARMS->SetDefaultParameter( "ETA2G_PRIMEXD_SKIM:WRITE_ROOT", WRITE_ROOT );
+  */
+}
+
+//------------------
+// ~JEventProcessor_eta2g_primexd_skim (Destructor)
+//------------------
+JEventProcessor_eta2g_primexd_skim::~JEventProcessor_eta2g_primexd_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_eta2g_primexd_skim::init(void)
+{
+  num_epics_events = 0;
+/*
+  if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
+
+    cerr << "No output mechanism has been specified." << endl;
+    return UNRECOVERABLE_ERROR;
+  }
+
+  if( WRITE_ROOT ){
+
+    japp->RootWriteLock();
+
+    m_tree = new TTree( "cluster", "Cluster Tree for Pi0 Calibration" );
+    m_tree->Branch( "nClus", &m_nClus, "nClus/I" );
+    m_tree->Branch( "hit0", m_hit0, "hit0[nClus]/I" );
+    m_tree->Branch( "px", m_px, "px[nClus]/F" );
+    m_tree->Branch( "py", m_py, "py[nClus]/F" );
+    m_tree->Branch( "pz", m_pz, "pz[nClus]/F" );
+
+    m_tree->Branch( "nHit", &m_nHit, "nHit/I" );
+    m_tree->Branch( "chan", m_chan, "chan[nHit]/I" );
+    m_tree->Branch( "e", m_e, "e[nHit]/F" );
+
+    japp->RootUnLock();
+  }
+*/
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_eta2g_primexd_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
+
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_eta2g_primexd_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+ 
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DBCALShower* > locBCALShowers;
+  vector< const DCCALShower* > locCCALShowers;
+  vector< const DVertex* > kinfitVertex;
+  vector<const DTOFPoint*> tof_points;
+  vector< const DBeamPhoton* > locBeamPhotons;
+  vector< const DSCHit* > locSCHit;
+
+  loop->Get(locFCALShowers);
+  loop->Get(locBCALShowers);
+  loop->Get(locCCALShowers);
+  loop->Get(kinfitVertex);
+  loop->Get(tof_points);
+  loop->Get(locBeamPhotons);
+  loop->Get(locSCHit);
+  
+  vector<const DTrackCandidate*> locTrackCandidate;
+  loop->Get(locTrackCandidate);
+
+  vector< const DTrackTimeBased* > locTrackTimeBased;
+  loop->Get(locTrackTimeBased);
+
+  
+
+  vector < const DFCALShower * > matchedShowers;
+  
+  const DEventWriterEVIO* locEventWriterEVIO = NULL;
+  loop->GetSingle(locEventWriterEVIO);
+
+  // always write out BOR events
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+      //jout << "Found BOR!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim" );
+      return NOERROR;
+  }
+
+  // write out the first few EPICS events to save run number & other meta info
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+      //jout << "Found EPICS!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim" );
+      num_epics_events++;
+      return NOERROR;
+  }
+
+  
+  vector< const JObject* > locObjectsToSave;  
+
+  bool Candidate = false;
+  
+  DVector3 vertex;
+  vertex.SetXYZ(m_beamSpotX, m_beamSpotY, m_targetZ);
+  for (unsigned int i = 0 ; i < tof_points.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(tof_points[i]));
+  }
+  for (unsigned int i = 0 ; i < locBCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locCCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locCCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackCandidate.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackCandidate[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackTimeBased.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackTimeBased[i]));
+  }
+  for (unsigned int i = 0 ; i < locBeamPhotons.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBeamPhotons[i]));
+  }
+  for (unsigned int i = 0 ; i < locSCHit.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locSCHit[i]));
+  }
+  //Use kinfit when available
+  double kinfitVertexX = m_beamSpotX;
+  double kinfitVertexY = m_beamSpotY;
+  double kinfitVertexZ = m_targetZ;
+  for (unsigned int i = 0 ; i < kinfitVertex.size(); i++) {
+    if(i==0)
+      locObjectsToSave.push_back(static_cast<const JObject *>(kinfitVertex[0]));
+  }
+  
+  vector<const DEventRFBunch*> locEventRFBunches;
+  loop->Get(locEventRFBunches);
+  if(locEventRFBunches.size() > 0) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locEventRFBunches[0]));
+  }
+  
+  DVector3 norm(0.0,0.0,-1);
+  DVector3 pos,mom;
+  Double_t BCAL_energy_sum = 0;
+  Double_t CCAL_energy_sum = 0;
+  
+  for (unsigned int i=0; i<locBCALShowers.size(); i++) {
+    Double_t E = locBCALShowers[i]->E;
+    BCAL_energy_sum += E;
+    
+  }
+
+  for (unsigned int i=0; i<locCCALShowers.size(); i++) {
+    Double_t E = locCCALShowers[i]->E;
+    CCAL_energy_sum += E;
+    
+  }
+  for (unsigned int i=0; i<locFCALShowers.size(); i++) {
+    const DFCALShower *s1 = locFCALShowers[i];
+    
+    vector<const DFCALCluster*> associated_clusters1;
+    s1->Get(associated_clusters1);
+    Double_t dx1 = s1->getPosition().X() - kinfitVertexX;
+    Double_t dy1 = s1->getPosition().Y() - kinfitVertexY;
+    Double_t dz1 = s1->getPosition().Z() - kinfitVertexZ;
+    Double_t R1 = sqrt(dx1*dx1 + dy1*dy1 + dz1*dz1);
+    Double_t  E1 = s1->getEnergy();
+    Double_t  t1 = s1->getTime();
+    TLorentzVector sh1_p(E1*dx1/R1, E1*dy1/R1, E1*dz1/R1, E1);
+    
+    for (unsigned int j=i+1; j<locFCALShowers.size(); j++) {
+      const DFCALShower *s2 = locFCALShowers[j];
+            
+      vector<const DFCALCluster*> associated_clusters2;
+      s2->Get(associated_clusters2);
+      Double_t dx2 = s2->getPosition().X() - kinfitVertexX;
+      Double_t dy2 = s2->getPosition().Y() - kinfitVertexY;
+      Double_t dz2 = s2->getPosition().Z() - kinfitVertexZ; 
+      Double_t R2 = sqrt(dx2*dx2 + dy2*dy2 + dz2*dz2);
+      Double_t E2 = s2->getEnergy();
+      Double_t  t2 = s2->getTime();
+      
+      TLorentzVector sh2_p(E2*dx2/R2, E2*dy2/R2, E2*dz2/R2, E2);
+      TLorentzVector ptot = sh1_p+sh2_p;
+      Double_t inv_mass = ptot.M();
+      
+      //Candidate |= (E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) ;
+      Candidate |= (E1 > 0.1 && E2 > 0.1 && (fabs (t1-t2) < 15) && (inv_mass>0.380) && BCAL_energy_sum < 0.1 && CCAL_energy_sum < 0.1) ;
+      
+      //if(E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) {
+      if(E1 > 0.1 && E2 > 0.1 && (fabs (t1-t2) < 15) && (inv_mass>0.380) ) {
+	if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[i]) == locObjectsToSave.end())
+	  locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
+	if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[j]) == locObjectsToSave.end())
+	  locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[j]));
+      }
+    }
+  }		
+  
+  if( Candidate ){
+    
+    if( WRITE_EVIO ){
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+    
+ }
+ 
+ 
+ /*
+  vector< const DFCALCluster* > clusterVec;
+  loop->Get( clusterVec );
+
+  if( clusterVec.size() < 2 ) return NOERROR;
+
+  bool hasCandidate = false;
+  double eTot = 0;
+
+  for( vector< const DFCALCluster*>::const_iterator clus1Itr = clusterVec.begin();
+       clus1Itr != clusterVec.end(); ++clus1Itr ){
+
+    eTot += (**clus1Itr).getEnergy();
+
+    for( vector< const DFCALCluster*>::const_iterator clus2Itr = clus1Itr + 1;
+	 clus2Itr != clusterVec.end(); ++clus2Itr ){
+
+      const DFCALCluster& clusL = 
+	( (**clus1Itr).getEnergy() > (**clus2Itr).getEnergy() ? 
+	  (**clus2Itr) : (**clus1Itr) );
+
+      const DFCALCluster& clusH = 
+	( (**clus1Itr).getEnergy() > (**clus2Itr).getEnergy() ? 
+	  (**clus1Itr) : (**clus2Itr) );
+
+      double clusLX = clusL.getCentroid().X();
+      double clusLY = clusL.getCentroid().Y();
+      double rL = sqrt( clusLX * clusLX + clusLY * clusLY );
+      double eL = clusL.getEnergy();
+      double tL = clusL.getTime();
+      int nHitL = clusL.GetHits().size();
+
+      double clusHX = clusH.getCentroid().X();
+      double clusHY = clusH.getCentroid().Y();
+      double rH = sqrt( clusHX * clusHX + clusHY * clusHY );
+      double eH = clusH.getEnergy();
+      double tH = clusH.getTime();
+      int nHitH = clusH.GetHits().size();
+
+      DVector3 clusLMom = clusL.getCentroid(); 
+      clusLMom.SetMag( eL );
+
+      DVector3 clusHMom = clusH.getCentroid(); 
+      clusHMom.SetMag( eH );
+   √ 
+      double dt = fabs( tL - tH );
+
+      DLorentzVector gamL( clusLMom, clusLMom.Mag() );
+      DLorentzVector gamH( clusHMom, clusHMom.Mag() );
+
+      double mass = ( gamL + gamH ).M();
+
+  √    hasCandidate |= 
+	( ( eL > MIN_E ) &&
+	  ( dt < MAX_DT ) &&
+	  ( rL > MIN_R ) && ( rH > MIN_R ) &&
+√√	  ( nHitL >= MIN_BLOCKS ) && ( nHitH >= MIN_BLOCKS ) &&
+	  ( mass > MIN_MASS ) && ( mass < MAX_MASS  ) );
+    }
+  }
+
+  if( hasCandidate && ( eTot < MAX_ETOT ) ){
+
+    if( WRITE_EVIO ){
+
+      dEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim" );
+    }
+
+    if( WRITE_ROOT ){
+
+      japp->RootWriteLock();
+      writeClustersToRoot( clusterVec );
+      japp->RootUnLock();
+    }
+  }
+*/
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_eta2g_primexd_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_eta2g_primexd_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}
+
+
+/*
+void 
+JEventProcessor_eta2g_primexd_skim::writeClustersToRoot( const vector< const DFCALCluster* > clusVec ){
+
+  // this code must run serially -- obtain a lock before
+  // entering this function
+ 
+  m_nHit = 0;
+  m_nClus = 0;
+
+  // hit and cluster indices
+  int& iH = m_nHit;
+  int& iC = m_nClus;
+  
+  for( vector< const DFCALCluster* >::const_iterator clusItr = clusVec.begin();
+       clusItr != clusVec.end(); ++clusItr ){
+
+    // if we exceed max clusters abort writing for this event
+    if( iC == kMaxClus ) return;
+
+    const DFCALCluster& clus = (**clusItr);
+
+    if( ( clus.getCentroid().Perp() < 20*k_cm ) ||
+	( clus.getEnergy() < 1*k_GeV ) ||
+	( clus.GetHits().size() < 2 ) ) continue;
+
+    DVector3 gamMom = clus.getCentroid(); 
+    gamMom.SetMag( clus.getEnergy() );
+
+    m_hit0[iC] = iH;
+    m_px[iC] = gamMom.X();
+    m_py[iC] = gamMom.Y();
+    m_pz[iC] = gamMom.Z();
+    
+    const vector<DFCALCluster::DFCALClusterHit_t>& hits = clus.GetHits();
+
+    for( unsigned int i = 0; i < hits.size(); ++i ){
+
+      // if we exceed max hits abort this event and return
+      if( iH == kMaxHits ) return;
+
+      m_chan[iH] = hits[i].ch;
+      m_e[iH] = hits[i].E;
+      ++iH;
+    }
+    ++iC;
+  }
+
+  m_tree->Fill();
+}
+*/

--- a/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.cc
+++ b/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.cc
@@ -305,7 +305,8 @@ jerror_t JEventProcessor_eta2g_primexd_skim::evnt(JEventLoop *loop, uint64_t eve
   if( Candidate ){
     
     if( WRITE_EVIO ){
-      locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim", locObjectsToSave );
+      //locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim", locObjectsToSave );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta2g_primexd_skim");
     }
     if( WRITE_HDDM ) {
       vector<const DEventWriterHDDM*> locEventWriterHDDMVector;

--- a/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.h
+++ b/src/plugins/Utilities/eta2g_primexd_skim/JEventProcessor_eta2g_primexd_skim.h
@@ -1,0 +1,72 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#ifndef _JEventProcessor_eta2g_primexd_skim_
+#define _JEventProcessor_eta2g_primexd_skim_
+
+#include <JANA/JEventProcessor.h>
+#include "evio_writer/DEventWriterEVIO.h"
+
+class TTree;
+class DFCALCluster;
+
+#include <vector>
+
+class JEventProcessor_eta2g_primexd_skim:public jana::JEventProcessor{
+ public:
+
+  enum { kMaxHits = 500, kMaxClus = 20 };
+
+  JEventProcessor_eta2g_primexd_skim();
+  ~JEventProcessor_eta2g_primexd_skim();
+  const char* className(void){return "JEventProcessor_eta2g_primexd_skim";}
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
+
+  double MIN_MASS;
+  double MAX_MASS;
+  double MIN_E;
+  double MIN_R;
+  double MAX_DT;
+  double MAX_ETOT;
+  int    MIN_BLOCKS;
+
+  int WRITE_ROOT;
+  int WRITE_EVIO;
+  int WRITE_HDDM;
+
+  TTree* m_tree;
+  int m_nClus;
+  int m_hit0[kMaxClus];
+  float m_px[kMaxClus];
+  float m_py[kMaxClus];
+  float m_pz[kMaxClus];
+
+  int m_nHit;
+  int m_chan[kMaxHits];
+  float m_e[kMaxHits];
+
+  int num_epics_events;
+
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
+};
+
+#endif // _JEventProcessor_eta2g_primexd_skim_
+

--- a/src/plugins/Utilities/eta2g_primexd_skim/SConscript
+++ b/src/plugins/Utilities/eta2g_primexd_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+

--- a/src/plugins/Utilities/eta6g_primexd_skim/Combination.cc
+++ b/src/plugins/Utilities/eta6g_primexd_skim/Combination.cc
@@ -1,0 +1,70 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include "Combination.h"
+
+using namespace std;
+
+Combination::Combination (int npar) {
+  n        = npar;
+  maxCombi = 0;
+  if (n < 2)          return;
+  if (n >= MAXCOMBI)  return;
+  combi = new unsigned char [n];
+  iCombi   = 0;
+  maxCombi = calcMaxCombi ();
+  list  = new unsigned char [maxCombi * n];
+  if (n & 1) oddCombi ();
+  else       allCombi (0, 0);
+}
+
+void Combination::getCombi (int i) {
+  memcpy (combi, list + (i * n), n);
+}
+
+void Combination::oddCombi () {
+  for (int i = 0; i < n; i++) {
+    combi [n-1] = i;
+    allCombi (1 << i, 0);
+  }
+}
+
+void Combination::allCombi (int used, int deep) {
+  int nrem       = n - 2 * deep - (n & 1);
+  int remain [nrem];
+  int irem = 0;
+  for (int i = 0; i < n; i++) 
+    if ( ! ( (1 << i) & used ) )
+      remain [irem++] = i;
+
+  combi [deep*2]   = remain [0];
+  for (int j = 1; j < nrem; j++) {
+    combi [deep*2+1]  = remain [j];
+    int xused   = (1 << remain [0]) | (1 << remain [j]) | used ;
+    if (nrem >= 4)
+      allCombi (xused, deep + 1);
+    else {
+      memcpy (list + (iCombi++) * n , combi, n);
+    }
+  }
+}
+
+int Combination::calcMaxCombi () {
+  int max = 1;
+  int nn  = n;
+  if (! (nn & 1)) nn--;
+  while (nn > 0) {
+    max *= nn;
+    nn -= 2;
+  }
+  return (max);
+}
+  

--- a/src/plugins/Utilities/eta6g_primexd_skim/Combination.h
+++ b/src/plugins/Utilities/eta6g_primexd_skim/Combination.h
@@ -1,0 +1,47 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+//#if !defined(COMBINATION)
+//#define COMBINATION
+
+#ifndef _Combination_
+#define _Combination_
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+using namespace std;
+
+class Combination
+{
+#define MAXCOMBI 32
+protected:
+  int n;
+  int maxCombi, iCombi;
+  unsigned char * list;
+  
+public:
+  unsigned char * combi;
+
+  Combination (int npar);
+  void oddCombi ();
+  void allCombi (int used, int deep);
+  void getCombi (int i);
+  int getMaxCombi () { return (maxCombi);  }
+  int getN        () { return (n);         }
+  int calcMaxCombi ();
+};
+
+#endif // _combination_
+//#endif // _COMBINATION_H_

--- a/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.cc
+++ b/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.cc
@@ -1,0 +1,651 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include <math.h>
+
+#include "JEventProcessor_eta6g_skim.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include "JANA/JApplication.h"
+#include <TLorentzVector.h>
+#include "TMath.h"
+#include "JANA/JApplication.h"
+#include "DANA/DApplication.h"
+#include "FCAL/DFCALShower.h"
+#include "BCAL/DBCALShower.h"
+#include "CCAL/DCCALShower.h"
+#include "FCAL/DFCALCluster.h"
+#include "FCAL/DFCALHit.h"
+#include "START_COUNTER/DSCHit.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+#include "PID/DVertex.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+#include <HDGEOMETRY/DGeometry.h>
+#include <TOF/DTOFPoint.h>
+
+#include "GlueX.h"
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_eta6g_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_eta6g_skim (Constructor)
+//------------------
+JEventProcessor_eta6g_skim::JEventProcessor_eta6g_skim()
+{
+
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:WRITE_HDDM", WRITE_HDDM );
+
+  /*
+  MIN_MASS   = 0.03; // GeV
+  MAX_MASS   = 0.30; // GeV
+  MIN_E      =  1.0; // GeV (photon energy cut)
+  MIN_R      =   20; // cm  (cluster distance to beam line)
+  MAX_DT     =   10; // ns  (cluster time diff. cut)
+  MAX_ETOT   =   12; // GeV (max total FCAL energy)
+  MIN_BLOCKS =    2; // minumum blocks per cluster
+
+  WRITE_ROOT = 0;
+  WRITE_EVIO = 1;
+
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MIN_MASS", MIN_MASS );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MAX_MASS", MAX_MASS );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MIN_E", MIN_E );                
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MAX_DT", MAX_DT );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MAX_ETOT", MAX_ETOT );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:MIN_BLOCKS", MIN_BLOCKS );
+  gPARMS->SetDefaultParameter( "ETA6G_SKIM:WRITE_ROOT", WRITE_ROOT );
+  */
+}
+
+//------------------
+// ~JEventProcessor_eta6g_skim (Destructor)
+//------------------
+JEventProcessor_eta6g_skim::~JEventProcessor_eta6g_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_eta6g_skim::init(void)
+{
+  num_epics_events = 0;
+/*
+  if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
+
+    cerr << "No output mechanism has been specified." << endl;
+    return UNRECOVERABLE_ERROR;
+  }
+
+  if( WRITE_ROOT ){
+
+    japp->RootWriteLock();
+
+    m_tree = new TTree( "cluster", "Cluster Tree for Pi0 Calibration" );
+    m_tree->Branch( "nClus", &m_nClus, "nClus/I" );
+    m_tree->Branch( "hit0", m_hit0, "hit0[nClus]/I" );
+    m_tree->Branch( "px", m_px, "px[nClus]/F" );
+    m_tree->Branch( "py", m_py, "py[nClus]/F" );
+    m_tree->Branch( "pz", m_pz, "pz[nClus]/F" );
+
+    m_tree->Branch( "nHit", &m_nHit, "nHit/I" );
+    m_tree->Branch( "chan", m_chan, "chan[nHit]/I" );
+    m_tree->Branch( "e", m_e, "e[nHit]/F" );
+
+    japp->RootUnLock();
+  }
+*/
+  combi6  = new Combination (6);
+  combi7  = new Combination (7);
+  
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_eta6g_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
+
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_eta6g_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+ 
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DBCALShower* > locBCALShowers;
+  vector< const DCCALShower* > locCCALShowers;
+  vector< const DVertex* > kinfitVertex;
+  vector<const DTOFPoint*> tof_points;
+  vector< const DBeamPhoton* > locBeamPhotons;
+  vector< const DSCHit* > locSCHit;
+
+  loop->Get(locFCALShowers);
+  loop->Get(locBCALShowers);
+  loop->Get(locCCALShowers);
+  loop->Get(kinfitVertex);
+  loop->Get(tof_points);
+  loop->Get(locBeamPhotons);
+  loop->Get(locSCHit);
+  
+  vector<const DTrackCandidate*> locTrackCandidate;
+  loop->Get(locTrackCandidate);
+
+  vector< const DTrackTimeBased* > locTrackTimeBased;
+  loop->Get(locTrackTimeBased);
+
+  
+
+  vector < const DFCALShower * > matchedShowers;
+  
+  const DEventWriterEVIO* locEventWriterEVIO = NULL;
+  loop->GetSingle(locEventWriterEVIO);
+
+  // always write out BOR events
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+      //jout << "Found BOR!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim" );
+      return NOERROR;
+  }
+
+  // write out the first few EPICS events to save run number & other meta info
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+      //jout << "Found EPICS!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim" );
+      num_epics_events++;
+      return NOERROR;
+  }
+
+  
+  vector< const JObject* > locObjectsToSave;  
+
+  bool Candidate = false;
+  
+  DVector3 vertex;
+  vertex.SetXYZ(m_beamSpotX, m_beamSpotY, m_targetZ);
+  for (unsigned int i = 0 ; i < tof_points.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(tof_points[i]));
+  }
+  for (unsigned int i = 0 ; i < locBCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locFCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locCCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locCCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackCandidate.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackCandidate[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackTimeBased.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackTimeBased[i]));
+  }
+  for (unsigned int i = 0 ; i < locBeamPhotons.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBeamPhotons[i]));
+  }
+  for (unsigned int i = 0 ; i < locSCHit.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locSCHit[i]));
+  }
+  //Use kinfit when available
+  double kinfitVertexX = m_beamSpotX;
+  double kinfitVertexY = m_beamSpotY;
+  double kinfitVertexZ = m_targetZ;
+  for (unsigned int i = 0 ; i < kinfitVertex.size(); i++) {
+    if(i==0)
+      locObjectsToSave.push_back(static_cast<const JObject *>(kinfitVertex[0]));
+  }
+  
+  vector<const DEventRFBunch*> locEventRFBunches;
+  loop->Get(locEventRFBunches);
+  if(locEventRFBunches.size() > 0) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locEventRFBunches[0]));
+  }
+
+  vector <TLorentzVector> PhotonList; PhotonList.clear(); 
+  int photon_nb = locBCALShowers.size() + locFCALShowers.size() + locCCALShowers.size();
+  for (unsigned int i = 0; i < locBCALShowers.size(); i ++) {
+    double e =  locBCALShowers[i]->E;
+    double x =  locBCALShowers[i]->x - kinfitVertexX;
+    double y =  locBCALShowers[i]->y - kinfitVertexY;
+    double z =  locBCALShowers[i]->z - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex.Mag();
+    //double t = locCCALShowers[j]->time - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  for (unsigned int i = 0; i < locFCALShowers.size(); i ++) {
+    double e = locFCALShowers[i]->getEnergy();
+    double x = locFCALShowers[i]->getPosition().X() - kinfitVertexX;
+    double y = locFCALShowers[i]->getPosition().Y() - kinfitVertexY;
+    double z = locFCALShowers[i]->getPosition().Z() - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex1.Mag();
+    //double t = locFCALShowers[i]->getTime() - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  for (unsigned int i = 0; i < locCCALShowers.size(); i ++) {
+    double e =  locCCALShowers[i]->E;
+    double x =  locCCALShowers[i]->x - kinfitVertexX;
+    double y =  locCCALShowers[i]->y - kinfitVertexY;
+    double z =  locCCALShowers[i]->z - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex.Mag();
+    //double t = locCCALShowers[j]->time - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  
+  Double_t bestChi2Eta = 1.0e30;
+  Double_t bestChi2EtaPrim = 1.0e30;
+  vector <TLorentzVector> PhotonEta6gList;PhotonEta6gList.clear();
+  vector <TLorentzVector> PhotonEtaprim6gList;PhotonEtaprim6gList.clear();
+  Combined6g(PhotonList,
+	     bestChi2Eta,
+	     bestChi2EtaPrim,
+	     PhotonEta6gList,
+	     PhotonEtaprim6gList);
+  Combined7g(PhotonList,
+	     bestChi2Eta,
+	     bestChi2EtaPrim,
+	     PhotonEta6gList,
+	     PhotonEtaprim6gList);
+
+  Candidate |= ( (6 <= photon_nb && photon_nb <= 7) && (PhotonEta6gList.size() > 0 || PhotonEtaprim6gList.size() > 0) );
+  
+  if ( Candidate ) {
+    //cout <<"eta6g_skim"<<endl;
+    if( WRITE_EVIO ){
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+    
+ }
+ 
+
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_eta6g_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_eta6g_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}
+void JEventProcessor_eta6g_skim::Combined6g(vector<TLorentzVector>&EMList,
+					    Double_t &bestChi0Eta,
+					    Double_t &bestChi0EtaPrim,
+					    vector<TLorentzVector>&PhotonEta6gList,
+					    vector<TLorentzVector>&PhotonEtaprim6gList)
+{	  
+  bestChi0EtaPrim   = 1.0e30;
+  bestChi0Eta       = 1.0e30;
+  if(EMList.size() == 6) {
+    for (int i_comb = 0; i_comb < (*combi6).getMaxCombi(); i_comb ++) {
+      combi6->getCombi(i_comb);
+      
+      double Esum = 0.0;		  
+      for (int i = 0; i < 6; i ++) {
+	Esum += EMList[combi6->combi[i]].E();
+      }
+      
+      double Chi2_pi0Mass[3];
+      double Chi2_etaMass[3];
+      vector<TLorentzVector>GG;GG.clear();
+      vector<TLorentzVector>Pi0Cor;Pi0Cor.clear();
+      vector<TLorentzVector>EtaCor;EtaCor.clear();
+      
+      for (int i = 0; i < 3; i ++) {
+	GG.push_back(EMList[combi6->combi[2*i]] + EMList[combi6->combi[2*i+1]] );
+	Pi0Cor.push_back( pi0Mass / GG[i].M() * GG[i] );
+	EtaCor.push_back( etaMass / GG[i].M() * GG[i] );
+	Chi2_pi0Mass[i] = TMath::Power((GG[i].M() - pi0Mass) / 12.8e-3,2.0);
+	Chi2_etaMass[i] = TMath::Power((GG[i].M() - etaMass) / 31.1e-3,2.0);
+      }
+      
+      double Chi2_3pi0      = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2]; 
+      double Chi2_2pi0eta_0 = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_etaMass[2];
+      double Chi2_2pi0eta_1 = Chi2_pi0Mass[0] + Chi2_etaMass[1] + Chi2_pi0Mass[2];
+      double Chi2_2pi0eta_2 = Chi2_etaMass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2];
+      
+      if (Esum > 500.0e-3) {
+	TLorentzVector EtaVec = Pi0Cor[0] + Pi0Cor[1] + Pi0Cor[2];
+	bool AnEta     = false; 
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEta = true;
+	
+	bool AnEtaPrim  = false; 
+	bool AnEtaPrim1 = false; 
+	bool AnEtaPrim2 = false; 
+	bool AnEtaPrim3 = false; 
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 500.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 600.0e-3)
+	  AnEtaPrim1 = true;
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 500.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 600.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEtaPrim2 = true;
+	if (GG[0].M() > 500.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 600.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEtaPrim3 = true;
+	if (AnEtaPrim1 || AnEtaPrim2 || AnEtaPrim3)
+	  AnEtaPrim = true;
+	
+	if (AnEta && !AnEtaPrim && Esum > 500.0e-3) {
+	  if (Chi2_3pi0<bestChi0Eta) {
+	    bestChi0Eta = Chi2_3pi0;
+	    PhotonEta6gList.clear();
+	    PhotonEta6gList.push_back(EMList[combi6->combi[0]]);
+	    PhotonEta6gList.push_back(EMList[combi6->combi[1]]);
+	    PhotonEta6gList.push_back(EMList[combi6->combi[2]]);
+	    PhotonEta6gList.push_back(EMList[combi6->combi[3]]);
+	    PhotonEta6gList.push_back(EMList[combi6->combi[4]]);
+	    PhotonEta6gList.push_back(EMList[combi6->combi[5]]);
+	  }
+	}
+	
+	if (!AnEta && AnEtaPrim && Esum > 900.0e-3) {
+	  double Esum2gg1 = EMList[combi6->combi[4]].E() + EMList[combi6->combi[5]].E();
+	  if (AnEtaPrim1 && Esum2gg1 > 500.0e-3) {
+	    if (Chi2_2pi0eta_0 < bestChi0EtaPrim) {
+	      bestChi0EtaPrim = Chi2_2pi0eta_0;
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[1]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[3]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[5]]);
+	    }
+	  }
+	  if (AnEtaPrim2) {
+	    double Esum2gg2 = EMList[combi6->combi[2]].E() + EMList[combi6->combi[3]].E();
+	    if (Chi2_2pi0eta_1 < bestChi0EtaPrim && Esum2gg2 > 500.0e-3) {
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[1]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[5]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[3]]);
+	    }
+	  }
+	  if (AnEtaPrim3) {
+	    double Esum2gg3 = EMList[combi6->combi[0]].E() + EMList[combi6->combi[1]].E();
+	    if (Chi2_2pi0eta_2 < bestChi0EtaPrim && Esum2gg3 > 500.0e-3) {
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[3]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[5]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi6->combi[1]]);
+	    }
+	  }
+	}
+      }
+    }
+  }
+  if(PhotonEta6gList.size()>0)
+    PhotonEtaprim6gList.clear();
+}
+void JEventProcessor_eta6g_skim::Combined7g(vector<TLorentzVector>&EMList,
+					    Double_t &bestChi0Eta,
+					    Double_t &bestChi0EtaPrim,
+					    vector<TLorentzVector>&PhotonEta6gList,
+					    vector<TLorentzVector>&PhotonEtaprim6gList)
+{	  
+  bestChi0EtaPrim   = 1.0e30;
+  bestChi0Eta       = 1.0e30;
+  if (EMList.size() == 7) {
+    for (int i_comb = 0; i_comb < (*combi7).getMaxCombi(); i_comb ++) {
+      combi7->getCombi(i_comb);
+      
+      double Esum = 0.0;		  
+      for (int i = 0; i < 6; i ++) {
+	Esum += EMList[combi7->combi[i]].E();
+      }
+      
+      double Chi2_pi0Mass[3];
+      double Chi2_etaMass[3];
+      vector<TLorentzVector>GG;GG.clear();
+      vector<TLorentzVector>Pi0Cor;Pi0Cor.clear();
+      vector<TLorentzVector>EtaCor;EtaCor.clear();
+      
+      for (int i = 0; i < 3; i ++) {
+	GG.push_back( EMList[combi7->combi[2*i]] + EMList[combi7->combi[2*i+1]] );
+	Pi0Cor.push_back( pi0Mass / GG[i].M() * GG[i] );
+	EtaCor.push_back( etaMass / GG[i].M() * GG[i] );
+	Chi2_pi0Mass[i] = TMath::Power((GG[i].M() - pi0Mass) / 12.8e-3,2.0);
+	Chi2_etaMass[i] = TMath::Power((GG[i].M() - etaMass) / 31.1e-3,2.0);
+      }
+      
+      if (Esum > 500.0e-3) {
+	TLorentzVector EtaVec             = Pi0Cor[0] + Pi0Cor[1] + Pi0Cor[2];
+	TLorentzVector EtaprimVec1        = Pi0Cor[0] + Pi0Cor[1] + EtaCor[2];
+	TLorentzVector EtaprimVec2        = Pi0Cor[0] + EtaCor[1] + Pi0Cor[2];
+	TLorentzVector EtaprimVec3        = EtaCor[0] + Pi0Cor[1] + Pi0Cor[2];
+	TLorentzVector Candidate          = (TLorentzVector) EMList[combi7->combi[6]];
+	Double_t CopAngleEta       = (fabs(EtaVec.Phi() - Candidate.Phi())) * TMath::RadToDeg();
+	Double_t Chi2AngleEta      = TMath::Power((180.0  - CopAngleEta) / 30.0,2.0);
+	
+	Double_t CopAngleEtaprim1  = (fabs(EtaprimVec1.Phi() - Candidate.Phi())) * TMath::RadToDeg();
+	Double_t Chi2AngleEtaprim1 = TMath::Power((180.0  - CopAngleEtaprim1) / 30.0,2.0);
+	
+	Double_t CopAngleEtaprim2  = (fabs(EtaprimVec2.Phi() - Candidate.Phi())) * TMath::RadToDeg();
+	Double_t Chi2AngleEtaprim2 = TMath::Power((180.0  - CopAngleEtaprim2) / 30.0,2.0);
+	
+	Double_t CopAngleEtaprim3  = (fabs(EtaprimVec3.Phi() - Candidate.Phi())) * TMath::RadToDeg();
+	Double_t Chi2AngleEtaprim3 = TMath::Power((180.0  - CopAngleEtaprim3) / 30.0,2.0);
+	
+	double Chi2_3pi0           = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2] + Chi2AngleEta; 
+	double Chi2_2pi0eta_0      = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_etaMass[2] + Chi2AngleEtaprim1;
+	double Chi2_2pi0eta_1      = Chi2_pi0Mass[0] + Chi2_etaMass[1] + Chi2_pi0Mass[2] + Chi2AngleEtaprim2;
+	double Chi2_2pi0eta_2      = Chi2_etaMass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2] + Chi2AngleEtaprim3;
+	/*
+	  double Chi2_3pi0           = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2];
+	  double Chi2_2pi0eta_0      = Chi2_pi0Mass[0] + Chi2_pi0Mass[1] + Chi2_etaMass[2];
+	  double Chi2_2pi0eta_1      = Chi2_pi0Mass[0] + Chi2_etaMass[1] + Chi2_pi0Mass[2];
+	  double Chi2_2pi0eta_2      = Chi2_etaMass[0] + Chi2_pi0Mass[1] + Chi2_pi0Mass[2];
+	*/
+	bool AnEta         = false; 
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEta = true;
+	
+	bool AnEtaPrim  = false; 
+	bool AnEtaPrim1 = false; 
+	bool AnEtaPrim2 = false; 
+	bool AnEtaPrim3 = false; 
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 500.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 600.0e-3)
+	  AnEtaPrim1 = true;
+	if (GG[0].M() > 110.0e-3 && 
+	    GG[1].M() > 500.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 160.0e-3 && 
+	    GG[1].M() < 600.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEtaPrim2 = true;
+	if (GG[0].M() > 500.0e-3 && 
+	    GG[1].M() > 110.0e-3 && 
+	    GG[2].M() > 110.0e-3 
+	    && 
+	    GG[0].M() < 600.0e-3 && 
+	    GG[1].M() < 160.0e-3 && 
+	    GG[2].M() < 160.0e-3)
+	  AnEtaPrim3 = true;
+	if(AnEtaPrim1 || AnEtaPrim2 || AnEtaPrim3)
+	  AnEtaPrim = true;
+	
+	if (AnEta && !AnEtaPrim && Esum > 500.0e-3) {
+	  if (Chi2_3pi0 < bestChi0Eta) {
+	    bestChi0Eta = Chi2_3pi0;
+	    PhotonEta6gList.clear();
+	    PhotonEta6gList.push_back(EMList[combi7->combi[0]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[1]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[2]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[3]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[4]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[5]]);
+	    PhotonEta6gList.push_back(EMList[combi7->combi[6]]);
+	  }
+	}
+	
+	if (!AnEta && AnEtaPrim && Esum > 900.0e-3) {
+	  double Esum2gg1 = EMList[combi7->combi[4]].E() + EMList[combi7->combi[5]].E();
+	  if (AnEtaPrim1 && Esum2gg1 > 500.0e-3) {
+	    if(Chi2_2pi0eta_0 < bestChi0EtaPrim) {
+	      bestChi0EtaPrim = Chi2_2pi0eta_0;
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[1]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[3]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[5]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[6]]);
+	    }
+	  }
+	  double Esum2gg2 = EMList[combi7->combi[2]].E() + EMList[combi7->combi[3]].E();
+	  if (AnEtaPrim2 && Esum2gg2 > 500.0e-3) {
+	    if(Chi2_2pi0eta_1 < bestChi0EtaPrim) {
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[1]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[5]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[3]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[6]]);
+	    }
+	  }
+	  double Esum2gg3 = EMList[combi7->combi[0]].E() + EMList[combi7->combi[1]].E();
+	  if (AnEtaPrim3 && Esum2gg3 > 500.0e-3) {
+	    if(Chi2_2pi0eta_2 < bestChi0EtaPrim) {
+	      PhotonEtaprim6gList.clear();
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[2]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[3]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[4]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[5]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[0]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[1]]);
+	      PhotonEtaprim6gList.push_back(EMList[combi7->combi[6]]);
+	    }
+	  }
+	}
+      }
+    }
+  }
+  if(PhotonEta6gList.size()>0)
+    PhotonEtaprim6gList.clear();
+}

--- a/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.cc
+++ b/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.cc
@@ -317,7 +317,8 @@ jerror_t JEventProcessor_eta6g_skim::evnt(JEventLoop *loop, uint64_t eventnumber
   if ( Candidate ) {
     //cout <<"eta6g_skim"<<endl;
     if( WRITE_EVIO ){
-      locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim", locObjectsToSave );
+      //locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim", locObjectsToSave );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "eta6g_skim");
     }
     if( WRITE_HDDM ) {
       vector<const DEventWriterHDDM*> locEventWriterHDDMVector;

--- a/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.h
+++ b/src/plugins/Utilities/eta6g_primexd_skim/JEventProcessor_eta6g_skim.h
@@ -1,0 +1,91 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#ifndef _JEventProcessor_eta6g_skim_
+#define _JEventProcessor_eta6g_skim_
+
+#include <JANA/JEventProcessor.h>
+#include "evio_writer/DEventWriterEVIO.h"
+#include "Combination.h"
+
+class TTree;
+class DFCALCluster;
+
+#include <vector>
+
+class JEventProcessor_eta6g_skim:public jana::JEventProcessor{
+ public:
+
+  enum { kMaxHits = 500, kMaxClus = 20 };
+
+  JEventProcessor_eta6g_skim();
+  ~JEventProcessor_eta6g_skim();
+  const char* className(void){return "JEventProcessor_eta6g_skim";}
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
+  void Combined6g(vector<TLorentzVector>&EMList,
+		  Double_t &bestChi2Eta,
+		  Double_t &bestChi2EtaPrim,
+		  vector<TLorentzVector>&PhotonEta6gList,
+		  vector<TLorentzVector>&PhotonEtaprim6gList);
+  void Combined7g(vector<TLorentzVector>&EMList,
+		  Double_t &bestChi2Eta,
+		  Double_t &bestChi2EtaPrim,
+		  vector<TLorentzVector>&PhotonEta6gList,
+		  vector<TLorentzVector>&PhotonEtaprim6gList);
+
+  double MIN_MASS;
+  double MAX_MASS;
+  double MIN_E;
+  double MIN_R;
+  double MAX_DT;
+  double MAX_ETOT;
+  int    MIN_BLOCKS;
+
+  int WRITE_ROOT;
+  int WRITE_EVIO;
+  int WRITE_HDDM;
+
+  TTree* m_tree;
+  int m_nClus;
+  int m_hit0[kMaxClus];
+  float m_px[kMaxClus];
+  float m_py[kMaxClus];
+  float m_pz[kMaxClus];
+
+  int m_nHit;
+  int m_chan[kMaxHits];
+  float m_e[kMaxHits];
+
+  int num_epics_events;
+
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
+  
+  Combination  *combi6;       
+  Combination  *combi7;       
+  
+  const double me = 0.510998928e-3;
+  const double pi0Mass = 0.13497666;
+  const double etaMass = 0.547962;
+  const double etaprimeMass = 0.95778;  
+};
+
+#endif // _JEventProcessor_eta6g_skim_
+

--- a/src/plugins/Utilities/eta6g_primexd_skim/SConscript
+++ b/src/plugins/Utilities/eta6g_primexd_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+

--- a/src/plugins/Utilities/etapi0_primexd_skim/Combination.cc
+++ b/src/plugins/Utilities/etapi0_primexd_skim/Combination.cc
@@ -1,0 +1,70 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include "Combination.h"
+
+using namespace std;
+
+Combination::Combination (int npar) {
+  n        = npar;
+  maxCombi = 0;
+  if (n < 2)          return;
+  if (n >= MAXCOMBI)  return;
+  combi = new unsigned char [n];
+  iCombi   = 0;
+  maxCombi = calcMaxCombi ();
+  list  = new unsigned char [maxCombi * n];
+  if (n & 1) oddCombi ();
+  else       allCombi (0, 0);
+}
+
+void Combination::getCombi (int i) {
+  memcpy (combi, list + (i * n), n);
+}
+
+void Combination::oddCombi () {
+  for (int i = 0; i < n; i++) {
+    combi [n-1] = i;
+    allCombi (1 << i, 0);
+  }
+}
+
+void Combination::allCombi (int used, int deep) {
+  int nrem       = n - 2 * deep - (n & 1);
+  int remain [nrem];
+  int irem = 0;
+  for (int i = 0; i < n; i++) 
+    if ( ! ( (1 << i) & used ) )
+      remain [irem++] = i;
+
+  combi [deep*2]   = remain [0];
+  for (int j = 1; j < nrem; j++) {
+    combi [deep*2+1]  = remain [j];
+    int xused   = (1 << remain [0]) | (1 << remain [j]) | used ;
+    if (nrem >= 4)
+      allCombi (xused, deep + 1);
+    else {
+      memcpy (list + (iCombi++) * n , combi, n);
+    }
+  }
+}
+
+int Combination::calcMaxCombi () {
+  int max = 1;
+  int nn  = n;
+  if (! (nn & 1)) nn--;
+  while (nn > 0) {
+    max *= nn;
+    nn -= 2;
+  }
+  return (max);
+}
+  

--- a/src/plugins/Utilities/etapi0_primexd_skim/Combination.h
+++ b/src/plugins/Utilities/etapi0_primexd_skim/Combination.h
@@ -1,0 +1,47 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+//#if !defined(COMBINATION)
+//#define COMBINATION
+
+#ifndef _Combination_
+#define _Combination_
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <iostream>
+#include <stdio.h>
+#include <string.h>
+
+using namespace std;
+
+class Combination
+{
+#define MAXCOMBI 32
+protected:
+  int n;
+  int maxCombi, iCombi;
+  unsigned char * list;
+  
+public:
+  unsigned char * combi;
+
+  Combination (int npar);
+  void oddCombi ();
+  void allCombi (int used, int deep);
+  void getCombi (int i);
+  int getMaxCombi () { return (maxCombi);  }
+  int getN        () { return (n);         }
+  int calcMaxCombi ();
+};
+
+#endif // _combination_
+//#endif // _COMBINATION_H_

--- a/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.cc
+++ b/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.cc
@@ -1,0 +1,515 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include <math.h>
+
+#include "JEventProcessor_etapi0_skim.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include "JANA/JApplication.h"
+#include <TLorentzVector.h>
+#include "TMath.h"
+#include "JANA/JApplication.h"
+#include "DANA/DApplication.h"
+#include "FCAL/DFCALShower.h"
+#include "BCAL/DBCALShower.h"
+#include "CCAL/DCCALShower.h"
+#include "FCAL/DFCALCluster.h"
+#include "FCAL/DFCALHit.h"
+#include "START_COUNTER/DSCHit.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+#include "PID/DVertex.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+#include <HDGEOMETRY/DGeometry.h>
+#include <TOF/DTOFPoint.h>
+
+#include "GlueX.h"
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include "TLorentzVector.h"
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_etapi0_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_etapi0_skim (Constructor)
+//------------------
+JEventProcessor_etapi0_skim::JEventProcessor_etapi0_skim()
+{
+
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:WRITE_HDDM", WRITE_HDDM );
+
+  /*
+  MIN_MASS   = 0.03; // GeV
+  MAX_MASS   = 0.30; // GeV
+  MIN_E      =  1.0; // GeV (photon energy cut)
+  MIN_R      =   20; // cm  (cluster distance to beam line)
+  MAX_DT     =   10; // ns  (cluster time diff. cut)
+  MAX_ETOT   =   12; // GeV (max total FCAL energy)
+  MIN_BLOCKS =    2; // minumum blocks per cluster
+
+  WRITE_ROOT = 0;
+  WRITE_EVIO = 1;
+
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MIN_MASS", MIN_MASS );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MAX_MASS", MAX_MASS );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MIN_E", MIN_E );                
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MAX_DT", MAX_DT );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MAX_ETOT", MAX_ETOT );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:MIN_BLOCKS", MIN_BLOCKS );
+  gPARMS->SetDefaultParameter( "ETAPI0_SKIM:WRITE_ROOT", WRITE_ROOT );
+  */
+}
+
+//------------------
+// ~JEventProcessor_etapi0_skim (Destructor)
+//------------------
+JEventProcessor_etapi0_skim::~JEventProcessor_etapi0_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_etapi0_skim::init(void)
+{
+  num_epics_events = 0;
+/*
+  if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
+
+    cerr << "No output mechanism has been specified." << endl;
+    return UNRECOVERABLE_ERROR;
+  }
+
+  if( WRITE_ROOT ){
+
+    japp->RootWriteLock();
+
+    m_tree = new TTree( "cluster", "Cluster Tree for Pi0 Calibration" );
+    m_tree->Branch( "nClus", &m_nClus, "nClus/I" );
+    m_tree->Branch( "hit0", m_hit0, "hit0[nClus]/I" );
+    m_tree->Branch( "px", m_px, "px[nClus]/F" );
+    m_tree->Branch( "py", m_py, "py[nClus]/F" );
+    m_tree->Branch( "pz", m_pz, "pz[nClus]/F" );
+
+    m_tree->Branch( "nHit", &m_nHit, "nHit/I" );
+    m_tree->Branch( "chan", m_chan, "chan[nHit]/I" );
+    m_tree->Branch( "e", m_e, "e[nHit]/F" );
+
+    japp->RootUnLock();
+  }
+*/
+    
+  combi4  = new Combination (4);
+  combi5  = new Combination (5);
+  
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_etapi0_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
+
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_etapi0_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+ 
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DBCALShower* > locBCALShowers;
+  vector< const DCCALShower* > locCCALShowers;
+  vector< const DVertex* > kinfitVertex;
+  vector<const DTOFPoint*> tof_points;
+  vector< const DBeamPhoton* > locBeamPhotons;
+  vector< const DSCHit* > locSCHit;
+
+  loop->Get(locFCALShowers);
+  loop->Get(locBCALShowers);
+  loop->Get(locCCALShowers);
+  loop->Get(kinfitVertex);
+  loop->Get(tof_points);
+  loop->Get(locBeamPhotons);
+  loop->Get(locSCHit);
+  
+  vector<const DTrackCandidate*> locTrackCandidate;
+  loop->Get(locTrackCandidate);
+
+  vector< const DTrackTimeBased* > locTrackTimeBased;
+  loop->Get(locTrackTimeBased);
+
+  vector < const DFCALShower * > matchedShowers;
+  
+  const DEventWriterEVIO* locEventWriterEVIO = NULL;
+  loop->GetSingle(locEventWriterEVIO);
+
+  // always write out BOR events
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+      //jout << "Found BOR!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim" );
+      return NOERROR;
+  }
+
+  // write out the first few EPICS events to save run number & other meta info
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+      //jout << "Found EPICS!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim" );
+      num_epics_events++;
+      return NOERROR;
+  }
+
+  
+  vector< const JObject* > locObjectsToSave;  
+
+  bool Candidate = false;
+  
+  DVector3 vertex;
+  vertex.SetXYZ(m_beamSpotX, m_beamSpotY, m_targetZ);
+  for (unsigned int i = 0 ; i < tof_points.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(tof_points[i]));
+  }
+  for (unsigned int i = 0 ; i < locBCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locFCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locCCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locCCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackCandidate.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackCandidate[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackTimeBased.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackTimeBased[i]));
+  }
+  for (unsigned int i = 0 ; i < locBeamPhotons.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBeamPhotons[i]));
+  }
+  for (unsigned int i = 0 ; i < locSCHit.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locSCHit[i]));
+  }
+  //Use kinfit when available
+  double kinfitVertexX = m_beamSpotX;
+  double kinfitVertexY = m_beamSpotY;
+  double kinfitVertexZ = m_targetZ;
+  for (unsigned int i = 0 ; i < kinfitVertex.size(); i++) {
+    if(i==0)
+      locObjectsToSave.push_back(static_cast<const JObject *>(kinfitVertex[0]));
+  }
+  
+  vector<const DEventRFBunch*> locEventRFBunches;
+  loop->Get(locEventRFBunches);
+  if(locEventRFBunches.size() > 0) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locEventRFBunches[0]));
+  }
+  vector <TLorentzVector> PhotonList; PhotonList.clear(); 
+  int photon_nb = locBCALShowers.size() + locFCALShowers.size() + locCCALShowers.size();
+  
+  for (unsigned int i = 0; i < locBCALShowers.size(); i ++) {
+    double e =  locBCALShowers[i]->E;
+    double x =  locBCALShowers[i]->x - kinfitVertexX;
+    double y =  locBCALShowers[i]->y - kinfitVertexY;
+    double z =  locBCALShowers[i]->z - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex.Mag();
+    //double t = locCCALShowers[j]->time - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  for (unsigned int i = 0; i < locFCALShowers.size(); i ++) {
+    double e = locFCALShowers[i]->getEnergy();
+    double x = locFCALShowers[i]->getPosition().X() - kinfitVertexX;
+    double y = locFCALShowers[i]->getPosition().Y() - kinfitVertexY;
+    double z = locFCALShowers[i]->getPosition().Z() - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex1.Mag();
+    //double t = locFCALShowers[i]->getTime() - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  for (unsigned int i = 0; i < locCCALShowers.size(); i ++) {
+    double e =  locCCALShowers[i]->E;
+    double x =  locCCALShowers[i]->x - kinfitVertexX;
+    double y =  locCCALShowers[i]->y - kinfitVertexY;
+    double z =  locCCALShowers[i]->z - kinfitVertexZ;
+    DVector3 vertex(x, y, z);
+    //double r = vertex.Mag();
+    //double t = locCCALShowers[j]->time - (r / TMath::C());
+    double p = e;
+    double px = p * sin(vertex.Theta()) * cos(vertex.Phi());
+    double py = p * sin(vertex.Theta()) * sin(vertex.Phi());
+    double pz = p * cos(vertex.Theta());
+    TLorentzVector PhotonVec(px, py, pz, e);
+    PhotonList.push_back(PhotonVec);
+  }
+  
+  Double_t bestChi22Pi0 = 1.0e30;
+  Double_t bestChi2Pi0Eta = 1.0e30;
+  Double_t bestChi22Eta = 1.0e30;
+  vector <TLorentzVector> Photon2Pi0List;Photon2Pi0List.clear();
+  vector <TLorentzVector> PhotonPi0EtaList;PhotonPi0EtaList.clear();
+  vector <TLorentzVector> Photon2EtaList;Photon2EtaList.clear();
+  Combined4g(PhotonList,
+	     bestChi22Pi0,
+	     bestChi2Pi0Eta,
+	     bestChi22Eta,
+	     Photon2Pi0List,
+	     PhotonPi0EtaList,
+	     Photon2EtaList);
+  Combined5g(PhotonList,
+	     bestChi22Pi0,
+	     bestChi2Pi0Eta,
+	     bestChi22Eta,
+	     Photon2Pi0List,
+	     PhotonPi0EtaList,
+	     Photon2EtaList);
+  
+  Candidate |= ( (4 <= photon_nb && photon_nb <= 5) && (Photon2Pi0List.size() > 0 || PhotonPi0EtaList.size() > 0 || Photon2EtaList.size() > 0) );
+  
+  if ( Candidate ){
+    //cout <<"etapi0_skim"<<endl;
+    if( WRITE_EVIO ){
+      locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+    
+ }
+ 
+
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_etapi0_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_etapi0_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}
+
+
+void JEventProcessor_etapi0_skim::Combined4g(vector<TLorentzVector>&EMList,
+					     Double_t &bestChi22Pi0,
+					     Double_t &bestChi2EtaPi0,
+					     Double_t &bestChi22Eta,
+					     vector<TLorentzVector>&Photon2Pi0List,
+					     vector<TLorentzVector>&PhotonEtaPi0List,
+					     vector<TLorentzVector>&Photon2EtaList)
+{	  
+  bestChi22Pi0   = 1.0e30;
+  bestChi2EtaPi0 = 1.0e30;
+  bestChi22Eta   = 1.0e30;
+
+  if(EMList.size() == 4) {
+    for (int i_comb = 0; i_comb < (*combi4).getMaxCombi(); i_comb ++) {
+      combi4->getCombi(i_comb);
+      
+      double Esum = 0.0;		  
+      for (int i = 0; i < 4; i ++) {
+	Esum += EMList[combi4->combi[i]].E();
+      }
+      
+      double Chi2_pi0Mass[3];
+      double Chi2_etaMass[3];
+      vector<TLorentzVector>GG;GG.clear();
+      vector<TLorentzVector>Pi0Cor;Pi0Cor.clear();
+      vector<TLorentzVector>EtaCor;EtaCor.clear();
+      
+      for (int i = 0; i < 2; i ++) {
+	GG.push_back(EMList[combi4->combi[2*i]] + EMList[combi4->combi[2*i+1]] );
+	Pi0Cor.push_back( pi0Mass / GG[i].M() * GG[i] );
+	EtaCor.push_back( etaMass / GG[i].M() * GG[i] );
+	Chi2_pi0Mass[i] = TMath::Power((GG[i].M() - pi0Mass) / 12.8e-3,2.0);
+	Chi2_etaMass[i] = TMath::Power((GG[i].M() - etaMass) / 31.1e-3,2.0);
+      }
+      
+      double Chi2_2pi0     = Chi2_pi0Mass[0] + Chi2_pi0Mass[1];
+      double Chi2_pi0eta_0 = Chi2_pi0Mass[0] + Chi2_etaMass[1];
+      double Chi2_pi0eta_1 = Chi2_etaMass[0] + Chi2_pi0Mass[1];
+      double Chi2_2eta     = Chi2_etaMass[0] + Chi2_etaMass[1];
+      if (Chi2_2pi0 < bestChi22Pi0 && Esum > 0.25) {
+	bestChi22Pi0 = Chi2_2pi0;
+	Photon2Pi0List.clear();
+	Photon2Pi0List.push_back(EMList[combi4->combi[0]]);
+	Photon2Pi0List.push_back(EMList[combi4->combi[1]]);
+	Photon2Pi0List.push_back(EMList[combi4->combi[2]]);
+	Photon2Pi0List.push_back(EMList[combi4->combi[3]]);
+      }
+      if (Chi2_2eta < bestChi22Eta && Esum > 1.0) {
+	bestChi22Eta = Chi2_2eta;
+	Photon2EtaList.clear();
+	Photon2EtaList.push_back(EMList[combi4->combi[0]]);
+	Photon2EtaList.push_back(EMList[combi4->combi[1]]);
+	Photon2EtaList.push_back(EMList[combi4->combi[2]]);
+	Photon2EtaList.push_back(EMList[combi4->combi[3]]);
+      }
+      double Esum2gg1 = EMList[combi4->combi[2]].E() + EMList[combi4->combi[3]].E();
+      double Esum2gg2 = EMList[combi4->combi[0]].E() + EMList[combi4->combi[1]].E();
+      if (Chi2_pi0eta_0 < bestChi2EtaPi0 && Esum2gg1 > 0.5 && Esum > 0.65) {
+	bestChi2EtaPi0 = Chi2_pi0eta_0;
+	PhotonEtaPi0List.clear();
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[0]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[1]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[2]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[3]]);
+      }
+      if (Chi2_pi0eta_1 < bestChi2EtaPi0 && Esum2gg2 > 0.5 && Esum > 0.65) {
+	bestChi2EtaPi0 = Chi2_pi0eta_1;
+	PhotonEtaPi0List.clear();
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[2]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[3]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[0]]);
+	PhotonEtaPi0List.push_back(EMList[combi4->combi[1]]);
+      }
+    }
+  }
+}
+void JEventProcessor_etapi0_skim::Combined5g(vector<TLorentzVector>&EMList,
+					     Double_t &bestChi22Pi0,
+					     Double_t &bestChi2EtaPi0,
+					     Double_t &bestChi22Eta,
+					     vector<TLorentzVector>&Photon2Pi0List,
+					     vector<TLorentzVector>&PhotonEtaPi0List,
+					     vector<TLorentzVector>&Photon2EtaList)
+{	  
+  bestChi22Pi0   = 1.0e30;
+  bestChi2EtaPi0 = 1.0e30;
+  bestChi22Eta   = 1.0e30;
+  if (EMList.size() == 5) {
+    for (int i_comb = 0; i_comb < (*combi5).getMaxCombi(); i_comb ++) {{
+	combi5->getCombi(i_comb);
+	
+	double Esum = 0.0;		  
+	for (int i = 0; i < 4; i ++) {
+	  Esum += EMList[combi5->combi[i]].E();
+	}
+	
+	double Chi2_pi0Mass[3];
+	double Chi2_etaMass[3];
+	vector<TLorentzVector>GG;GG.clear();
+	vector<TLorentzVector>Pi0Cor;Pi0Cor.clear();
+	vector<TLorentzVector>EtaCor;EtaCor.clear();
+	
+	for (int i = 0; i < 2; i ++) {
+	  GG.push_back( EMList[combi5->combi[2*i]] + EMList[combi5->combi[2*i+1]] );
+	  Pi0Cor.push_back( pi0Mass / GG[i].M() * GG[i] );
+	  EtaCor.push_back( etaMass / GG[i].M() * GG[i] );
+	  Chi2_pi0Mass[i] = TMath::Power((GG[i].M() - pi0Mass) / 12.8e-3,2.0);
+	  Chi2_etaMass[i] = TMath::Power((GG[i].M() - etaMass) / 31.1e-3,2.0);
+	}
+	
+	double Chi2_2pi0     = Chi2_pi0Mass[0] + Chi2_pi0Mass[1];
+	double Chi2_pi0eta_0 = Chi2_pi0Mass[0] + Chi2_etaMass[1];
+	double Chi2_pi0eta_1 = Chi2_etaMass[0] + Chi2_pi0Mass[1];
+	double Chi2_2eta     = Chi2_etaMass[0] + Chi2_etaMass[1];
+	if (Chi2_2pi0<bestChi22Pi0 && Esum > 0.25) {
+	  bestChi22Pi0 = Chi2_2pi0;
+	  Photon2Pi0List.clear();
+	  Photon2Pi0List.push_back(EMList[combi5->combi[0]]);
+	  Photon2Pi0List.push_back(EMList[combi5->combi[1]]);
+	  Photon2Pi0List.push_back(EMList[combi5->combi[2]]);
+	  Photon2Pi0List.push_back(EMList[combi5->combi[3]]);
+	  Photon2Pi0List.push_back(EMList[combi5->combi[4]]);
+	}
+	if (Chi2_2eta<bestChi22Eta && Esum > 1.0) {
+	  bestChi22Eta = Chi2_2eta;
+	  Photon2EtaList.clear();
+	  Photon2EtaList.push_back(EMList[combi5->combi[0]]);
+	  Photon2EtaList.push_back(EMList[combi5->combi[1]]);
+	  Photon2EtaList.push_back(EMList[combi5->combi[2]]);
+	  Photon2EtaList.push_back(EMList[combi5->combi[3]]);
+	  Photon2EtaList.push_back(EMList[combi5->combi[4]]);
+	}
+	double Esum2gg1 = EMList[combi5->combi[2]].E() + EMList[combi5->combi[3]].E();
+	double Esum2gg2 = EMList[combi5->combi[0]].E() + EMList[combi5->combi[1]].E();
+	if (Chi2_pi0eta_0<bestChi2EtaPi0 && Esum2gg1 > 0.5 && Esum > 0.65) {
+	  bestChi2EtaPi0 = Chi2_pi0eta_0;
+	  PhotonEtaPi0List.clear();
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[0]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[1]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[2]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[3]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[4]]);
+	}
+	if (Chi2_pi0eta_1<bestChi2EtaPi0 && Esum2gg2 > 0.5 && Esum > 0.65) {
+	  bestChi2EtaPi0 = Chi2_pi0eta_1;
+	  PhotonEtaPi0List.clear();
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[2]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[3]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[0]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[1]]);
+	  PhotonEtaPi0List.push_back(EMList[combi5->combi[4]]);
+	}
+      }
+    }
+  }
+}

--- a/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.cc
+++ b/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.cc
@@ -317,12 +317,14 @@ jerror_t JEventProcessor_etapi0_skim::evnt(JEventLoop *loop, uint64_t eventnumbe
 	     PhotonPi0EtaList,
 	     Photon2EtaList);
   
-  Candidate |= ( (4 <= photon_nb && photon_nb <= 5) && (Photon2Pi0List.size() > 0 || PhotonPi0EtaList.size() > 0 || Photon2EtaList.size() > 0) );
+  //Candidate |= ( (4 <= photon_nb && photon_nb <= 5) && (Photon2Pi0List.size() > 0 || PhotonPi0EtaList.size() > 0 || Photon2EtaList.size() > 0) );
+  Candidate |= ( (4 <= photon_nb && photon_nb <= 5) && (PhotonPi0EtaList.size() > 0 || Photon2EtaList.size() > 0) );
   
   if ( Candidate ){
     //cout <<"etapi0_skim"<<endl;
     if( WRITE_EVIO ){
-      locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim", locObjectsToSave );
+      //locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim", locObjectsToSave );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "etapi0_skim");
     }
     if( WRITE_HDDM ) {
       vector<const DEventWriterHDDM*> locEventWriterHDDMVector;

--- a/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.h
+++ b/src/plugins/Utilities/etapi0_primexd_skim/JEventProcessor_etapi0_skim.h
@@ -1,0 +1,94 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#ifndef _JEventProcessor_etapi0_skim_
+#define _JEventProcessor_etapi0_skim_
+
+#include <JANA/JEventProcessor.h>
+#include "evio_writer/DEventWriterEVIO.h"
+#include "Combination.h"
+
+class TTree;
+class DFCALCluster;
+
+#include <vector>
+
+class JEventProcessor_etapi0_skim:public jana::JEventProcessor{
+ public:
+
+  enum { kMaxHits = 500, kMaxClus = 20 };
+
+  JEventProcessor_etapi0_skim();
+  ~JEventProcessor_etapi0_skim();
+  const char* className(void){return "JEventProcessor_etapi0_skim";}
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
+  void Combined4g(vector<TLorentzVector>&EMList,
+		  Double_t &bestChi22Pi0,
+		  Double_t &bestChi2EtaPi0,
+		  Double_t &bestChi22Eta,
+		  vector<TLorentzVector>&Photon2Pi0List,
+		  vector<TLorentzVector>&PhotonEtaPi0List,
+		  vector<TLorentzVector>&Photon2EtaList);
+  void Combined5g(vector<TLorentzVector>&EMList,
+		  Double_t &bestChi22Pi0,
+		  Double_t &bestChi2EtaPi0,
+		  Double_t &bestChi22Eta,
+		  vector<TLorentzVector>&Photon2Pi0List,
+		  vector<TLorentzVector>&PhotonEtaPi0List,
+		  vector<TLorentzVector>&Photon2EtaList);
+  double MIN_MASS;
+  double MAX_MASS;
+  double MIN_E;
+  double MIN_R;
+  double MAX_DT;
+  double MAX_ETOT;
+  int    MIN_BLOCKS;
+
+  int WRITE_ROOT;
+  int WRITE_EVIO;
+  int WRITE_HDDM;
+
+  TTree* m_tree;
+  int m_nClus;
+  int m_hit0[kMaxClus];
+  float m_px[kMaxClus];
+  float m_py[kMaxClus];
+  float m_pz[kMaxClus];
+
+  int m_nHit;
+  int m_chan[kMaxHits];
+  float m_e[kMaxHits];
+
+  int num_epics_events;
+
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
+
+  Combination  *combi4;       
+  Combination  *combi5;       
+
+  const double me = 0.510998928e-3;
+  const double pi0Mass = 0.13497666;
+  const double etaMass = 0.547962;
+  const double etaprimeMass = 0.95778;  
+};
+
+#endif // _JEventProcessor_etapi0_skim_
+

--- a/src/plugins/Utilities/etapi0_primexd_skim/SConscript
+++ b/src/plugins/Utilities/etapi0_primexd_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+

--- a/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.cc
+++ b/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.cc
@@ -188,9 +188,9 @@ jerror_t JEventProcessor_single_neutral_skim::evnt(JEventLoop *loop, uint64_t ev
 
   // always write out BOR events
   if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
-      //jout << "Found BOR!" << endl;
-      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim" );
-      return NOERROR;
+    //jout << "Found BOR!" << endl;
+    locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim" );
+    return NOERROR;
   }
 
   // write out the first few EPICS events to save run number & other meta info
@@ -301,7 +301,8 @@ jerror_t JEventProcessor_single_neutral_skim::evnt(JEventLoop *loop, uint64_t ev
   if( Candidate ){
     //cout <<"single_neutral_skim"<<endl;
     if( WRITE_EVIO ){
-      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim", locObjectsToSave );
+      //locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim", locObjectsToSave );
+      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim");
     }
     if( WRITE_HDDM ) {
       vector<const DEventWriterHDDM*> locEventWriterHDDMVector;

--- a/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.cc
+++ b/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.cc
@@ -1,0 +1,336 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#include <math.h>
+
+#include "JEventProcessor_single_neutral_skim.h"
+using namespace jana;
+
+// Routine used to create our JEventProcessor
+#include "JANA/JApplication.h"
+#include <TLorentzVector.h>
+#include "TMath.h"
+#include "JANA/JApplication.h"
+#include "DANA/DApplication.h"
+#include "FCAL/DFCALShower.h"
+#include "BCAL/DBCALShower.h"
+#include "CCAL/DCCALShower.h"
+#include "FCAL/DFCALCluster.h"
+#include "FCAL/DFCALHit.h"
+#include "START_COUNTER/DSCHit.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+#include "PID/DVertex.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+#include <HDGEOMETRY/DGeometry.h>
+#include <TOF/DTOFPoint.h>
+
+#include "GlueX.h"
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_single_neutral_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_single_neutral_skim (Constructor)
+//------------------
+JEventProcessor_single_neutral_skim::JEventProcessor_single_neutral_skim()
+{
+
+  WRITE_EVIO = 1;
+  WRITE_HDDM = 0;
+
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:WRITE_EVIO", WRITE_EVIO );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:WRITE_HDDM", WRITE_HDDM );
+
+
+  /*
+  MIN_MASS   = 0.03; // GeV
+  MAX_MASS   = 0.30; // GeV
+  MIN_E      =  1.0; // GeV (photon energy cut)
+  MIN_R      =   20; // cm  (cluster distance to beam line)
+  MAX_DT     =   10; // ns  (cluster time diff. cut)
+  MAX_ETOT   =   12; // GeV (max total FCAL energy)
+  MIN_BLOCKS =    2; // minumum blocks per cluster
+
+  WRITE_ROOT = 0;
+  WRITE_EVIO = 1;
+
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MIN_MASS", MIN_MASS );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MAX_MASS", MAX_MASS );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MIN_E", MIN_E );                
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MAX_DT", MAX_DT );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MAX_ETOT", MAX_ETOT );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:MIN_BLOCKS", MIN_BLOCKS );
+  gPARMS->SetDefaultParameter( "SINGLE_NEUTRAL_SKIM:WRITE_ROOT", WRITE_ROOT );
+  */
+}
+
+//------------------
+// ~JEventProcessor_single_neutral_skim (Destructor)
+//------------------
+JEventProcessor_single_neutral_skim::~JEventProcessor_single_neutral_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_single_neutral_skim::init(void)
+{
+  num_epics_events = 0;
+/*
+  if( ! ( WRITE_ROOT || WRITE_EVIO ) ){
+
+    cerr << "No output mechanism has been specified." << endl;
+    return UNRECOVERABLE_ERROR;
+  }
+
+  if( WRITE_ROOT ){
+
+    japp->RootWriteLock();
+
+    m_tree = new TTree( "cluster", "Cluster Tree for Pi0 Calibration" );
+    m_tree->Branch( "nClus", &m_nClus, "nClus/I" );
+    m_tree->Branch( "hit0", m_hit0, "hit0[nClus]/I" );
+    m_tree->Branch( "px", m_px, "px[nClus]/F" );
+    m_tree->Branch( "py", m_py, "py[nClus]/F" );
+    m_tree->Branch( "pz", m_pz, "pz[nClus]/F" );
+
+    m_tree->Branch( "nHit", &m_nHit, "nHit/I" );
+    m_tree->Branch( "chan", m_chan, "chan[nHit]/I" );
+    m_tree->Branch( "e", m_e, "e[nHit]/F" );
+
+    japp->RootUnLock();
+  }
+*/
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_single_neutral_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+  DGeometry* dgeom = NULL;
+  DApplication* dapp = dynamic_cast< DApplication* >(eventLoop->GetJApplication());
+  if (dapp) dgeom = dapp->GetDGeometry(runnumber);
+  if (dgeom) {
+    dgeom->GetTargetZ(m_targetZ);
+  } else {
+    cerr << "No geometry accessbile to ccal_timing monitoring plugin." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }	
+  jana::JCalibration *jcalib = japp->GetJCalibration(runnumber);
+  std::map<string, float> beam_spot;
+  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
+  m_beamSpotX = beam_spot.at("x");
+  m_beamSpotY = beam_spot.at("y");
+
+  return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_single_neutral_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+ 
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DBCALShower* > locBCALShowers;
+  vector< const DCCALShower* > locCCALShowers;
+  vector< const DVertex* > kinfitVertex;
+  vector<const DTOFPoint*> tof_points;
+  vector< const DBeamPhoton* > locBeamPhotons;
+  vector< const DSCHit* > locSCHit;
+
+  loop->Get(locFCALShowers);
+  loop->Get(locBCALShowers);
+  loop->Get(locCCALShowers);
+  loop->Get(kinfitVertex);
+  loop->Get(tof_points);
+  loop->Get(locBeamPhotons);
+  loop->Get(locSCHit);
+  
+  vector<const DTrackCandidate*> locTrackCandidate;
+  loop->Get(locTrackCandidate);
+
+  vector< const DTrackTimeBased* > locTrackTimeBased;
+  loop->Get(locTrackTimeBased);
+
+  
+
+  vector < const DFCALShower * > matchedShowers;
+  
+  const DEventWriterEVIO* locEventWriterEVIO = NULL;
+  loop->GetSingle(locEventWriterEVIO);
+
+  // always write out BOR events
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+      //jout << "Found BOR!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim" );
+      return NOERROR;
+  }
+
+  // write out the first few EPICS events to save run number & other meta info
+  if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+      //jout << "Found EPICS!" << endl;
+      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim" );
+      num_epics_events++;
+      return NOERROR;
+  }
+
+  
+  vector< const JObject* > locObjectsToSave;  
+
+  bool Candidate = false;
+  
+  DVector3 vertex;
+  vertex.SetXYZ(m_beamSpotX, m_beamSpotY, m_targetZ);
+  for (unsigned int i = 0 ; i < tof_points.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(tof_points[i]));
+  }
+  for (unsigned int i = 0 ; i < locBCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locFCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locCCALShowers.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locCCALShowers[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackCandidate.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackCandidate[i]));
+  }
+  for (unsigned int i = 0 ; i < locTrackTimeBased.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locTrackTimeBased[i]));
+  }
+  for (unsigned int i = 0 ; i < locBeamPhotons.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locBeamPhotons[i]));
+  }
+  for (unsigned int i = 0 ; i < locSCHit.size(); i++) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locSCHit[i]));
+  }
+  //Use kinfit when available
+  double kinfitVertexX = m_beamSpotX;
+  double kinfitVertexY = m_beamSpotY;
+  double kinfitVertexZ = m_targetZ;
+  for (unsigned int i = 0 ; i < kinfitVertex.size(); i++) {
+    if(i==0)
+      locObjectsToSave.push_back(static_cast<const JObject *>(kinfitVertex[0]));
+  }
+  TLorentzVector Target4Vec(0,0,0,me);
+  vector<const DEventRFBunch*> locEventRFBunches;
+  loop->Get(locEventRFBunches);
+  if(locEventRFBunches.size() > 0) {
+    locObjectsToSave.push_back(static_cast<const JObject *>(locEventRFBunches[0]));
+  }
+  int photon_nb = locFCALShowers.size() + locCCALShowers.size();
+  if (photon_nb == 1 && locBCALShowers.size() == 0) {
+    for (unsigned int i = 0; i < locFCALShowers.size(); i ++) {
+      double e1 = locFCALShowers[i]->getEnergy();
+      double x1 = locFCALShowers[i]->getPosition().X() - kinfitVertexX;
+      double y1 = locFCALShowers[i]->getPosition().Y() - kinfitVertexY;
+      double z1 = locFCALShowers[i]->getPosition().Z() - kinfitVertexZ;
+      DVector3 vertex1(x1, y1, z1);
+      double r1 = vertex1.Mag();
+      double t1 = locFCALShowers[i]->getTime() - (r1 / TMath::C());
+      
+      double p1 = e1;
+      double px1 = p1 * sin(vertex1.Theta()) * cos(vertex1.Phi());
+      double py1 = p1 * sin(vertex1.Theta()) * sin(vertex1.Phi());
+      double pz1 = p1 * cos(vertex1.Theta());
+      TLorentzVector Photon1Vec(px1, py1, pz1, e1);
+      double theta1 = Photon1Vec.Theta() * TMath::RadToDeg();
+      for (unsigned int k = 0; k < locBeamPhotons.size(); k ++) {
+	double eb = locBeamPhotons[k]->lorentzMomentum().E();
+	double tb = locBeamPhotons[k]->time();
+	TLorentzVector PhotonBeam4Vec(0,0,eb,eb);
+	TLorentzVector Dark4Vec = Photon1Vec - (PhotonBeam4Vec + Target4Vec);
+	double M2 = Dark4Vec.M2();
+	Candidate |= ((theta1 < 5.0) && (-0.0005 < M2 && M2 < pow(0.2, 2)));
+      }
+    }
+    for (unsigned int i = 0; i < locCCALShowers.size(); i ++) {
+      double e1 = locCCALShowers[i]->E;
+      double x1 = locCCALShowers[i]->x - kinfitVertexX;
+      double y1 = locCCALShowers[i]->y - kinfitVertexY;
+      double z1 = locCCALShowers[i]->z - kinfitVertexZ;
+      DVector3 vertex1(x1, y1, z1);
+      double r1 = vertex1.Mag();
+      double t1 = locCCALShowers[i]->time - (r1 / TMath::C());
+      
+      double p1 = e1;
+      double px1 = p1 * sin(vertex1.Theta()) * cos(vertex1.Phi());
+      double py1 = p1 * sin(vertex1.Theta()) * sin(vertex1.Phi());
+      double pz1 = p1 * cos(vertex1.Theta());
+      TLorentzVector Photon1Vec(px1, py1, pz1, e1);
+      double theta1 = Photon1Vec.Theta() * TMath::RadToDeg();
+      for (unsigned int k = 0; k < locBeamPhotons.size(); k ++) {
+	double eb = locBeamPhotons[k]->lorentzMomentum().E();
+	double tb = locBeamPhotons[k]->time();
+	TLorentzVector PhotonBeam4Vec(0,0,eb,eb);
+	TLorentzVector Dark4Vec = Photon1Vec - (PhotonBeam4Vec + Target4Vec);
+	double M2 = Dark4Vec.M2();
+	Candidate |= ((theta1 < 5.0) && (-0.0005 < M2 && M2 < pow(0.2, 2)));
+      }
+    }
+  }
+  
+  if( Candidate ){
+    //cout <<"single_neutral_skim"<<endl;
+    if( WRITE_EVIO ){
+      locEventWriterEVIO->Write_EVIOEvent( loop, "single_neutral_skim", locObjectsToSave );
+    }
+    if( WRITE_HDDM ) {
+      vector<const DEventWriterHDDM*> locEventWriterHDDMVector;
+      loop->Get(locEventWriterHDDMVector);
+      locEventWriterHDDMVector[0]->Write_HDDMEvent(loop, ""); 
+    }
+    
+ }
+ 
+
+  return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_single_neutral_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_single_neutral_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}

--- a/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.h
+++ b/src/plugins/Utilities/single_neutral_skim/JEventProcessor_single_neutral_skim.h
@@ -1,0 +1,73 @@
+/**************************************************************************                                                             
+* HallD software                                                          * 
+* Copyright(C) 2020       GlueX and PrimEX-D Collaborations               * 
+*                                                                         *                                                                
+* Author: The GlueX and PrimEX-D Collaborations                           *                                                                
+* Contributors: Igal Jaegle                                               *                                                               
+*                                                                         *
+*                                                                         *   
+* This software is provided "as is" without any warranty.                 *
+**************************************************************************/
+
+#ifndef _JEventProcessor_single_neutral_skim_
+#define _JEventProcessor_single_neutral_skim_
+
+#include <JANA/JEventProcessor.h>
+#include "evio_writer/DEventWriterEVIO.h"
+
+class TTree;
+class DFCALCluster;
+
+#include <vector>
+
+class JEventProcessor_single_neutral_skim:public jana::JEventProcessor{
+ public:
+
+  enum { kMaxHits = 500, kMaxClus = 20 };
+
+  JEventProcessor_single_neutral_skim();
+  ~JEventProcessor_single_neutral_skim();
+  const char* className(void){return "JEventProcessor_single_neutral_skim";}
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);						///< Called after last event of last event source has been processed.
+
+  void writeClustersToRoot( const vector< const DFCALCluster* > clusVec );
+
+  double MIN_MASS;
+  double MAX_MASS;
+  double MIN_E;
+  double MIN_R;
+  double MAX_DT;
+  double MAX_ETOT;
+  int    MIN_BLOCKS;
+
+  int WRITE_ROOT;
+  int WRITE_EVIO;
+  int WRITE_HDDM;
+
+  TTree* m_tree;
+  int m_nClus;
+  int m_hit0[kMaxClus];
+  float m_px[kMaxClus];
+  float m_py[kMaxClus];
+  float m_pz[kMaxClus];
+
+  int m_nHit;
+  int m_chan[kMaxHits];
+  float m_e[kMaxHits];
+
+  int num_epics_events;
+
+  double m_beamSpotX;
+  double m_beamSpotY;
+  double m_targetZ;
+  const double me = 0.510998928e-3;
+};
+
+#endif // _JEventProcessor_single_neutral_skim_
+

--- a/src/plugins/Utilities/single_neutral_skim/SConscript
+++ b/src/plugins/Utilities/single_neutral_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+


### PR DESCRIPTION
Add different skimmers for PRIMEXD
1/ eta2g_primexd_skim -> eta Primakoff in FCAL, evio reduced by 4400
2/ eta6g_primexd_skim -> eta ->3pi0 and etaprime ->2pi0 eta, evio reduced by 575
3/ etapi0_primed_skim -> etapi0/etaeta/pi0pi0 skims, evio reduced by 8
4/ compton "neutral" skim, evio reduced by 36
5/ single "neutral" skim, evio reduced by 12