### PR TITLE
Added a function to the DFCALShower_factory which will provide a log-…

### DIFF
--- a/src/libraries/FCAL/DFCALShower.cc
+++ b/src/libraries/FCAL/DFCALShower.cc
@@ -7,6 +7,7 @@ DFCALShower::DFCALShower():ExyztCovariance(5)
   fEnergy = 0.;
   fTime = 0.;
   fPosition.SetXYZ(0., 0., 0.);
+  fPosition_log.SetXYZ(0., 0., 0.);
   fTimeTr = 1E3;
   fDocaTr = 1E3;
   fSumU = 0;
@@ -35,6 +36,11 @@ void DFCALShower::setTime(const double time)
 void DFCALShower::setPosition(const DVector3& aPosition ) 
 {
   fPosition = aPosition;
+}
+
+void DFCALShower::setPosition_log(const DVector3& aPosition_log ) 
+{
+  fPosition_log = aPosition_log;
 }
 
 void DFCALShower::setDocaTrack( const double docaTrack ){ fDocaTr = docaTrack; }

--- a/src/libraries/FCAL/DFCALShower.h
+++ b/src/libraries/FCAL/DFCALShower.h
@@ -31,6 +31,7 @@ class DFCALShower:public JObject{
   //  for the depth correction, the default vertex is in the target center
   DVector3 getPosition() const; 
   DVector3 getPositionError() const;
+  DVector3 getPosition_log() const;
   double getEnergy() const;  
   double getTime() const;
   double getDocaTrack() const;
@@ -42,7 +43,8 @@ class DFCALShower:public JObject{
   int getNumBlocks() const;
 
   // set shower information
-  void setPosition( const DVector3& aPosition );  
+  void setPosition( const DVector3& aPosition );
+  void setPosition_log( const DVector3& aPosition_log );
   void setEnergy( const double energy );  
   void setTime( const double time );
   void setDocaTrack( const double docaTrack );
@@ -138,6 +140,7 @@ class DFCALShower:public JObject{
   double fEnergy; 
   double fTime; 
   DVector3 fPosition;        // Shower position in the FCAL
+  DVector3 fPosition_log;    // log-weighted shower position
   double fTimeTr;
   double fDocaTr;
   double fSumU;
@@ -151,6 +154,11 @@ class DFCALShower:public JObject{
 inline DVector3 DFCALShower::getPosition() const
 {
   return fPosition;
+}
+
+inline DVector3 DFCALShower::getPosition_log() const
+{
+  return fPosition_log;
 }
 
 inline double DFCALShower::getEnergy() const

--- a/src/libraries/FCAL/DFCALShower_factory.h
+++ b/src/libraries/FCAL/DFCALShower_factory.h
@@ -38,6 +38,9 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
 				     double &Ecorrected,
 				     DVector3 &pos_corrected, double &errZ,
 				     const DVector3 *aVertex);
+  
+  void GetLogWeightedPosition( const DFCALCluster* cluster, DVector3 &pos_log, 
+  				     double Egamma, const DVector3 *aVertex  );
 
   unsigned int getMaxHit( const vector< const DFCALHit* >& hitVec ) const;
 
@@ -84,6 +87,8 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
   int VERBOSE;
   string COVARIANCEFILENAME;
   TH2F *CovarianceLookupTable[5][5];
+  
+  double log_position_const;
 };
 
 


### PR DESCRIPTION
…weighted position calculation. The log-constant (w0) by default is set to 4.2, but can be varied from the command line when running hd_root.

Nothing should be changed in the standard reconstruction, this is just added in as a second option for position calculation.

At the moment, this is only a log-weighted calculation with no additional linear (s-shape) corrections applied. If needed, they can be added later.