### PR TITLE
Straight track update apr20

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory.cc
+++ b/src/libraries/CDC/DCDCHit_factory.cc
@@ -21,6 +21,10 @@ static double DIGI_THRESHOLD = -1.0e8;
 jerror_t DCDCHit_factory::init(void)
 {
 
+  USE_CDC=true; 
+  gPARMS->SetDefaultParameter("CDC:ENABLE",USE_CDC);
+  if (USE_CDC==false) return RESOURCE_UNAVAILABLE;
+  
   LowTCut = -10000.;
   HighTCut = 10000.;
 
@@ -59,7 +63,8 @@ jerror_t DCDCHit_factory::init(void)
 //------------------
 jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
-  
+  if (USE_CDC==false) return RESOURCE_UNAVAILABLE;
+
   /// Read in calibration constants
   
   vector<double> cdc_timing_cuts;
@@ -96,7 +101,8 @@ jerror_t DCDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 // evnt
 //------------------
 jerror_t DCDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
-{
+{ 
+  if (USE_CDC==false) return RESOURCE_UNAVAILABLE;
  
   // Clear _data vector
   _data.clear();  

--- a/src/libraries/CDC/DCDCHit_factory.h
+++ b/src/libraries/CDC/DCDCHit_factory.h
@@ -52,7 +52,8 @@ class DCDCHit_factory: public jana::JFactory<DCDCHit>{
   jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
   jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
   jerror_t fini(void);						///< Called after last event of last event source has been processed.
-  
+
+	bool USE_CDC;  
   vector<const DTranslationTable *> ttab;
 };
 

--- a/src/libraries/FDC/DFDCHit_factory.cc
+++ b/src/libraries/FDC/DFDCHit_factory.cc
@@ -25,7 +25,10 @@ using namespace jana;
 // init
 //------------------
 jerror_t DFDCHit_factory::init(void)
-{
+{ 
+  USE_FDC=true; 
+  gPARMS->SetDefaultParameter("FDC:ENABLE",USE_FDC);
+  
    /// set the base conversion scales
    a_scale      = 2.4E4/1.3E5;  // cathodes
    t_scale      = 8.0/10.0;     // 8 ns/count and integer time is in 1/10th of sample
@@ -40,6 +43,8 @@ jerror_t DFDCHit_factory::init(void)
 //------------------
 jerror_t DFDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 {
+  if (USE_FDC==false) return RESOURCE_UNAVAILABLE;
+
    // Only print messages for one thread whenever run number change
    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
    static set<int> runs_announced;
@@ -123,6 +128,8 @@ jerror_t DFDCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 //------------------
 jerror_t DFDCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
+  if (USE_FDC==false) return RESOURCE_UNAVAILABLE;
+
    /// Generate DFDCHit object for each DFDCCathodeDigiHit and
    /// each DFDCWireDigiHit object.
    /// This is where the first set of calibration constants

--- a/src/libraries/FDC/DFDCHit_factory.h
+++ b/src/libraries/FDC/DFDCHit_factory.h
@@ -55,7 +55,8 @@ class DFDCHit_factory:public jana::JFactory<DFDCHit>{
 		jerror_t evnt(jana::JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
 		jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
-
+	
+	bool USE_FDC;
 		void LoadPackageCalibTables(jana::JEventLoop *eventLoop, string ccdb_prefix);
 };
 

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -250,10 +250,12 @@ inline double DTrackFitterStraightTrack::CDCDriftVariance(double t) const {
    return sigma*sigma;
 }
 
-// Convert time to distance for the cdc
-double DTrackFitterStraightTrack::CDCDriftDistance(double dphi,double delta,
-						   double t) const{
-  double d=0.;
+// Convert time to distance for the cdc.  Also returns the variance in d.
+void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
+						   double t, double &d, 
+						   double &V) const{
+  d=0.; 
+  double dd_dt=0;
   if (t>0){
     double f_0=0.;
     double f_delta=0.;
@@ -275,6 +277,8 @@ double DTrackFitterStraightTrack::CDCDriftDistance(double dphi,double delta,
       f_delta=(a1+a2*delta_mag)*sqrt_t+(b1+b2*delta_mag)*my_t
 	+(c1+c2*delta_mag+c3*delta*delta)*t3;
       f_0=a1*sqrt_t+b1*my_t+c1*t3;
+
+      dd_dt=0.001*(0.5*a1/sqrt_t+b1+3.*c1*my_t*my_t);
       }
     else{
       double my_t=0.001*t;
@@ -293,14 +297,14 @@ double DTrackFitterStraightTrack::CDCDriftDistance(double dphi,double delta,
       f_delta= (a1+a2*delta_mag+a3*delta_sq)*sqrt_t
 	+(b1+b2*delta_mag+b3*delta_sq)*my_t;
       f_0=a1*sqrt_t+b1*my_t;
+      
+      dd_dt=0.001*(0.5*a1/sqrt_t+b1);
     }
     
     unsigned int max_index=cdc_drift_table.size()-1;
     if (t>cdc_drift_table[max_index]){
       //_DBG_ << "t: " << t <<" d " << f_delta <<endl;
       d=f_delta;
-      
-      return d;
     }
     
     // Drift time is within range of table -- interpolate...
@@ -317,7 +321,7 @@ double DTrackFitterStraightTrack::CDCDriftDistance(double dphi,double delta,
     }
     d=f_delta*(d_0/f_0*P+1.-P);
   }
-  return d;
+  V=CDCDriftVariance(t)+mVarT0*dd_dt*dd_dt;
 }
 
 // Perform the Kalman Filter for the current set of cdc hits
@@ -416,13 +420,10 @@ jerror_t DTrackFitterStraightTrack::KalmanFilter(DMatrix4x1 &S,DMatrix4x4 &C,
       diff+=s*tdir-t*wdir;
       double d=diff.Mag()+d_EPS; // prevent division by zero
        
-      // The next measurement and its variance
+      // The next measurement
+      double dmeas=0.39,delta=0.;
       double tdrift=cdchits[cdc_index]->tdrift-trajectory[k].t;
-      double dmeas=0.39; 
-      double delta=0.0;
       if (fit_type==kTimeBased){
-	V=CDCDriftVariance(tdrift);	
-	
 	double phi_d=diff.Phi();
 	double dphi=phi_d-origin.Phi();  
 	while (dphi>M_PI) dphi-=2*M_PI;
@@ -431,11 +432,11 @@ jerror_t DTrackFitterStraightTrack::KalmanFilter(DMatrix4x1 &S,DMatrix4x4 &C,
 	int ring_index=cdchits[cdc_index]->wire->ring-1;
 	int straw_index=cdchits[cdc_index]->wire->straw-1;
 	double dz=t*wdir.z();
-	delta=max_sag[ring_index][straw_index]*(1.-dz*dz/5625.)
+	double delta=max_sag[ring_index][straw_index]*(1.-dz*dz/5625.)
 	  *cos(phi_d+sag_phi_offset[ring_index][straw_index]);
-	dmeas=CDCDriftDistance(dphi,delta,tdrift);
+	CDCDriftParameters(dphi,delta,tdrift,dmeas,V);
       }
-      
+
       // residual
       double res=dmeas-d;
       if (VERBOSE>5) jout << " Residual " << res << endl;
@@ -859,6 +860,29 @@ DTrackFitter::fit_status_t DTrackFitterStraightTrack::FitTrack(void){
   // Starting z-position and time
   double z=input_pos.z();
   double t0=input_params.t0();
+  // Variance in start time
+  cout << SystemName(input_params.t0_detector()) << endl;
+  switch(input_params.t0_detector()){
+  case SYS_TOF:
+    mVarT0=0.01;
+    break;
+  case SYS_CDC:
+    mVarT0=7.5;
+    break;
+  case SYS_FDC:
+    mVarT0=7.5;
+    break;
+  case SYS_BCAL:
+    mVarT0=0.25;
+    break;
+  case SYS_START:
+    mVarT0=0.09;
+    break;
+  default:
+    mVarT0=0.;
+    break;
+  }
+
 
   // Chisq and ndof
   chisq=1e16;
@@ -1486,22 +1510,23 @@ jerror_t DTrackFitterStraightTrack::KalmanFilter(DMatrix4x1 &S,DMatrix4x4 &C,
 	diff+=s*tdir-t*wdir;
 	double d=diff.Mag()+d_EPS; // prevent division by zero
 	
-	// The next measurement and its variance
-	double tdrift=cdchits[cdc_index]->tdrift-trajectory[k].t;
-	V_CDC=CDCDriftVariance(tdrift);
-	
-	double phi_d=diff.Phi();
-	double dphi=phi_d-origin.Phi();
-	while (dphi>M_PI) dphi-=2*M_PI;
-	while (dphi<-M_PI) dphi+=2*M_PI;
-	
-	int ring_index=cdchits[cdc_index]->wire->ring-1;
-	int straw_index=cdchits[cdc_index]->wire->straw-1;
-	double dz=t*wdir.z();
-	double delta=max_sag[ring_index][straw_index]*(1.-dz*dz/5625.)
-	  *cos(phi_d+sag_phi_offset[ring_index][straw_index]);
-	double dmeas=CDCDriftDistance(dphi,delta,tdrift);
-	
+	// The next measurement	
+	double dmeas=0.39,delta=0.;  
+	double tdrift=cdchits[cdc_index]->tdrift-trajectory[k].t;	 
+	if (fit_type==kTimeBased){	 
+	  double phi_d=diff.Phi();
+	  double dphi=phi_d-origin.Phi();
+	  while (dphi>M_PI) dphi-=2*M_PI;
+	  while (dphi<-M_PI) dphi+=2*M_PI;
+	  
+	  int ring_index=cdchits[cdc_index]->wire->ring-1;
+	  int straw_index=cdchits[cdc_index]->wire->straw-1;
+	  double dz=t*wdir.z();
+	  double delta=max_sag[ring_index][straw_index]*(1.-dz*dz/5625.)
+	    *cos(phi_d+sag_phi_offset[ring_index][straw_index]);
+	  CDCDriftParameters(dphi,delta,tdrift,dmeas,V_CDC);
+	}
+
 	// residual
 	double res=dmeas-d;
 	if (VERBOSE>5) jout << " Residual " << res << endl;
@@ -2064,57 +2089,61 @@ DTrackFitterStraightTrack::Get7x7ErrorMatrix(TMatrixFSym C,DMatrix4x1 &S,double 
 // Routine to get extrapolations to other detectors
 void DTrackFitterStraightTrack::GetExtrapolations(const DVector3 &pos0,
 						  const DVector3 &dir){
-  double z0=pos0.z();
-  double uz=dir.z();
+  double x0=pos0.x(),y0=pos0.y(),z0=pos0.z();
   double s=0.,t=0.;
   DVector3 pos(0,0,0);
   DVector3 diff(0,0,0);
   ClearExtrapolations();
 
-  // Extrapolate to Start Counter and BCAL
-  double R=pos0.Perp();
   double z=z0;
-  while (R<89.0 && z>17. && z<410.){
-    diff+=(1./dir.z())*dir;
-    pos=pos0+diff;
-    R=pos.Perp();
+  double dz=0.1;
+  double uz=dir.z();
+  double ux=dir.x()/uz,ux2=ux*ux;
+  double uy=dir.y()/uz,uy2=uy*uy;
+
+  // Extrapolate to start counter
+  double Rd=SC_BARREL_R;
+  double A=ux*x0 + uy*y0;
+  double B=uy2*(Rd - x0)*(Rd + x0) + 2*ux*uy*x0*y0 + ux2*(Rd - y0)*(Rd + y0);
+  double C=ux2 + uy2;
+  if (sc_pos.empty()==false && z<SC_END_NOSE_Z && B>0){
+    dz=-(A-sqrt(B))/C;
+    pos=pos0+(dz/uz)*dir;
     z=pos.z();
-    s=diff.Mag();
-    t=s/29.98;
-    //	   printf("R %f z %f\n",R,z);
-    // start counter
-    if (sc_pos.empty()==false && R<SC_BARREL_R && z<SC_END_NOSE_Z){
+    bool done=(z<sc_pos[0][0].z()||z>SC_END_NOSE_Z);
+    while(!done){
       double d_old=1000.,d=1000.;
       unsigned int index=0;
+     
       for (unsigned int m=0;m<12;m++){
 	double dphi=pos.Phi()-SC_PHI_SECTOR1;
 	if (dphi<0) dphi+=2.*M_PI;
 	index=int(floor(dphi/(2.*M_PI/30.)));
 	if (index>29) index=0;
 	d=sc_norm[index][m].Dot(pos-sc_pos[index][m]);
-	if (d*d_old<0){ // break if we cross the current plane  
-	  // Find the new distance to the start counter (which could 
-	  // now be to a plane in the one adjacent to the one before the
-	  // step...)
-	  int count=0;
-	  while (fabs(d)>0.05 && count<20){ 
-	    // Find the index for the nearest start counter paddle
-	    double dphi=pos.Phi()-SC_PHI_SECTOR1;
-	    if (dphi<0) dphi+=2.*M_PI;
-	    index=int(floor(dphi/(2.*M_PI/30.)));
-	    d=sc_norm[index][m].Dot(pos-sc_pos[index][m]);
-	    pos+=d*dir;
-	    count++;
-	  }
+	if (d*d_old<0){ // break if we cross the current plane
+	  pos+=d*dir;
+	  s=(pos-pos0).Mag();
+	  t=s/29.98;
 	  extrapolations[SYS_START].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s));
+	  done=true;
 	  break;
 	}
 	d_old=d;
       }
+      pos-=(0.1/uz)*dir;
+      z=pos.z();
     }
-    if (R>64.){	 
-      extrapolations[SYS_BCAL].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s));
-    }
+  }
+  // Extrapolate to BCAL
+  Rd=65.; // approximate BCAL inner radius
+  B=uy2*(Rd - x0)*(Rd + x0) + 2*ux*uy*x0*y0 + ux2*(Rd - y0)*(Rd + y0);
+  if (B>0){
+    diff=-(A-sqrt(B))/(C*uz)*dir;
+    s=diff.Mag();
+    t=s/29.98;
+    pos=pos0+diff;
+    extrapolations[SYS_BCAL].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s));
   }
 
   // Extrapolate to TRD

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -2143,7 +2143,16 @@ void DTrackFitterStraightTrack::GetExtrapolations(const DVector3 &pos0,
     s=diff.Mag();
     t=s/29.98;
     pos=pos0+diff;
-    extrapolations[SYS_BCAL].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s));
+    extrapolations[SYS_BCAL].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s)); 
+    Rd=89.; // approximate BCAL outer radius
+    B=uy2*(Rd - x0)*(Rd + x0) + 2*ux*uy*x0*y0 + ux2*(Rd - y0)*(Rd + y0);
+    if (B>0){
+      diff=-(A-sqrt(B))/(C*uz)*dir;
+      s=diff.Mag();
+      t=s/29.98;
+      pos=pos0+diff;
+      extrapolations[SYS_BCAL].push_back(DTrackFitter::Extrapolation_t(pos,dir,t,s));
+    }
   }
 
   // Extrapolate to TRD

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.h
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.h
@@ -76,7 +76,7 @@ public:
   
   unsigned int Locate(const vector<double>&xx,double x) const;
   double CDCDriftVariance(double t) const;
-  double CDCDriftDistance(double dphi,double delta,double t) const;
+  void CDCDriftParameters(double dphi,double delta,double t,double &d,double &V) const;
   jerror_t SetReferenceTrajectory(double t0,double z,DMatrix4x1 &S,
 				  const DCDCTrackHit *last_cdc,double &dzsign);
   jerror_t KalmanFilter(DMatrix4x1 &S,DMatrix4x4 &C,vector<int>&used_hits,
@@ -128,7 +128,7 @@ public:
   vector<double>fdc_drift_table;
   
   // Resolution parameters
-  double CDC_RES_PAR1,CDC_RES_PAR2,CDC_RES_PAR3;
+  double CDC_RES_PAR1,CDC_RES_PAR2,CDC_RES_PAR3,mVarT0;
   // Parameters for fdc drift resolution
   double DRIFT_RES_PARMS[3];
   double DRIFT_FUNC_PARMS[6];


### PR DESCRIPTION
Adds improvements to fitting in CDC and simplifies extrapolations to start counter and BCAL.
Also adds command-line parameters to disable CDC and FDC hits for testing purposes.