### PR TITLE
* Introduce run-dependent option to require all TAGM hits to have

### DIFF
--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -263,6 +263,12 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
         if (USE_ADC && hit->has_fADC) hit->t = hit->time_fadc;
         else  hit->t = T;
         
+        // Interpret a negative value on the integral cut to require
+        // an associated tdc hit in place of an the pulse integral cut.
+        if (CUT_FACTOR*int_cuts[row][column] < 0 && T == 0) {
+           hit->has_fADC = 0;
+        }
+
         hit->AddAssociatedObject(digihit);
     }
 


### PR DESCRIPTION
  an associated tdc hit. This can be selected for a particular run
  range by assigning negative to /PHOTON_BEAM/microscope/integral_cuts
  table in ccdb. The value in ccdb can be overridden by the command
  line option -PTAGMHit:CUT_FACTOR=0.