### PR TITLE
revert to using CDC/FDC time for t0 value with missing mass hyptheses…

### DIFF
--- a/src/libraries/PID/DDetectorMatches_factory.cc
+++ b/src/libraries/PID/DDetectorMatches_factory.cc
@@ -164,7 +164,7 @@ void DDetectorMatches_factory::MatchToDIRC(const DParticleID* locParticleID, con
 	vector<DTrackFitter::Extrapolation_t> extrapolations=locTrackTimeBased->extrapolations.at(SYS_DIRC);
 	if(extrapolations.size()==0) return;
 
-	double locInputStartTime = locTrackTimeBased->t0();
+	double locInputStartTime = locTrackTimeBased->time();
 
 	// objects to hold DIRC match parameters and links between tracks and DIRC hits
 	shared_ptr<DDIRCMatchParams> locDIRCMatchParams;

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -1042,9 +1042,8 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
       timebased_track->IsSmoothed = fitter->GetIsSmoothed();  
       *static_cast<DTrackingData*>(timebased_track) = fitter->GetFitParameters();
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
-
+      
       timebased_track->setTime(timebased_track->start_times[0].t0);
-      timebased_track->setT0(timebased_track->start_times[0].t0, timebased_track->start_times[0].t0_sigma, timebased_track->start_times[0].system);
 
       // Add hits used as associated objects
       const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();


### PR DESCRIPTION
…, but set time value to the matched detector ST/FCAL/BCAL/TOF to be used for extrapolations to the DIRC