### PR TITLE
Allow handling of multiple different DGeometry objects

### DIFF
--- a/src/libraries/DANA/DApplication.cc
+++ b/src/libraries/DANA/DApplication.cc
@@ -246,12 +246,15 @@ DGeometry* DApplication::GetDGeometry(unsigned int run_number)
 	// built on a JGeometryFile object. If so, simply return it under the
 	// assumption we are still doing development with simulated data and
 	// a single set of geometry files.
-	Lock();
-	if(geometries.size()==1 && string("JGeometryXML")==geometries[0]->GetJGeometry()->className()){
-		Unlock();
-		return geometries[0];
-	}
-	Unlock();
+	//
+	// This isn't a good assumption anymore, disabling... [sdobbs, 1 June 2020]
+	//
+	//Lock();
+	//if(geometries.size()==1 && string("JGeometryXML")==geometries[0]->GetJGeometry()->className()){
+	//	Unlock();
+	//	return geometries[0];
+	//}
+	//Unlock();
 	
 	// First, get the JGeometry object using our JApplication
 	// base class. Then, use that to find the correct DGeometry


### PR DESCRIPTION
Currently, the DANA library only manages one set of DGeometry objects.  Since this is run-dependent, in principle there can be more, and there is code set up to handle this case.  But currently it's short-circuited on the "assumption we are still doing development with simulated data and a single set of geometry files".  This has not been the case for awhile now.  So we relax this condition.  I haven't noticed anything wrong in some limited testing.

I would hold off on merging this before the reconstruction launch out of an abundance of caution.

This should help with some of the weird problems with hdview2 and any time we encounter multiple run numbers in one program execution.