### PR TITLE
* remove the cut pulse_integral > 250 from the TAGM hit factory,

### DIFF
--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -75,6 +75,12 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t locE
     for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
     {
         if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
+        // Requiring tdc hits in time with the adc hit
+        // increases the purity of good tags and improves
+        // the time resolution by making sure that all 
+        // tagm hits have the time resolution provided
+        // by the time-walk-corrected tdc. -rtj
+        if (!tagm_hits[ih]->has_TDC) continue; // Skip ADC-only hits (i.e. hits with no TDC info.)
         if (tagm_hits[ih]->row > 0) continue; // Skip individual fiber readouts
         DBeamPhoton* gamma = Get_Resource();
 

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -31,7 +31,21 @@ jerror_t DTAGMHit_factory_Calib::init(void)
 {
     DELTA_T_ADC_TDC_MAX = 10.0; // ns
     USE_ADC = 0;
-    CUT_FACTOR = 1;
+    // This adc threshold is currently set to a constant of 250 channels in
+    // all TAGM channels for all run periods in CCDB. This is a problem in
+    // particular for data taken after January 2020, when the gains in some
+    // of the low-yield fibers were reduced for better performance under
+    // conditions of running at high rates. This only changes the default
+    // behavior; JANA parameter TAGMHit:CUT_FACTOR still allows the user
+    // to put it back to 1 if the old behavior is desired. The new default
+    // behavior is to fall back on the readout threshold in the fadc pulse
+    // finding algorithm to provide the minimum pulse height for hits in
+    // the tagm. Supplementing this with a requirement of a tdc hit in
+    // time with the adc pulse time provides a much better way of selecting
+    // good tags in the tagm, especially for data taken after Jan 2020.
+    // -rtj-
+    //CUT_FACTOR = 1;
+    CUT_FACTOR = 0;
     gPARMS->SetDefaultParameter("TAGMHit:DELTA_T_ADC_TDC_MAX", DELTA_T_ADC_TDC_MAX,
                 "Maximum difference in ns between a (calibrated) fADC time and"
                 " F1TDC time for them to be matched in a single hit");


### PR DESCRIPTION
  and replace it with a requirement that all fadc hits must have
  an in-time tdc hit associated in order to be counted as a legit
  tag, and have a DBeamPhoton created for it. The pulse_integral
  cut can be restored by using TAGM:CUT_FACTOR=1 on the command
  line. [rtj]