### PR TITLE
Correct inconsistencies in the FCAL shower factory

### DIFF
--- a/src/libraries/FCAL/DFCALShower_factory.cc
+++ b/src/libraries/FCAL/DFCALShower_factory.cc
@@ -389,8 +389,8 @@ void DFCALShower_factory::GetCorrectedEnergyAndPosition(const DFCALCluster* clus
    
     double z0 = m_FCALfront - zV;
     double zMax = FCAL_RADIATION_LENGTH*(FCAL_SHOWER_OFFSET 
-					 //+ log(Egamma/FCAL_CRITICAL_ENERGY));
-					 + log(Eclust/FCAL_CRITICAL_ENERGY));
+					 + log(Egamma/FCAL_CRITICAL_ENERGY));
+					 //+ log(Eclust/FCAL_CRITICAL_ENERGY));
     double zed = z0;
     double zed1 = z0 + zMax;
 

--- a/src/libraries/FCAL/DFCALShower_factory.h
+++ b/src/libraries/FCAL/DFCALShower_factory.h
@@ -54,7 +54,10 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
   
   double m_zTarget, m_FCALfront;
   double m_FCALdX,m_FCALdY;
-
+  double m_beamSpotX;
+  double m_beamSpotY;  
+  double LOAD_NONLIN_CCDB;
+  double LOAD_TIMING_CCDB; 
   double LOAD_CCDB_CONSTANTS;
   double SHOWER_ENERGY_THRESHOLD;
   double cutoff_energy;


### PR DESCRIPTION
1/ Add option to remove non-linear correction and decouple it from time correction
FCAL:LOAD_NONLIN_CCDB 0
FCAL:LOAD_TIMING_CCDB 0
2/ Add beam spot x,y
3/ Use for the shower depth correction, the cluster energy instead of the energy corrected