### PR TITLE
Updates for field-off analysis

### DIFF
--- a/src/libraries/PID/DVertex_factory.cc
+++ b/src/libraries/PID/DVertex_factory.cc
@@ -43,6 +43,7 @@ jerror_t DVertex_factory::brun(jana::JEventLoop* locEventLoop, int32_t runnumber
 	m_beamSpotX = beam_spot.at("x");
 	m_beamSpotY = beam_spot.at("y");
 
+	gPARMS->SetDefaultParameter("VERTEX:USE_TARGET_CENTER", dForceTargetCenter);
 	gPARMS->SetDefaultParameter("VERTEX:NO_KINFIT_FLAG", dNoKinematicFitFlag);
 	gPARMS->SetDefaultParameter("VERTEX:DEBUGLEVEL", dKinFitDebugLevel);
 
@@ -71,6 +72,11 @@ jerror_t DVertex_factory::evnt(JEventLoop* locEventLoop, uint64_t eventnumber)
 
 	const DDetectorMatches* locDetectorMatches = NULL;
 	locEventLoop->GetSingle(locDetectorMatches);
+
+	// give option for just using the target center, e.g. if the magnetic
+	// field is off and/or tracking is otherwise not working well
+	if(dForceTargetCenter)
+		return Create_Vertex_NoTracks(locEventRFBunch);
 
 	//select the best DTrackTimeBased for each track: use best tracking FOM
 	map<JObject::oid_t, const DTrackTimeBased*> locBestTrackTimeBasedMap; //lowest tracking chisq/ndf for each candidate id

--- a/src/libraries/PID/DVertex_factory.h
+++ b/src/libraries/PID/DVertex_factory.h
@@ -47,6 +47,7 @@ class DVertex_factory : public jana::JFactory<DVertex>
 
 		int dKinFitDebugLevel;
 		bool dNoKinematicFitFlag;
+		bool dForceTargetCenter;
 		double dTargetZCenter;
 		double dTargetLength;
 		double dTargetRadius;

--- a/src/plugins/Utilities/SConscript
+++ b/src/plugins/Utilities/SConscript
@@ -5,7 +5,7 @@ Import('*')
 
 # Default targets (always built)
 subdirs = ['danarest', 'evio_writer', 'evio-hddm']
-subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim','single_neutral_skim','compton_neutral_skim','eta2g_primexd_skim','eta6g_primexd_skim','etapi0_primexd_skim'])
+subdirs.extend(['2trackskim', 'pi0bcalskim', 'pi0fcalskim', 'twogamma_fcal_skim', 'run_summary', 'track_skimmer', 'trackeff_missing','ps_skim', 'trigger_skims', 'bigevents_skim', 'coherent_peak_skim','exclusivepi0skim','randomtrigger_skim','pi0fcaltofskim','single_neutral_skim','compton_neutral_skim','eta2g_primexd_skim','eta6g_primexd_skim','etapi0_primexd_skim', 'cdcbcal_skim'])
 subdirs.extend(['EventTagPi0','es_test','omega_skim','cal_high_energy_skim'])
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 

--- a/src/plugins/Utilities/cdcbcal_skim/JEventProcessor_cdcbcal_skim.cc
+++ b/src/plugins/Utilities/cdcbcal_skim/JEventProcessor_cdcbcal_skim.cc
@@ -1,0 +1,147 @@
+// $Id$
+//
+//    File: JEventProcessor_cdcbcal_skim.cc
+// Created: Mon Dec  1 14:57:11 EST 2014 (copied structure from pi0fcalskim plugin)
+// Creator: wmcginle (on Linux ifarm1101 2.6.32-220.7.1.el6.x86_64 x86_64)
+//
+
+#include <math.h>
+#include <TLorentzVector.h>
+#include <vector>
+#include <deque>
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include "JEventProcessor_cdcbcal_skim.h"
+
+
+#include "TRACKING/DMCThrown.h"
+// Routine used to create our JEventProcessor
+#include "PID/DVertex.h"
+#include "DANA/DApplication.h"
+#include "JANA/JApplication.h"
+#include "JANA/JFactory.h"
+#include "BCAL/DBCALShower.h"
+#include "RF/DRFTime.h"
+#include "PID/DEventRFBunch.h"
+#include "HDDM/DEventWriterHDDM.h"
+
+#include "DLorentzVector.h"
+#include "TTree.h"
+#include "units.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+
+extern "C"{
+  void InitPlugin(JApplication *app){
+    InitJANAPlugin(app);
+    app->AddProcessor(new JEventProcessor_cdcbcal_skim());
+  }
+} // "C"
+
+
+//------------------
+// JEventProcessor_cdcbcal_skim (Constructor)
+//------------------
+JEventProcessor_cdcbcal_skim::JEventProcessor_cdcbcal_skim()
+{
+  
+}
+
+//------------------
+// ~JEventProcessor_cdcbcal_skim (Destructor)
+//------------------
+JEventProcessor_cdcbcal_skim::~JEventProcessor_cdcbcal_skim()
+{
+
+}
+
+//------------------
+// init
+//------------------
+jerror_t JEventProcessor_cdcbcal_skim::init(void)
+{  
+  num_epics_events = 0;
+  return NOERROR;
+}
+
+//------------------
+// brun
+//------------------
+jerror_t JEventProcessor_cdcbcal_skim::brun(JEventLoop *eventLoop, int32_t runnumber)
+{
+    return NOERROR;
+}
+
+//------------------
+// evnt
+//------------------
+jerror_t JEventProcessor_cdcbcal_skim::evnt(JEventLoop *loop, uint64_t eventnumber)
+{
+    const DEventWriterEVIO* locEventWriterEVIO = NULL;
+    loop->GetSingle(locEventWriterEVIO);
+
+	// always write out BOR events
+	if(loop->GetJEvent().GetStatusBit(kSTATUS_BOR_EVENT)) {
+	  //jout << "Found BOR!" << endl;
+	  locEventWriterEVIO->Write_EVIOEvent( loop, "cdcbcal_skim" );
+	  return NOERROR;
+	}
+
+	// write out the first few EPICS events to save run number & other meta info
+	if(loop->GetJEvent().GetStatusBit(kSTATUS_EPICS_EVENT) && (num_epics_events<5)) {
+	  //jout << "Found EPICS!" << endl;
+	  locEventWriterEVIO->Write_EVIOEvent( loop, "cdcbcal_skim" );
+	  num_epics_events++;
+	  return NOERROR;
+	}
+
+	vector<const DTrackTimeBased *> tracks;
+	loop->Get(tracks);
+
+	if(tracks.size() == 0)
+		return NOERROR;
+
+	vector<const DDetectorMatches *> detectorMatchVec;
+	loop->Get(detectorMatchVec);
+	const DDetectorMatches *locDetectorMatching = detectorMatchVec[0];
+
+	vector<shared_ptr<const DBCALShowerMatchParams> > locBCALMatchParams;
+
+	// only save events with a track that is matched to the BCAL
+	bool save_event = false;
+	for( auto track : tracks ) {
+		locDetectorMatching->Get_BCALMatchParams(track,locBCALMatchParams);
+		if(locBCALMatchParams.size() > 0) {
+			save_event = true;
+			break;
+		}
+	}
+
+	if(save_event)
+		locEventWriterEVIO->Write_EVIOEvent( loop, "cdcbcal_skim" );
+
+    return NOERROR;
+}
+
+//------------------
+// erun
+//------------------
+jerror_t JEventProcessor_cdcbcal_skim::erun(void)
+{
+  // This is called whenever the run number changes, before it is
+  // changed to give you a chance to clean up before processing
+  // events from the next run number.
+  return NOERROR;
+}
+
+//------------------
+// Fin
+//------------------
+jerror_t JEventProcessor_cdcbcal_skim::fini(void)
+{
+  // Called before program exit after event processing is finished.
+  return NOERROR;
+}
+

--- a/src/plugins/Utilities/cdcbcal_skim/JEventProcessor_cdcbcal_skim.h
+++ b/src/plugins/Utilities/cdcbcal_skim/JEventProcessor_cdcbcal_skim.h
@@ -1,0 +1,40 @@
+// $Id$
+//
+//    File: JEventProcessor_cdcbcal_skim.h
+// Created: Mon feb 6 15:46:00 EST 2015
+// Creator: wmcginle(on Linux ifarm1101 2.6.32-220.7.1.el6.x86_64 x86_64)
+//
+
+#ifndef _JEventProcessor_cdcbcal_skim_
+#define _JEventProcessor_cdcbcal_skim_
+
+#include <JANA/JEventProcessor.h>
+#include <JANA/JApplication.h>
+#include "evio_writer/DEventWriterEVIO.h"
+#include <TRACKING/DTrackFitter.h>
+
+#include <vector>
+
+using namespace jana;
+using namespace std;
+
+class JEventProcessor_cdcbcal_skim:public jana::JEventProcessor{
+ public:
+
+  JEventProcessor_cdcbcal_skim();
+  ~JEventProcessor_cdcbcal_skim();
+  const char* className(void){return "JEventProcessor_cdcbcal_skim";}
+
+
+ private:
+  jerror_t init(void);						///< Called once at program start.
+  jerror_t brun(jana::JEventLoop *eventLoop, int32_t runnumber);	///< Called everytime a new run number is detected.
+  jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+  jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
+  jerror_t fini(void);	
+  					///< Called after last event of last event source has been processed.
+
+  int num_epics_events;
+};
+#endif // _JEventProcessor_cdcbcal_skim_
+

--- a/src/plugins/Utilities/cdcbcal_skim/SConscript
+++ b/src/plugins/Utilities/cdcbcal_skim/SConscript
@@ -1,0 +1,11 @@
+import sbms
+
+# get env object and clone it
+Import('*')
+env = env.Clone()
+
+sbms.AddJANA(env)
+sbms.AddDANA(env)
+sbms.AddROOT(env)
+sbms.plugin(env)
+


### PR DESCRIPTION
- Add option to force DVertex to be at the target center, actually useful for other measurements, like those with narrow targets
- Add skim to select events with CDC tracks matched to a BCAL hit