### PR TITLE
Nsj cdc time to distance tweak

### DIFF
--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -140,9 +140,14 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
       // Derivative of d with respect to t, needed to add t0 variance 
       // dependence to sigma
       double dd_dt=0;
-      // Scale factor to account for affect of B-field on maximum drift time
+      // Scale factor to account for effect of B-field on maximum drift time
       //double Bscale=long_drift_Bscale_par1+long_drift_Bscale_par2*B;
       // tcorr=t*Bscale;
+
+      // NSJ 26 May 2020 included long side a3, b3 and short side c1, c2, c3
+      // Previously these parameters were not used (0 in ccdb) for production runs
+      // except intensity scan run 72312 by accident 5 May 2020, superseded 8 May.
+      // They were used in 2015 for runs 0-3050.
 
       //	if (delta>0)
       if (delta>-EPS2){

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -148,8 +148,10 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
       if (delta>-EPS2){
          double a1=long_drift_func[0][0];
          double a2=long_drift_func[0][1];
+         double a3=long_drift_func[0][2];
          double b1=long_drift_func[1][0];
          double b2=long_drift_func[1][1];
+         double b3=long_drift_func[1][2];
          double c1=long_drift_func[2][0];
          double c2=long_drift_func[2][1];
          double c3=long_drift_func[2][2];
@@ -159,9 +161,12 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
          double sqrt_t=sqrt(my_t);
          double t3=my_t*my_t*my_t;
          double delta_mag=fabs(delta);
-         double a=a1+a2*delta_mag;
-         double b=b1+b2*delta_mag;
-         double c=c1+c2*delta_mag+c3*delta*delta;
+
+         double delta_sq=delta*delta;
+         double a=a1+a2*delta_mag+a3*delta_sq;
+         double b=b1+b2*delta_mag+b3*delta_sq;
+         double c=c1+c2*delta_mag+c3*delta_sq;
+
          f_delta=a*sqrt_t+b*my_t+c*t3;
          f_0=a1*sqrt_t+b1*my_t+c1*t3;
 
@@ -188,10 +193,6 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
          double a=a1+a2*delta_mag+a3*delta_sq;
          double b=b1+b2*delta_mag+b3*delta_sq;
          double c=c1+c2*delta_mag+c3*delta_sq;
-
-         //f_delta=a*sqrt_t+b*my_t;
-         //f_0=a1*sqrt_t+b1*my_t;
-         //dd_dt=0.001*(0.5*a/sqrt_t+b);
 
          f_delta=a*sqrt_t+b*my_t+c*t3;
          f_0=a1*sqrt_t+b1*my_t+c1*t3;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -170,6 +170,7 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
       else{
          double my_t=0.001*tcorr;
          double sqrt_t=sqrt(my_t);
+         double t3=my_t*my_t*my_t;
          double delta_mag=fabs(delta);
 
          // use "short side" functional form
@@ -179,14 +180,24 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
          double b1=short_drift_func[1][0];
          double b2=short_drift_func[1][1];
          double b3=short_drift_func[1][2];
+         double c1=short_drift_func[2][0];
+         double c2=short_drift_func[2][1];
+         double c3=short_drift_func[2][2];
 
          double delta_sq=delta*delta;
          double a=a1+a2*delta_mag+a3*delta_sq;
          double b=b1+b2*delta_mag+b3*delta_sq;
-         f_delta=a*sqrt_t+b*my_t;
-         f_0=a1*sqrt_t+b1*my_t;
+         double c=c1+c2*delta_mag+c3*delta*delta;
 
-         dd_dt=0.001*(0.5*a/sqrt_t+b);
+         //f_delta=a*sqrt_t+b*my_t;
+         //f_0=a1*sqrt_t+b1*my_t;
+         //dd_dt=0.001*(0.5*a/sqrt_t+b);
+
+         f_delta=a*sqrt_t+b*my_t+c*t3;
+         f_0=a1*sqrt_t+b1*my_t+c1*t3;
+
+         dd_dt=0.001*(0.5*a/sqrt_t+b+3.*c*my_t*my_t);
+
       }
 
       unsigned int max_index=cdc_drift_table.size()-1;

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -187,7 +187,7 @@ void DTrackFitterKalmanSIMD::ComputeCDCDrift(double dphi,double delta,double t,
          double delta_sq=delta*delta;
          double a=a1+a2*delta_mag+a3*delta_sq;
          double b=b1+b2*delta_mag+b3*delta_sq;
-         double c=c1+c2*delta_mag+c3*delta*delta;
+         double c=c1+c2*delta_mag+c3*delta_sq;
 
          //f_delta=a*sqrt_t+b*my_t;
          //f_0=a1*sqrt_t+b1*my_t;

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -283,6 +283,7 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
     else{
       double my_t=0.001*t;
       double sqrt_t=sqrt(my_t);
+      double t3=my_t*my_t*my_t;
       double delta_mag=fabs(delta);
       
       // use "short side" functional form
@@ -292,13 +293,19 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
       double b1=short_drift_func[1][0];
       double b2=short_drift_func[1][1];
       double b3=short_drift_func[1][2];
+      double c1=short_drift_func[2][0];
+      double c2=short_drift_func[2][1];
+      double c3=short_drift_func[2][2];
       
       double delta_sq=delta*delta;
+
       f_delta= (a1+a2*delta_mag+a3*delta_sq)*sqrt_t
-	+(b1+b2*delta_mag+b3*delta_sq)*my_t;
-      f_0=a1*sqrt_t+b1*my_t;
-      
-      dd_dt=0.001*(0.5*a1/sqrt_t+b1);
+	+(b1+b2*delta_mag+b3*delta_sq)*my_t
+	+(c1+c2*delta_mag+c3*delta*delta)*t3;
+
+      f_0=a1*sqrt_t+b1*my_t+c1*t3;
+
+      dd_dt=0.001*(0.5*a1/sqrt_t+b1+3.*c1*my_t*my_t);
     }
     
     unsigned int max_index=cdc_drift_table.size()-1;

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -263,8 +263,10 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
     if (delta>0){
       double a1=long_drift_func[0][0];
       double a2=long_drift_func[0][1];
+      double a3=long_drift_func[0][2];
       double b1=long_drift_func[1][0];
       double b2=long_drift_func[1][1];
+      double b3=long_drift_func[1][2];
       double c1=long_drift_func[2][0];
       double c2=long_drift_func[2][1];
       double c3=long_drift_func[2][2];
@@ -274,11 +276,17 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
       double sqrt_t=sqrt(my_t);
       double t3=my_t*my_t*my_t;
       double delta_mag=fabs(delta);
-      f_delta=(a1+a2*delta_mag)*sqrt_t+(b1+b2*delta_mag)*my_t
-	+(c1+c2*delta_mag+c3*delta*delta)*t3;
+
+      double delta_sq=delta*delta;
+      double a=a1+a2*delta_mag+a3*delta_sq;
+      double b=b1+b2*delta_mag+b3*delta_sq;
+      double c=c1+c2*delta_mag+c3*delta_sq;
+
+      f_delta=a*sqrt_t+b*my_t+c*t3;
       f_0=a1*sqrt_t+b1*my_t+c1*t3;
 
-      dd_dt=0.001*(0.5*a1/sqrt_t+b1+3.*c1*my_t*my_t);
+      dd_dt=0.001*(0.5*a/sqrt_t+b+3.*c*my_t*my_t);
+
       }
     else{
       double my_t=0.001*t;
@@ -296,16 +304,17 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
       double c1=short_drift_func[2][0];
       double c2=short_drift_func[2][1];
       double c3=short_drift_func[2][2];
-      
+
       double delta_sq=delta*delta;
+      double a=a1+a2*delta_mag+a3*delta_sq;
+      double b=b1+b2*delta_mag+b3*delta_sq;
+      double c=c1+c2*delta_mag+c3*delta_sq;
 
-      f_delta= (a1+a2*delta_mag+a3*delta_sq)*sqrt_t
-	+(b1+b2*delta_mag+b3*delta_sq)*my_t
-	+(c1+c2*delta_mag+c3*delta_sq)*t3;
-
+      f_delta=a*sqrt_t+b*my_t+c*t3;
       f_0=a1*sqrt_t+b1*my_t+c1*t3;
 
-      dd_dt=0.001*(0.5*a1/sqrt_t+b1+3.*c1*my_t*my_t);
+      dd_dt=0.001*(0.5*a/sqrt_t+b+3.*c*my_t*my_t);
+      
     }
     
     unsigned int max_index=cdc_drift_table.size()-1;

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -301,7 +301,7 @@ void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
 
       f_delta= (a1+a2*delta_mag+a3*delta_sq)*sqrt_t
 	+(b1+b2*delta_mag+b3*delta_sq)*my_t
-	+(c1+c2*delta_mag+c3*delta*delta)*t3;
+	+(c1+c2*delta_mag+c3*delta_sq)*t3;
 
       f_0=a1*sqrt_t+b1*my_t+c1*t3;
 

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.cc
@@ -254,7 +254,13 @@ inline double DTrackFitterStraightTrack::CDCDriftVariance(double t) const {
 void DTrackFitterStraightTrack::CDCDriftParameters(double dphi,double delta,
 						   double t, double &d, 
 						   double &V) const{
-  d=0.; 
+  
+// NSJ 26 May 2020 included long side a3, b3 and short side c1, c2, c3
+// Previously these parameters were not used (0 in ccdb) for production runs
+// except intensity scan run 72312 by accident 5 May 2020, superseded 8 May.
+// They were used in 2015 for runs 0-3050.
+
+d=0.; 
   double dd_dt=0;
   if (t>0){
     double f_0=0.;


### PR DESCRIPTION
This implements the remainder of the time to distance parameters in /CDC/drift_parameters which were previously read in, but not used.  Similar function forms are used for both long and short sides of the straw.  At present the previously unused parameters are 0.  

There is only one instance in ccdb where these parameters were non-0 for a production run, this was intensity scan 72312, may 8 2020, for which the calibration failed, the histograms were empty, better parameters were added 3 minutes later using another run at the same pressure. 
They were also non-zero for some very early entries, runs 0-3050 and 3050, in 2015.

non-zero value for a3 (first row), run max = 72312 min = 72312 added at 2020-05-08 18:39:11
non-zero value for c1 (second row), run max = 3050 min = 3050 added at 2015-12-03 14:17:47
non-zero value for c1 (second row), run max = 3050 min = 3050 added at 2015-12-03 14:16:56
non-zero value for c1 (second row), run max = 3050 min = 3050 added at 2015-12-03 14:16:42
non-zero value for c1 (second row), run max = 0 min = 0 added at 2015-10-16 16:16:44  

Essentially this PR gives more flexibility for future calibrations while changing nothing for past calibrations.   

Also, the dd/dt  in the straightline tracker was corrected.