### PR TITLE
Various analysis & QOL improvements

### DIFF
--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -419,6 +419,21 @@ bool DCutAction_KinFitFOM::Perform_Action(JEventLoop* locEventLoop, const DParti
 	return (locKinFitResults->Get_ConfidenceLevel() > dMinimumConfidenceLevel);
 }
 
+string DCutAction_KinFitChiSq::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMaximumChiSq;
+	return locStream.str();
+}
+
+bool DCutAction_KinFitChiSq::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	const DKinFitResults* locKinFitResults = locParticleCombo->Get_KinFitResults();
+	if(locKinFitResults == NULL)
+		return false;
+	return (locKinFitResults->Get_ChiSq()/locKinFitResults->Get_NDF() < dMaximumChiSq);
+}
+
 void DCutAction_BDTSignalCombo::Initialize(JEventLoop* locEventLoop)
 {
 	if(dCutAction_TrueBeamParticle == nullptr)

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -1222,6 +1222,150 @@ bool DCutAction_NoPIDHit::Perform_Action(JEventLoop* locEventLoop, const DPartic
 	return true;
 }
 
+string DCutAction_FlightDistance::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dMinFlightDistance;
+	return locStream.str();
+}
+
+bool DCutAction_FlightDistance::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	DKinFitType locKinFitType = Get_Reaction()->Get_KinFitType();
+
+	// for now, require a kinematic fit to make these selections, assuming that the common decay vertex
+	// is constrained in the fit
+	if(!Get_UseKinFitResultsFlag())  
+		return true;
+
+	vector<const DReactionVertexInfo*> locVertexInfos;
+	locEventLoop->Get(locVertexInfos);
+	
+	// figure out what the right DReactionVertexInfo is
+	const DReactionVertexInfo *locReactionVertexInfo = nullptr;
+	for(auto& locVertexInfo : locVertexInfos) {
+		auto locVertexReactions = locVertexInfo->Get_Reactions();
+		if(find(locVertexReactions.begin(), locVertexReactions.end(), Get_Reaction()) != locVertexReactions.end()) {
+			locReactionVertexInfo = locVertexInfo;
+			break;
+		}
+	}
+
+	// check each individual decaying particle (if they exist)
+	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
+	{	
+		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
+		//auto locParticles = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticles(Get_Reaction()->Get_ReactionStep(loc_i), false, false, d_AllCharges) : locParticleComboStep->Get_FinalParticles_Measured(Get_Reaction()->Get_ReactionStep(loc_i), d_AllCharges);
+
+		if((dPID != Unknown) && (locParticleComboStep->Get_InitialParticle()->PID() != dPID))
+			continue;
+
+		// fill info on decaying particles, which is on the particle combo step level
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
+			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
+			// was performed where the vertex is constrained
+			// TODO: Cleverly handle the other cases
+	
+			// pull out information related to the kinematic fit
+			if( !Get_UseKinFitResultsFlag() ) continue; 
+			if( locReactionVertexInfo == nullptr ) continue; 
+			
+			auto locKinFitParticle = locParticleComboStep->Get_InitialKinFitParticle();
+		
+			// extract the info about the vertex, to make sure that the information that we 
+			// need to calculate displaced vertices is there
+			auto locStepVertexInfo = locReactionVertexInfo->Get_StepVertexInfo(loc_i);
+
+			auto locParentVertexInfo = locStepVertexInfo->Get_ParentVertexInfo();
+			auto locVertexKinFitFlag = ((locKinFitType != d_P4Fit) && (locKinFitType != d_NoFit));
+			
+			auto locPathLength = locKinFitParticle->Get_PathLength();
+			
+			if(locPathLength < dMinFlightDistance)
+				return false;
+		}
+		
+	}
+
+	return true;
+}
+
+
+string DCutAction_FlightSignificance::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dMinFlightSignificance;
+	return locStream.str();
+}
+
+bool DCutAction_FlightSignificance::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	DKinFitType locKinFitType = Get_Reaction()->Get_KinFitType();
+
+	// for now, require a kinematic fit to make these selections, assuming that the common decay vertex
+	// is constrained in the fit
+	if(!Get_UseKinFitResultsFlag())  
+		return true;
+
+	vector<const DReactionVertexInfo*> locVertexInfos;
+	locEventLoop->Get(locVertexInfos);
+	
+	// figure out what the right DReactionVertexInfo is
+	const DReactionVertexInfo *locReactionVertexInfo = nullptr;
+	for(auto& locVertexInfo : locVertexInfos) {
+		auto locVertexReactions = locVertexInfo->Get_Reactions();
+		if(find(locVertexReactions.begin(), locVertexReactions.end(), Get_Reaction()) != locVertexReactions.end()) {
+			locReactionVertexInfo = locVertexInfo;
+			break;
+		}
+	}
+
+	// check each individual decaying particle (if they exist)
+	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
+	{	
+		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
+		//auto locParticles = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticles(Get_Reaction()->Get_ReactionStep(loc_i), false, false, d_AllCharges) : locParticleComboStep->Get_FinalParticles_Measured(Get_Reaction()->Get_ReactionStep(loc_i), d_AllCharges);
+
+		if((dPID != Unknown) && (locParticleComboStep->Get_InitialParticle()->PID() != dPID))
+			continue;
+
+		// fill info on decaying particles, which is on the particle combo step level
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
+			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
+			// was performed where the vertex is constrained
+			// TODO: Cleverly handle the other cases
+	
+			// pull out information related to the kinematic fit
+			if( !Get_UseKinFitResultsFlag() ) continue; 
+			if( locReactionVertexInfo == nullptr ) continue; 
+			
+			auto locKinFitParticle = locParticleComboStep->Get_InitialKinFitParticle();
+		
+			// extract the info about the vertex, to make sure that the information that we 
+			// need to calculate displaced vertices is there
+			auto locStepVertexInfo = locReactionVertexInfo->Get_StepVertexInfo(loc_i);
+
+			auto locParentVertexInfo = locStepVertexInfo->Get_ParentVertexInfo();
+			auto locVertexKinFitFlag = ((locKinFitType != d_P4Fit) && (locKinFitType != d_NoFit));
+			
+			auto locPathLength = locKinFitParticle->Get_PathLength();
+			auto locPathLengthSigma = locKinFitParticle->Get_PathLengthUncertainty();
+			double locPathLengthSignificance = locPathLength / locPathLengthSigma;
+	
+			if(locPathLengthSignificance < dMinFlightSignificance)
+				return false;
+
+		}
+		
+	}
+
+	return true;
+}
+
+
+
 void DCutAction_OneVertexKinFit::Initialize(JEventLoop* locEventLoop)
 {
 	// Optional: Useful utility functions.

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -61,6 +61,9 @@ DCutAction_PIDDeltaT
 DCutAction_PIDTimingBeta
 DCutAction_NoPIDHit
 
+DCutAction_FlightDistance
+DCutAction_FlightSignificance
+
 DCutAction_OneVertexKinFit
 */
 
@@ -746,6 +749,54 @@ class DCutAction_OneVertexKinFit : public DAnalysisAction
 		TH1I* dHist_VertexZ;
 		TH2I* dHist_VertexYVsX;
 };
+
+class DCutAction_FlightDistance : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all relevant PIDs
+
+	public:
+
+		DCutAction_FlightDistance(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinFlightDistance, Particle_t locPID = Unknown, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_FlightDistance", locUseKinFitResultsFlag, locActionUniqueString),
+		dMinFlightDistance(locMinFlightDistance), dPID(locPID) {}
+
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		double dMinFlightDistance;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
+class DCutAction_FlightSignificance : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all relevant PIDs
+
+	public:
+
+		DCutAction_FlightSignificance(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinFlightSignificance, Particle_t locPID = Unknown, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_FlightSignificance", locUseKinFitResultsFlag, locActionUniqueString),
+		dMinFlightSignificance(locMinFlightSignificance), dPID(locPID) {}
+
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		double dMinFlightSignificance;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
+
 
 #endif // _DCutActions_
 

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -45,6 +45,7 @@ DCutAction_ProductionVertexZ
 DCutAction_AllVertexZ
 DCutAction_MaxTrackDOCA
 DCutAction_KinFitFOM
+DCutAction_KinFitChiSq
 
 DCutAction_MissingMass
 DCutAction_MissingMassSquared
@@ -357,6 +358,23 @@ class DCutAction_KinFitFOM : public DAnalysisAction
 
 		const string dKinFitName;
 		double dMinimumConfidenceLevel;
+};
+
+class DCutAction_KinFitChiSq : public DAnalysisAction
+{
+	public:
+		DCutAction_KinFitChiSq(const DReaction* locReaction, double locMaximumChiSq, string locActionUniqueString = "") : 
+		DAnalysisAction(locReaction, "Cut_KinFitFOM", true, locActionUniqueString), dMaximumChiSq(locMaximumChiSq){}
+
+		string Get_ActionName(void) const;
+		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+
+	private:
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		const string dKinFitName;
+		double dMaximumChiSq;
 };
 
 class DCutAction_MissingMass : public DAnalysisAction

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1837,6 +1837,13 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 		locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 		dHist_ConfidenceLevel = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle.str(), dNumConfidenceLevelBins, 0.0, 1.0);
 
+		// Reduced chi^2 (chi^2/# d.o.f.)
+		locHistName = "ChiSq";
+		locHistTitle.str("");   // clear the ostringstream
+		locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << "; #chi^{2}/# d.o.f. (" << locNumConstraints;
+		locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+		dHist_ChiSq = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle.str(), dNumChiSqBins, 0.0, dMaxChiSq);
+
 		//beam (pulls & conlev)
 		Particle_t locInitialPID = Get_Reaction()->Get_ReactionStep(0)->Get_InitialPID();
 		bool locBeamFlag = Get_IsFirstStepBeam(Get_Reaction());
@@ -2171,6 +2178,9 @@ bool DHistogramAction_KinFitResults::Perform_Action(JEventLoop* locEventLoop, co
 
 	// Get Confidence Level
 	double locConfidenceLevel = locKinFitResults->Get_ConfidenceLevel();
+	
+	// Get reduced chi^2
+	double locChiSq = locKinFitResults->Get_ChiSq()/locKinFitResults->Get_NDF() ;
 
 	// Get Pulls
 	map<const JObject*, map<DKinFitPullType, double> > locPulls; //DKinematicData is the MEASURED particle
@@ -2185,7 +2195,8 @@ bool DHistogramAction_KinFitResults::Perform_Action(JEventLoop* locEventLoop, co
 	Lock_Action();
 	{
 		dHist_ConfidenceLevel->Fill(locConfidenceLevel);
-
+		dHist_ChiSq->Fill(locChiSq);
+		
 		// beam
 		if(locBeamFlag)
 		{

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -1485,6 +1485,11 @@ void DHistogramAction_InvariantMass::Run_Update(JEventLoop* locEventLoop)
 	locGeometry->GetTargetZ(dTargetZCenter);
 
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1538,7 +1543,7 @@ bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, co
 			
 			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
 
-			if(locDeltaTRF > 2.)
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
 				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
 		}
 	}
@@ -1613,6 +1618,11 @@ void DHistogramAction_MissingMass::Run_Update(JEventLoop* locEventLoop)
 	locGeometry->GetTargetZ(dTargetZCenter);
 
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1647,7 +1657,7 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 			
 			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
 
-			if(locDeltaTRF > 2.)
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
 				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
 		}
 	}
@@ -1724,6 +1734,11 @@ void DHistogramAction_MissingMassSquared::Run_Update(JEventLoop* locEventLoop)
 	locGeometry->GetTargetZ(dTargetZCenter);
 
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1758,7 +1773,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 			
 			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
 
-			if(locDeltaTRF > 2.)
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
 				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
 		}
 	}
@@ -1825,6 +1840,11 @@ void DHistogramAction_2DInvariantMass::Run_Update(JEventLoop* locEventLoop)
 	locGeometry->GetTargetZ(dTargetZCenter);
 
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1878,7 +1898,7 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 			
 			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
 
-			if(locDeltaTRF > 2.)
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
 				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
 		}
 	}

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -491,14 +491,16 @@ bool DHistogramAction_PID::Perform_Action(JEventLoop* locEventLoop, const DParti
 				continue; //previously histogrammed
 
 			dPreviouslyHistogrammedParticles.insert(locHistInfo);
-			if(ParticleCharge(locParticles[loc_j]->PID()) != 0) //charged
-				Fill_ChargedHists(static_cast<const DChargedTrackHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
-			else //neutral
-				Fill_NeutralHists(static_cast<const DNeutralParticleHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+			if(Is_FinalStateParticle(locParticles[loc_j]->PID())) { 
+				if(ParticleCharge(locParticles[loc_j]->PID()) != 0) //charged
+					Fill_ChargedHists(static_cast<const DChargedTrackHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+				else //neutral
+					Fill_NeutralHists(static_cast<const DNeutralParticleHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+			}
 		}
 
 		// fill info on decaying particles, which is on the particle combo step level
-		if(!Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID())) {  // decaying particles
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
 			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
 			// was performed where the vertex is constrained
 			// TODO: Cleverly handle the other cases

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -291,17 +291,17 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 class DHistogramAction_InvariantMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0) {}
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0), dSubtractAccidentals(locSubtractAccidentals) {}
 
 		//e.g. if g, p -> pi+, pi-, p
 			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
-		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0) {}
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0), dSubtractAccidentals(locSubtractAccidentals) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -325,6 +325,9 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 	public:
 		unsigned int dNum2DMassBins, dNum2DBeamEBins;
 		double dMinBeamE, dMaxBeamE;
+
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
 
 	private:
 		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
@@ -413,11 +416,11 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 class DHistogramAction_MissingMassSquared : public DAnalysisAction
 {
 	public:
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -435,20 +438,20 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		//But:
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
 
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -473,6 +476,9 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
+
 	private:
 		TH1I* dHist_MissingMassSquared;
 		TH2I* dHist_MissingMassSquaredVsBeamE;
@@ -485,10 +491,10 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 class DHistogramAction_2DInvariantMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
+		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_2DInvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs), dNumXBins(locNumXBins), dNumYBins(locNumYBins), 
-		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
+		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dSubtractAccidentals(locSubtractAccidentals), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -505,6 +511,9 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		deque<Particle_t> dXPIDs, dYPIDs;
 		unsigned int dNumXBins, dNumYBins;
 		double dMinX, dMaxX, dMinY, dMaxY;
+
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -532,22 +532,22 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 	public:
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString),
-		dHistDependenceFlag(false), dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dHistDependenceFlag(false), dNumConfidenceLevelBins(400), dNumChiSqBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
 		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
-		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
+		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dMaxChiSq(100.), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
 
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, bool locHistDependenceFlag, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString), 
-		dHistDependenceFlag(locHistDependenceFlag), dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dHistDependenceFlag(locHistDependenceFlag), dNumConfidenceLevelBins(400), dNumChiSqBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
 		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
-		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
+		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dMaxChiSq(100.), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
 
 	private:
 		bool dHistDependenceFlag;
 
 	public:
-		unsigned int dNumConfidenceLevelBins, dNumPullBins, dNum2DPBins, dNum2DThetaBins, dNum2DPhiBins, dNum2DPullBins, dNum2DConfidenceLevelBins, dNum2DBeamEBins;
-		double dMinPull, dMaxPull, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinBeamE, dMaxBeamE;
+		unsigned int dNumConfidenceLevelBins, dNumChiSqBins, dNumPullBins, dNum2DPBins, dNum2DThetaBins, dNum2DPhiBins, dNum2DPullBins, dNum2DConfidenceLevelBins, dNum2DBeamEBins;
+		double dMinPull, dMaxPull, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinBeamE, dMaxBeamE, dMaxChiSq;
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -572,6 +572,7 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 
 		//below maps: int is step index (-1 for beam), 2nd is particle
 		TH1I* dHist_ConfidenceLevel;
+		TH1I* dHist_ChiSq;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsP;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsTheta;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsPhi;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -328,6 +328,7 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 
 		bool dSubtractAccidentals;
 		double dTargetZCenter;
+		double dBeamBunchPeriod;
 
 	private:
 		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
@@ -403,6 +404,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 
 		bool dSubtractAccidentals;
 		double dTargetZCenter;
+		double dBeamBunchPeriod;
 
 	private:
 		TH1I* dHist_MissingMass;
@@ -478,6 +480,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 
 		bool dSubtractAccidentals;
 		double dTargetZCenter;
+		double dBeamBunchPeriod;
 
 	private:
 		TH1I* dHist_MissingMassSquared;
@@ -514,6 +517,7 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 
 		bool dSubtractAccidentals;
 		double dTargetZCenter;
+		double dBeamBunchPeriod;
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -338,11 +338,11 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 class DHistogramAction_MissingMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -360,20 +360,20 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		//But:
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
-		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex),
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
 
-		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -397,6 +397,9 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 	public:
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
+
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
 
 	private:
 		TH1I* dHist_MissingMass;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -86,9 +86,10 @@ class DHistogramAction_PID : public DAnalysisAction
 		dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), 
 		dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), dMinCCALTheta(0.0), dMaxCCALTheta(2.0), dMinTheta(0.0), dMaxTheta(140.0), dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), 
 		dMaxDeltaBeta(1.0), dMinDeltadEdx(-30.0), dMaxDeltadEdx(30.0), dMinDeltaT(-10.0), dMaxDeltaT(10.0), dMinPull(-10.0), dMaxPull(10.0),
-	        dDIRCNumPhotonsBins(100), dDIRCThetaCBins(100), dDIRCLikelihoodBins(100),
+	    dDIRCNumPhotonsBins(100), dDIRCThetaCBins(100), dDIRCLikelihoodBins(100),
 		dDIRCMinNumPhotons(0), dDIRCMaxNumPhotons(100),
-                dDIRCMinThetaC(0.6), dDIRCMaxThetaC(1.0), dDIRCMinLikelihood(0), dDIRCMaxLikelihood(1000)
+        dDIRCMinThetaC(0.6), dDIRCMaxThetaC(1.0), dDIRCMinLikelihood(0), dDIRCMaxLikelihood(1000),
+        dNumFlightDistanceBins(200), dNumFlightSignificanceBins(200), dMaxFlightDistance(20.), dMaxFlightSignificance(40.)
 		{
 			dThrownPIDs.push_back(Gamma);  dThrownPIDs.push_back(Neutron);
 			dThrownPIDs.push_back(PiPlus);  dThrownPIDs.push_back(KPlus);  dThrownPIDs.push_back(Proton);
@@ -116,6 +117,9 @@ class DHistogramAction_PID : public DAnalysisAction
 		unsigned int dDIRCNumPhotonsBins, dDIRCThetaCBins, dDIRCLikelihoodBins, dDIRCMinNumPhotons, dDIRCMaxNumPhotons;
                 double dDIRCMinThetaC, dDIRCMaxThetaC;
                 double dDIRCMinLikelihood, dDIRCMaxLikelihood;
+                
+        unsigned int dNumFlightDistanceBins, dNumFlightSignificanceBins;
+        double dMaxFlightDistance, dMaxFlightSignificance;
 
 		deque<Particle_t> dThrownPIDs;
 
@@ -124,6 +128,7 @@ class DHistogramAction_PID : public DAnalysisAction
 
 		void Fill_ChargedHists(const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
 		void Fill_NeutralHists(const DNeutralParticleHypothesis* locNeutralParticleHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
+		void Fill_DecayingHists(const DKinematicData *locInitiaParticle, std::shared_ptr<const DKinFitParticle> locDecayingParticle, const DReactionStepVertexInfo *locStepVertexInfo);
 
 		DetectorSystem_t SYS_CDC_AMP;
 
@@ -153,6 +158,14 @@ class DHistogramAction_PID : public DAnalysisAction
 		map<Particle_t, TH2I*> dHistMap_PVsTheta_NegativeBeta;
 
 		map<pair<Particle_t, Particle_t>, TH1I*> dHistMap_PIDFOMForTruePID;
+
+		map<Particle_t, TH1I*> dHistMap_FlightDistance; 
+		map<Particle_t, TH1I*> dHistMap_FlightSignificance; 
+
+		map<Particle_t, TH2I*> dHistMap_FlightDistanceVsP; 
+		map<Particle_t, TH2I*> dHistMap_FlightDistanceVsTheta; 
+		map<Particle_t, TH2I*> dHistMap_FlightSignificanceVsP; 
+		map<Particle_t, TH2I*> dHistMap_FlightSignificanceVsTheta; 
 
 		map<Particle_t, TH1I*> dHistMap_NumPhotons_DIRC;
                 map<Particle_t, TH2I*> dHistMap_ThetaCVsP_DIRC;

--- a/src/libraries/ANALYSIS/DReaction.cc
+++ b/src/libraries/ANALYSIS/DReaction.cc
@@ -70,6 +70,31 @@ vector<Particle_t> DReaction::Get_MissingPIDs(int locStepIndex, Charge_t locChar
 	return locFinalPIDs;
 }
 
+vector<Particle_t> DReaction::Get_DecayingPIDs(int locStepIndex, Charge_t locCharge, bool locIncludeDuplicatesFlag) const
+{
+	vector<Particle_t> locFinalPIDs;
+	for(size_t locLoopStepIndex = 0; locLoopStepIndex < dReactionSteps.size(); ++locLoopStepIndex)
+	{
+		if((locStepIndex != -1) && (int(locLoopStepIndex) != locStepIndex))
+			continue;
+
+		auto locStep = dReactionSteps[locLoopStepIndex];
+		for(size_t locPIDIndex = 0; locPIDIndex < locStep->Get_NumFinalPIDs(); ++locPIDIndex)
+		{
+			Particle_t locPID = locStep->Get_FinalPID(locPIDIndex);
+			if(Is_CorrectCharge(locPID, locCharge) && IsDetachedVertex(locPID) && !Is_FinalStateParticle(locPID))
+				locFinalPIDs.push_back(locPID);
+		}
+	}
+
+	if(!locIncludeDuplicatesFlag)
+	{
+		std::sort(locFinalPIDs.begin(), locFinalPIDs.end()); //must sort first or else std::unique won't do what we want!
+		locFinalPIDs.erase(std::unique(locFinalPIDs.begin(), locFinalPIDs.end()), locFinalPIDs.end());
+	}
+	return locFinalPIDs;
+}
+
 void DReaction::Set_MaxPhotonRFDeltaT(double locMaxPhotonRFDeltaT)
 {
 	cout << "WARNING: USING DReaction::Set_MaxPhotonRFDeltaT() IS DEPRECATED. PLEASE SWITCH TO Set_NumPlusMinusRFBunches()." << endl;

--- a/src/libraries/ANALYSIS/DReaction.h
+++ b/src/libraries/ANALYSIS/DReaction.h
@@ -88,6 +88,7 @@ class DReaction : public JObject
 		vector<Particle_t> Get_FinalPIDs(int locStepIndex = -1, bool locIncludeMissingFlag = true, bool locIncludeDecayingFlag = true,
 		Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
 		vector<Particle_t> Get_MissingPIDs(int locStepIndex = -1, Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
+		vector<Particle_t> Get_DecayingPIDs(int locStepIndex = -1, Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
 
 		// GET ANALYSIS ACTIONS:
 		size_t Get_NumAnalysisActions(void) const{return dAnalysisActions.size();}

--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -1771,7 +1771,8 @@ bool DGeometry::GetCCALZ(double &z_ccal) const
    bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);
 
    if(!good){
-      _DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
+	  // NEED TO RETHINK ERROR REPORTING FOR OPTIONAL DETECTOR ELEMENTS
+      //_DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;  
       z_ccal = 1279.376;   
       return false;
    }else{
@@ -1809,8 +1810,7 @@ bool DGeometry::GetFCALPosition(double &x,double &y,double &z) const{
     return false;
   }else{
     x=ForwardEMcalpos[0],y=ForwardEMcalpos[1],z=ForwardEMcalpos[2];
-    _DBG_ << "FCAL position: (x,y,z)=(" << x <<"," << y << "," << z << ")"
-	  <<endl;
+    //_DBG_ << "FCAL position: (x,y,z)=(" << x <<"," << y << "," << z << ")"<<endl;
     return true;
   }
 }
@@ -1820,13 +1820,13 @@ bool DGeometry::GetCCALPosition(double &x,double &y,double &z) const{
   bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);
   
   if(!good){
-    _DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
+    //_DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
     x=0.,y=0.,z=0.;
     return false;
   }else{
     x=ComptonEMcalpos[0],y=ComptonEMcalpos[1],z=ComptonEMcalpos[2]; 
-    _DBG_ << "CCAL position: (x,y,z)=(" << ComptonEMcalpos[0] <<","
-	  << ComptonEMcalpos[1]<<","<<ComptonEMcalpos[2]<< ")" << endl;
+    //_DBG_ << "CCAL position: (x,y,z)=(" << ComptonEMcalpos[0] <<","
+	// << ComptonEMcalpos[1]<<","<<ComptonEMcalpos[2]<< ")" << endl;
     return true;
   }
 }
@@ -1840,7 +1840,7 @@ bool DGeometry::GetDIRCZ(double &z_dirc) const
   bool good = Get("//section/composition/posXYZ[@volume='DIRC']/@X_Y_Z",dirc_face);
 
   if(!good){
-    _DBG_<<"Unable to retrieve DIRC position."<<endl;
+    //_DBG_<<"Unable to retrieve DIRC position."<<endl;
     z_dirc=0.0;
     return false;
   }
@@ -1852,7 +1852,7 @@ bool DGeometry::GetDIRCZ(double &z_dirc) const
     Get("//composition[@name='DIRC']/posXYZ[@volume='DRCC']/@X_Y_Z", dirc_shift);
     z_dirc=dirc_face[2]+dirc_plane[2]+dirc_shift[2] + 0.8625; // last shift is the average center of quartz bar (585.862)
 
-    jout << "DIRC z position = " << z_dirc << " cm." << endl;
+    //jout << "DIRC z position = " << z_dirc << " cm." << endl;
     return true;
   }
 }
@@ -1866,7 +1866,7 @@ bool DGeometry::GetTRDZ(vector<double> &z_trd) const
    bool good = Get("//section/composition/posXYZ[@volume='TRDGEM']/@X_Y_Z",trd_origin);
    
    if(!good){
-     _DBG_<<"Unable to retrieve TRD position."<<endl;
+     //_DBG_<<"Unable to retrieve TRD position."<<endl;
      return false;
    }
    else{ 

--- a/src/libraries/TAGGER/DTAGHGeometry.cc
+++ b/src/libraries/TAGGER/DTAGHGeometry.cc
@@ -24,11 +24,26 @@
 
 const unsigned int DTAGHGeometry::kCounterCount = 274;
 
+// Only print messages for one thread whenever run number change
+static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+static set<int> runs_announced;
+    
+
 //---------------------------------
 // DTAGHGeometry    (Constructor)
 //---------------------------------
 DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
 {
+   // keep track of which runs we print out messages for
+   int32_t runnumber = loop->GetJEvent().GetRunNumber();
+   pthread_mutex_lock(&print_mutex);
+   bool print_messages = false;
+   if(runs_announced.find(runnumber) == runs_announced.end()){
+	  print_messages = true;
+	  runs_announced.insert(runnumber);
+   }
+   pthread_mutex_unlock(&print_mutex);
+
    /* read tagger set endpoint energy from calibdb */
    std::map<string,double> result1;
    loop->GetCalib("/PHOTON_BEAM/endpoint_energy", result1);
@@ -62,7 +77,6 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
       }
    }
 
-
    int status = 0;
    m_endpoint_energy_calib_GeV = 0.;
    
@@ -79,7 +93,8 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
      } else {
        m_endpoint_energy_calib_GeV  = result3["TAGGER_CALIB_ENERGY"];
 
-       printf(" Correct Beam Photon Energy  (TAGH)   %f \n\n", m_endpoint_energy_calib_GeV);
+	   if(print_messages)
+       	  jout << " Correct Beam Photon Energy (TAGH) = " << m_endpoint_energy_calib_GeV << " (GeV)" << std::endl;
 
      }
    }

--- a/src/libraries/TOF/DTOFHit_factory.cc
+++ b/src/libraries/TOF/DTOFHit_factory.cc
@@ -209,7 +209,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
       
     case 1:  // walk corrections based on Integral values
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 1"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 1"<<endl;
 	string locTOFTimewalkTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms";
 	if(eventLoop->GetCalib(locTOFTimewalkTable.c_str(), timewalk_parameters)){
 	  jout << "Error loading "<<locTOFTimewalkTable<<" !" << endl;
@@ -223,7 +223,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 
     case 2:  // walk correction based on peak Amplitudes single function 
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 2"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 2"<<endl;
 	USE_AMP_4WALKCORR = 1;
 	string locTOFTimewalkAMPTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms_AMP";
 	if(eventLoop->GetCalib(locTOFTimewalkAMPTable.c_str(), timewalk_parameters_AMP)){
@@ -238,7 +238,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
       
     case 3:
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 3"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 3"<<endl;
 	USE_NEWAMP_4WALKCORR = 1;
 	string locTOFChanOffsetNEWAMPTable = tofGeom.Get_CCDB_DirectoryName() + "/timing_offsets_NEWAMP";
 	if(eventLoop->GetCalib(locTOFChanOffsetNEWAMPTable.c_str(), raw_tdc_offsets)) {
@@ -253,7 +253,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 
     case 4:
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 4"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 4"<<endl;
 	USE_NEW_WALK_NEW = 1;
 	string locTOFTimewalkNEWTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms_5PAR";
 	if(eventLoop->GetCalib(locTOFTimewalkNEWTable.c_str(), timewalk_parameters_5PAR)){

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -27,6 +27,9 @@
 #define CHISQ_DELTA 0.01
 #define MIN_ITER 3
 
+// Only print messages for one thread whenever run number change
+static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+static set<int> runs_announced;
 
 // Local boolean routines for sorting
 //bool static DKalmanSIMDHit_cmp(DKalmanSIMDHit_t *a, DKalmanSIMDHit_t *b){
@@ -275,7 +278,17 @@ double DTrackFitterKalmanSIMD::fdc_drift_distance(double time,double Bz) const {
 DTrackFitterKalmanSIMD::DTrackFitterKalmanSIMD(JEventLoop *loop):DTrackFitter(loop){
    FactorForSenseOfRotation=(bfield->GetBz(0.,0.,65.)>0.)?-1.:1.;
 
-   // Some useful values
+   // keep track of which runs we print out messages for
+   int32_t runnumber = loop->GetJEvent().GetRunNumber();
+   pthread_mutex_lock(&print_mutex);
+   bool print_messages = false;
+   if(runs_announced.find(runnumber) == runs_announced.end()){
+	  print_messages = true;
+	  runs_announced.insert(runnumber);
+   }
+   pthread_mutex_unlock(&print_mutex);
+
+  // Some useful values
    two_m_e=2.*ELECTRON_MASS;
    m_e_sq=ELECTRON_MASS*ELECTRON_MASS;
 
@@ -630,9 +643,11 @@ DTrackFitterKalmanSIMD::DTrackFitterKalmanSIMD(JEventLoop *loop):DTrackFitter(lo
    jcalib->Get("PHOTON_BEAM/beam_spot",beam_vals);
    beam_center.Set(beam_vals["x"],beam_vals["y"]); 
    beam_dir.Set(beam_vals["dxdz"],beam_vals["dydz"]);
-   jout << " Beam spot: x=" << beam_center.X() << " y=" << beam_center.Y()
-	<< " z=" << beam_vals["z"]
-	<< " dx/dz=" << beam_dir.X() << " dy/dz=" << beam_dir.Y() << endl;
+
+   if(print_messages)
+	   jout << " Beam spot: x=" << beam_center.X() << " y=" << beam_center.Y()
+			<< " z=" << beam_vals["z"]
+			<< " dx/dz=" << beam_dir.X() << " dy/dz=" << beam_dir.Y() << endl;
    beam_z0=beam_vals["z"];
    
    // Inform user of some configuration settings

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -167,9 +167,6 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 	dSourceComboP4Handler = new DSourceComboP4Handler(nullptr, false);
 	dSourceComboTimeHandler = new DSourceComboTimeHandler(nullptr, nullptr, nullptr);
 	
-	double locKinFitChiSqCut = -1.;
-	gPARMS->SetDefaultParameter("REACTIONFILTER:KINFIT_CHISQCUT", locKinFitChiSqCut, "Maximum value of the kinematic fit chi^2/d.o.f. to keep (default: all)");
-
 
 	auto locInputTuple = Parse_Input();
 	auto locReactions = Create_Reactions(locInputTuple);
@@ -197,8 +194,8 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 
 		// KINEMATIC FIT
 		locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-		if(locKinFitChiSqCut > 0.)
-			locReaction->Add_AnalysisAction(new DCutAction_KinFitChiSq(locReaction, locKinFitChiSqCut));
+		if(dKinFitChiSqCut > 0.)
+			locReaction->Add_AnalysisAction(new DCutAction_KinFitChiSq(locReaction, dKinFitChiSqCut));
 
 		//POST-KINFIT PID CUTS
 		Add_PostKinfitTimingCuts(locReaction);

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -191,7 +191,17 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 			_data.push_back(locReaction); //Register the DReaction with the factory
 			continue;
 		}
-
+		
+		// OTHER OPTIONAL CUTS
+		if(dFlightSignificanceCut>0.) {
+			auto locDecayingPIDs = locReaction->Get_DecayingPIDs();
+			for(auto locPID : locDecayingPIDs) {
+				stringstream ss;
+				ss << "FltDist" << dFlightSignificanceCut << "Cut_" << locPID;
+				locReaction->Add_AnalysisAction(new DCutAction_FlightSignificance(locReaction, true, dFlightSignificanceCut, locPID, ss.str()));
+			}
+		}
+		
 		// KINEMATIC FIT
 		locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
 		if(dKinFitChiSqCut > 0.)

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -166,6 +166,10 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 	//INIT
 	dSourceComboP4Handler = new DSourceComboP4Handler(nullptr, false);
 	dSourceComboTimeHandler = new DSourceComboTimeHandler(nullptr, nullptr, nullptr);
+	
+	double locKinFitChiSqCut = -1.;
+	gPARMS->SetDefaultParameter("REACTIONFILTER:KINFIT_CHISQCUT", locKinFitChiSqCut, "Maximum value of the kinematic fit chi^2/d.o.f. to keep (default: all)");
+
 
 	auto locInputTuple = Parse_Input();
 	auto locReactions = Create_Reactions(locInputTuple);
@@ -193,6 +197,8 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 
 		// KINEMATIC FIT
 		locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+		if(locKinFitChiSqCut > 0.)
+			locReaction->Add_AnalysisAction(new DCutAction_KinFitChiSq(locReaction, locKinFitChiSqCut));
 
 		//POST-KINFIT PID CUTS
 		Add_PostKinfitTimingCuts(locReaction);

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
@@ -34,6 +34,7 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 			SetFactoryFlag(PERSISTANT);
 			
 			gPARMS->SetDefaultParameter("REACTIONFILTER:KINFIT_CHISQCUT", dKinFitChiSqCut, "Maximum value of the kinematic fit chi^2/d.o.f. to keep (default: all)");
+			gPARMS->SetDefaultParameter("REACTIONFILTER:FLIGHTSIG_CUT", dFlightSignificanceCut, "Minimum value of the  (default: no cut)");
 
 		}
 		const char* Tag(void){return "ReactionFilter";}
@@ -69,6 +70,7 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 		deque<DReactionStep*> dReactionStepPool; //to prevent memory leaks
 		
 		double dKinFitChiSqCut = -1.;
+		double dFlightSignificanceCut = -1.;
 
 };
 

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
@@ -32,6 +32,9 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 		{
 			// This is so that the created DReaction objects persist throughout the life of the program instead of being cleared each event. 
 			SetFactoryFlag(PERSISTANT);
+			
+			gPARMS->SetDefaultParameter("REACTIONFILTER:KINFIT_CHISQCUT", dKinFitChiSqCut, "Maximum value of the kinematic fit chi^2/d.o.f. to keep (default: all)");
+
 		}
 		const char* Tag(void){return "ReactionFilter";}
 
@@ -64,6 +67,9 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 		DSourceComboP4Handler* dSourceComboP4Handler = nullptr;
 		DSourceComboTimeHandler* dSourceComboTimeHandler = nullptr;
 		deque<DReactionStep*> dReactionStepPool; //to prevent memory leaks
+		
+		double dKinFitChiSqCut = -1.;
+
 };
 
 #endif // _DReaction_factory_ReactionFilter_


### PR DESCRIPTION
A few different partially related changes:

* New histogram and cut actions for particles with displaced vertices
* New OPTIONAL ReactionFilter options to help reduce file size
* Reduce the number of informational lines printed out to the screen by eliminating unncessary geometry printouts & only printing other messages once per run.  (plans are being discussed to reduce the XML error messages)