### PR TITLE
Add error warning for mcthrown_tree plugin

### DIFF
--- a/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.cc
+++ b/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.cc
@@ -30,6 +30,7 @@ jerror_t DEventProcessor_mcthrown_tree::init(void)
 {
 	// require tagger hit for MCGEN beam photon by default to write event to TTree
 	dTagCheck = true;
+	numgoodevents=0;
 	gPARMS->SetDefaultParameter("MCTHROWN:TAGCHECK", dTagCheck);
 
 	return NOERROR;
@@ -62,6 +63,25 @@ jerror_t DEventProcessor_mcthrown_tree::evnt(JEventLoop *locEventLoop, uint64_t 
 		return NOERROR;
 
 	locEventWriterROOT->Fill_ThrownTree(locEventLoop);
+	numgoodevents++;
+
+	return NOERROR;
+}
+
+
+//------------------
+// fini
+//------------------
+jerror_t DEventProcessor_mcthrown_tree::fini(void)
+{
+	// Called before program exit after event processing is finished.
+	if (numgoodevents==0) {
+		jerr << " mcthrown_tree\n";
+		jerr << "\tThe thrown tree has no events.\n";
+		jerr << "\tThe default behavior of the mcthrown_tree plugin is to require a tagged photon.\n";
+		jerr << "\tIf the input file is directly from a generator, this requirement can be disabled\n";
+		jerr << "\tby using -PMCTHROWN:TAGCHECK=0\n";
+	}
 
 	return NOERROR;
 }

--- a/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.h
+++ b/src/plugins/Analysis/mcthrown_tree/DEventProcessor_mcthrown_tree.h
@@ -24,8 +24,10 @@ class DEventProcessor_mcthrown_tree : public JEventProcessor
 	private:
 		jerror_t init(void);						///< Called once at program start.
 		jerror_t evnt(JEventLoop *eventLoop, uint64_t eventnumber);	///< Called every event.
+		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
 		bool dTagCheck;
+		int numgoodevents;
 };
 
 #endif // _DEventProcessor_mcthrown_tree_


### PR DESCRIPTION
Add error warning when there is a mismatch between the type of input file and the behavior of the plugin.