### PR TITLE
explicitly set start time and T0 for missing track hypotheses

### DIFF
--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -1043,6 +1043,9 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
       *static_cast<DTrackingData*>(timebased_track) = fitter->GetFitParameters();
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
 
+      timebased_track->setTime(timebased_track->start_times[0].t0);
+      timebased_track->setT0(timebased_track->start_times[0].t0, timebased_track->start_times[0].t0_sigma, timebased_track->start_times[0].system);
+
       // Add hits used as associated objects
       const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();
       const vector<const DFDCPseudo*> &fdchits = fitter->GetFDCFitHits();


### PR DESCRIPTION
These two additional lines explicitly assign the track time for missing hypotheses, instead of using the poorer resolution drift chamber time initially used in the fit.  

Note: I believe this only affects the DIRC reconstruction, where we use this track time to get the extrapolated hit time at the DIRC plane.  This was found from the observation that pion tracks have better timing resolution than kaon tracks in the DIRC, due to the use of this courser time in the extrapolation.  With this fix, the time resolution for pions and kaons in the DIRC is much more symmetric.