### PR TITLE
TOF energy calibration features

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -955,7 +955,7 @@ DLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DReaction* locReactio
 	return locFinalStateP4;
 }
 
-int DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers) const
+int DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers, int &locNumber_UnusedShowers_Quality, double &locEnergy_UnusedShowers_Quality) const
 {
 	DVector3 locVertex(0.0, 0.0, dTargetZCenter);
 	const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
@@ -964,8 +964,10 @@ int DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, cons
 	vector<const DNeutralShower*> locUnusedNeutralShowers;
 	Get_UnusedNeutralShowers(locEventLoop, locParticleCombo, locUnusedNeutralShowers);
 	
-	locEnergy_UnusedShowers = 0.; 
 	int locNumber_UnusedShowers = 0;
+	locEnergy_UnusedShowers = 0.;
+	locEnergy_UnusedShowers_Quality = 0.; 
+	locNumber_UnusedShowers_Quality = 0;
 	for(size_t loc_i = 0; loc_i < locUnusedNeutralShowers.size(); ++loc_i) {
 		const DNeutralShower* locUnusedNeutralShower = locUnusedNeutralShowers[loc_i];
 
@@ -979,6 +981,11 @@ int DAnalysisUtilities::Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, cons
 
 		locEnergy_UnusedShowers += locUnusedNeutralShower->dEnergy;
 		locNumber_UnusedShowers++;
+
+		if(locUnusedNeutralShower->dQuality > 0.5) {
+			locEnergy_UnusedShowers_Quality += locUnusedNeutralShower->dEnergy;
+	                locNumber_UnusedShowers_Quality++;
+		}
 	}
 	
 	return locNumber_UnusedShowers;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -120,7 +120,7 @@ class DAnalysisUtilities : public JObject
 		DLorentzVector Calc_FinalStateP4(const DReaction* locReaction, const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, bool locUseKinFitDataFlag) const;
 		DLorentzVector Calc_FinalStateP4(const DReaction* locReaction, const DParticleCombo* locParticleCombo, size_t locStepIndex, set<size_t> locToIncludeIndices, set<pair<const JObject*, unsigned int> >& locSourceObjects, bool locUseKinFitDataFlag) const;
 
-		int Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers) const;
+		int Calc_Energy_UnusedShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locEnergy_UnusedShowers, int &locNumber_UnusedShowers_Quality, double &locEnergy_UnusedShowers_Quality) const;
 		int Calc_Momentum_UnusedTracks(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, double &locSumPMag_UnusedTracks, TVector3 &locSumP3_UnusedTracks) const;
 
 		// These routines use the MEAURED particle data.  For the kinfit-data result, just use the error matrix from the missing particle

--- a/src/libraries/ANALYSIS/DCutActions.cc
+++ b/src/libraries/ANALYSIS/DCutActions.cc
@@ -419,6 +419,21 @@ bool DCutAction_KinFitFOM::Perform_Action(JEventLoop* locEventLoop, const DParti
 	return (locKinFitResults->Get_ConfidenceLevel() > dMinimumConfidenceLevel);
 }
 
+string DCutAction_KinFitChiSq::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMaximumChiSq;
+	return locStream.str();
+}
+
+bool DCutAction_KinFitChiSq::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	const DKinFitResults* locKinFitResults = locParticleCombo->Get_KinFitResults();
+	if(locKinFitResults == NULL)
+		return false;
+	return (locKinFitResults->Get_ChiSq()/locKinFitResults->Get_NDF() < dMaximumChiSq);
+}
+
 void DCutAction_BDTSignalCombo::Initialize(JEventLoop* locEventLoop)
 {
 	if(dCutAction_TrueBeamParticle == nullptr)
@@ -1206,6 +1221,150 @@ bool DCutAction_NoPIDHit::Perform_Action(JEventLoop* locEventLoop, const DPartic
 
 	return true;
 }
+
+string DCutAction_FlightDistance::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dMinFlightDistance;
+	return locStream.str();
+}
+
+bool DCutAction_FlightDistance::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	DKinFitType locKinFitType = Get_Reaction()->Get_KinFitType();
+
+	// for now, require a kinematic fit to make these selections, assuming that the common decay vertex
+	// is constrained in the fit
+	if(!Get_UseKinFitResultsFlag())  
+		return true;
+
+	vector<const DReactionVertexInfo*> locVertexInfos;
+	locEventLoop->Get(locVertexInfos);
+	
+	// figure out what the right DReactionVertexInfo is
+	const DReactionVertexInfo *locReactionVertexInfo = nullptr;
+	for(auto& locVertexInfo : locVertexInfos) {
+		auto locVertexReactions = locVertexInfo->Get_Reactions();
+		if(find(locVertexReactions.begin(), locVertexReactions.end(), Get_Reaction()) != locVertexReactions.end()) {
+			locReactionVertexInfo = locVertexInfo;
+			break;
+		}
+	}
+
+	// check each individual decaying particle (if they exist)
+	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
+	{	
+		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
+		//auto locParticles = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticles(Get_Reaction()->Get_ReactionStep(loc_i), false, false, d_AllCharges) : locParticleComboStep->Get_FinalParticles_Measured(Get_Reaction()->Get_ReactionStep(loc_i), d_AllCharges);
+
+		if((dPID != Unknown) && (locParticleComboStep->Get_InitialParticle()->PID() != dPID))
+			continue;
+
+		// fill info on decaying particles, which is on the particle combo step level
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
+			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
+			// was performed where the vertex is constrained
+			// TODO: Cleverly handle the other cases
+	
+			// pull out information related to the kinematic fit
+			if( !Get_UseKinFitResultsFlag() ) continue; 
+			if( locReactionVertexInfo == nullptr ) continue; 
+			
+			auto locKinFitParticle = locParticleComboStep->Get_InitialKinFitParticle();
+		
+			// extract the info about the vertex, to make sure that the information that we 
+			// need to calculate displaced vertices is there
+			auto locStepVertexInfo = locReactionVertexInfo->Get_StepVertexInfo(loc_i);
+
+			auto locParentVertexInfo = locStepVertexInfo->Get_ParentVertexInfo();
+			auto locVertexKinFitFlag = ((locKinFitType != d_P4Fit) && (locKinFitType != d_NoFit));
+			
+			auto locPathLength = locKinFitParticle->Get_PathLength();
+			
+			if(locPathLength < dMinFlightDistance)
+				return false;
+		}
+		
+	}
+
+	return true;
+}
+
+
+string DCutAction_FlightSignificance::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dMinFlightSignificance;
+	return locStream.str();
+}
+
+bool DCutAction_FlightSignificance::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{
+	//if dPID = Unknown, apply cut to all PIDs
+	DKinFitType locKinFitType = Get_Reaction()->Get_KinFitType();
+
+	// for now, require a kinematic fit to make these selections, assuming that the common decay vertex
+	// is constrained in the fit
+	if(!Get_UseKinFitResultsFlag())  
+		return true;
+
+	vector<const DReactionVertexInfo*> locVertexInfos;
+	locEventLoop->Get(locVertexInfos);
+	
+	// figure out what the right DReactionVertexInfo is
+	const DReactionVertexInfo *locReactionVertexInfo = nullptr;
+	for(auto& locVertexInfo : locVertexInfos) {
+		auto locVertexReactions = locVertexInfo->Get_Reactions();
+		if(find(locVertexReactions.begin(), locVertexReactions.end(), Get_Reaction()) != locVertexReactions.end()) {
+			locReactionVertexInfo = locVertexInfo;
+			break;
+		}
+	}
+
+	// check each individual decaying particle (if they exist)
+	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
+	{	
+		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
+		//auto locParticles = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticles(Get_Reaction()->Get_ReactionStep(loc_i), false, false, d_AllCharges) : locParticleComboStep->Get_FinalParticles_Measured(Get_Reaction()->Get_ReactionStep(loc_i), d_AllCharges);
+
+		if((dPID != Unknown) && (locParticleComboStep->Get_InitialParticle()->PID() != dPID))
+			continue;
+
+		// fill info on decaying particles, which is on the particle combo step level
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
+			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
+			// was performed where the vertex is constrained
+			// TODO: Cleverly handle the other cases
+	
+			// pull out information related to the kinematic fit
+			if( !Get_UseKinFitResultsFlag() ) continue; 
+			if( locReactionVertexInfo == nullptr ) continue; 
+			
+			auto locKinFitParticle = locParticleComboStep->Get_InitialKinFitParticle();
+		
+			// extract the info about the vertex, to make sure that the information that we 
+			// need to calculate displaced vertices is there
+			auto locStepVertexInfo = locReactionVertexInfo->Get_StepVertexInfo(loc_i);
+
+			auto locParentVertexInfo = locStepVertexInfo->Get_ParentVertexInfo();
+			auto locVertexKinFitFlag = ((locKinFitType != d_P4Fit) && (locKinFitType != d_NoFit));
+			
+			auto locPathLength = locKinFitParticle->Get_PathLength();
+			auto locPathLengthSigma = locKinFitParticle->Get_PathLengthUncertainty();
+			double locPathLengthSignificance = locPathLength / locPathLengthSigma;
+	
+			if(locPathLengthSignificance < dMinFlightSignificance)
+				return false;
+
+		}
+		
+	}
+
+	return true;
+}
+
+
 
 void DCutAction_OneVertexKinFit::Initialize(JEventLoop* locEventLoop)
 {

--- a/src/libraries/ANALYSIS/DCutActions.h
+++ b/src/libraries/ANALYSIS/DCutActions.h
@@ -45,6 +45,7 @@ DCutAction_ProductionVertexZ
 DCutAction_AllVertexZ
 DCutAction_MaxTrackDOCA
 DCutAction_KinFitFOM
+DCutAction_KinFitChiSq
 
 DCutAction_MissingMass
 DCutAction_MissingMassSquared
@@ -59,6 +60,9 @@ DCutAction_TrackFCALShowerEOverP
 DCutAction_PIDDeltaT
 DCutAction_PIDTimingBeta
 DCutAction_NoPIDHit
+
+DCutAction_FlightDistance
+DCutAction_FlightSignificance
 
 DCutAction_OneVertexKinFit
 */
@@ -357,6 +361,23 @@ class DCutAction_KinFitFOM : public DAnalysisAction
 
 		const string dKinFitName;
 		double dMinimumConfidenceLevel;
+};
+
+class DCutAction_KinFitChiSq : public DAnalysisAction
+{
+	public:
+		DCutAction_KinFitChiSq(const DReaction* locReaction, double locMaximumChiSq, string locActionUniqueString = "") : 
+		DAnalysisAction(locReaction, "Cut_KinFitFOM", true, locActionUniqueString), dMaximumChiSq(locMaximumChiSq){}
+
+		string Get_ActionName(void) const;
+		inline void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+
+	private:
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		const string dKinFitName;
+		double dMaximumChiSq;
 };
 
 class DCutAction_MissingMass : public DAnalysisAction
@@ -728,6 +749,54 @@ class DCutAction_OneVertexKinFit : public DAnalysisAction
 		TH1I* dHist_VertexZ;
 		TH2I* dHist_VertexYVsX;
 };
+
+class DCutAction_FlightDistance : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all relevant PIDs
+
+	public:
+
+		DCutAction_FlightDistance(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinFlightDistance, Particle_t locPID = Unknown, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_FlightDistance", locUseKinFitResultsFlag, locActionUniqueString),
+		dMinFlightDistance(locMinFlightDistance), dPID(locPID) {}
+
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		double dMinFlightDistance;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
+class DCutAction_FlightSignificance : public DAnalysisAction
+{
+	//if dPID = Unknown, apply cut to all relevant PIDs
+
+	public:
+
+		DCutAction_FlightSignificance(const DReaction* locReaction, bool locUseKinFitResultsFlag, double locMinFlightSignificance, Particle_t locPID = Unknown, string locActionUniqueString = "") :
+		DAnalysisAction(locReaction, "Cut_FlightSignificance", locUseKinFitResultsFlag, locActionUniqueString),
+		dMinFlightSignificance(locMinFlightSignificance), dPID(locPID) {}
+
+		void Initialize(JEventLoop* locEventLoop){}
+		void Run_Update(JEventLoop* locEventLoop){}
+		string Get_ActionName(void) const;
+
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+		double dMinFlightSignificance;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
+
 
 #endif // _DCutActions_
 

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -793,6 +793,8 @@ void DEventWriterROOT::Create_Branches_Combo(DTreeBranchRegister& locBranchRegis
 	}
 	locBranchRegister.Register_FundamentalArray<UChar_t>("NumUnusedShowers", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>("Energy_UnusedShowers", locNumComboString, dInitNumComboArraySize);
+	locBranchRegister.Register_FundamentalArray<UChar_t>("NumUnusedShowers_Quality", locNumComboString, dInitNumComboArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>("Energy_UnusedShowers_Quality", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>("SumPMag_UnusedTracks", locNumComboString, dInitNumComboArraySize);
 	locBranchRegister.Register_ClonesArray<TVector3>("SumP3_UnusedTracks", dInitNumComboArraySize);
 
@@ -1220,9 +1222,13 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 		
 		//ENERGY OF UNUSED SHOWERS (access to event loop required)
 		double locEnergy_UnusedShowers = 0.;
-		int locNumber_UnusedShowers = dAnalysisUtilities->Calc_Energy_UnusedShowers(locEventLoop, locParticleCombos[loc_i], locEnergy_UnusedShowers);
+		double locEnergy_UnusedShowers_Quality = 0.;
+		int locNumber_UnusedShowers_Quality = 0;
+		int locNumber_UnusedShowers = dAnalysisUtilities->Calc_Energy_UnusedShowers(locEventLoop, locParticleCombos[loc_i], locEnergy_UnusedShowers, locNumber_UnusedShowers_Quality, locEnergy_UnusedShowers_Quality);
 		locTreeFillData->Fill_Array<UChar_t>("NumUnusedShowers", locNumber_UnusedShowers, loc_i);
 		locTreeFillData->Fill_Array<Float_t>("Energy_UnusedShowers", locEnergy_UnusedShowers, loc_i);
+		locTreeFillData->Fill_Array<UChar_t>("NumUnusedShowers_Quality", locNumber_UnusedShowers_Quality, loc_i);
+		locTreeFillData->Fill_Array<Float_t>("Energy_UnusedShowers_Quality", locEnergy_UnusedShowers_Quality, loc_i);
 
 		//MOMENTUM OF UNUSED TRACKS (access to event loop required)
 		double locSumPMag_UnusedTracks = 0;

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.cc
@@ -8,7 +8,8 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 
 	Run_Update(locEventLoop);
 
-	auto locDesiredPIDs = Get_Reaction()->Get_FinalPIDs(-1, false, false, d_AllCharges, false);
+	//auto locDesiredPIDs = Get_Reaction()->Get_FinalPIDs(-1, false, false, d_AllCharges, false);
+	auto locDesiredPIDs = Get_Reaction()->Get_FinalPIDs(-1, false, true, d_AllCharges, false);
 
 	vector<const DMCThrown*> locMCThrowns;
 	locEventLoop->Get(locMCThrowns);
@@ -25,7 +26,7 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 			locParticleROOTName = ParticleName_ROOT(locPID);
 			CreateAndChangeTo_Directory(locParticleName, locParticleName);
 
-			if(ParticleCharge(locPID) == 0)
+			if(ParticleCharge(locPID) == 0 && Is_FinalStateParticle(locPID))
 			{
 				//BCAL
 				CreateAndChangeTo_Directory("BCAL", "BCAL");
@@ -385,7 +386,7 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 			}
 
 			//no FOM for massive neutrals
-			if((ParticleCharge(locPID) != 0) || (locPID == Gamma))
+			if((ParticleCharge(locPID) != 0 && Is_FinalStateParticle(locPID)) || (locPID == Gamma))
 			{
 				// Overall Confidence Level
 				locHistName = "PIDConfidenceLevel";
@@ -397,6 +398,43 @@ void DHistogramAction_PID::Initialize(JEventLoop* locEventLoop)
 				locHistTitle = locParticleROOTName + string(", PID FOM = NaN;#theta#circ;p (GeV/c)");
 				dHistMap_PVsTheta_NaNPIDFOM[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNum2DThetaBins, dMinTheta, dMaxTheta, dNum2DPBins, dMinP, dMaxP);
 			}
+
+			// look at decaying particles
+			if(!Is_FinalStateParticle(locPID))
+			{			
+				// Flight Distance
+				locHistName = "FlightDistance";
+				locHistTitle = locParticleROOTName + string(" Flight Distance;Flight Distance (cm)");
+				dHistMap_FlightDistance[locPID] = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle, dNumFlightDistanceBins, 0.0, dMaxFlightDistance);
+
+				// Flight Distance Vs P
+				locHistName = "FlightDistanceVsP";
+				locHistTitle = locParticleROOTName + string(" Flight Distance;Flight Distance (cm);p (GeV/c)");
+				dHistMap_FlightDistanceVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNumFlightDistanceBins, 0.0, dMaxFlightDistance, dNum2DPBins, dMinP, dMaxP);
+
+				// Flight Distance Vs Theta
+				locHistName = "FlightDistanceVsTheta";
+				locHistTitle = locParticleROOTName + string(" Flight Distance;Flight Distance (cm);#theta#circ");
+				dHistMap_FlightDistanceVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNumFlightDistanceBins, 0.0, dMaxFlightDistance, dNum2DThetaBins, dMinTheta, dMaxTheta);
+
+
+				// Flight Distance
+				locHistName = "FlightSignificance";
+				locHistTitle = locParticleROOTName + string(" Flight Significance;Flight Significance (#sigma)");
+				dHistMap_FlightSignificance[locPID] = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle, dNumFlightSignificanceBins, 0.0, dMaxFlightSignificance);
+
+				// Flight Distance Vs P
+				locHistName = "FlightSignificanceVsP";
+				locHistTitle = locParticleROOTName + string(" Flight Significance;Flight Significance (#sigma);p (GeV/c)");
+				dHistMap_FlightSignificanceVsP[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNumFlightSignificanceBins, 0.0, dMaxFlightSignificance, dNum2DPBins, dMinP, dMaxP);
+
+				// Flight Distance Vs Theta
+				locHistName = "FlightSignificanceVsTheta";
+				locHistTitle = locParticleROOTName + string(" Flight Significance;Flight Significance (#sigma);#theta#circ");
+				dHistMap_FlightSignificanceVsTheta[locPID] = GetOrCreate_Histogram<TH2I>(locHistName, locHistTitle, dNumFlightSignificanceBins, 0.0, dMaxFlightSignificance, dNum2DThetaBins, dMinTheta, dMaxTheta);
+
+			}
+
 
 			gDirectory->cd("..");
 		} //end of PID loop
@@ -427,8 +465,21 @@ bool DHistogramAction_PID::Perform_Action(JEventLoop* locEventLoop, const DParti
 
 	const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
 
+	vector<const DReactionVertexInfo*> locVertexInfos;
+	locEventLoop->Get(locVertexInfos);
+	
+	// figure out what the right DReactionVertexInfo is
+	const DReactionVertexInfo *locReactionVertexInfo = nullptr;
+	for(auto& locVertexInfo : locVertexInfos) {
+		auto locVertexReactions = locVertexInfo->Get_Reactions();
+		if(find(locVertexReactions.begin(), locVertexReactions.end(), Get_Reaction()) != locVertexReactions.end()) {
+			locReactionVertexInfo = locVertexInfo;
+			break;
+		}
+	}
+
 	for(size_t loc_i = 0; loc_i < locParticleCombo->Get_NumParticleComboSteps(); ++loc_i)
-	{
+	{	
 		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_i);
 		auto locParticles = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticles(Get_Reaction()->Get_ReactionStep(loc_i), false, false, d_AllCharges) : locParticleComboStep->Get_FinalParticles_Measured(Get_Reaction()->Get_ReactionStep(loc_i), d_AllCharges);
 		for(size_t loc_j = 0; loc_j < locParticles.size(); ++loc_j)
@@ -440,15 +491,69 @@ bool DHistogramAction_PID::Perform_Action(JEventLoop* locEventLoop, const DParti
 				continue; //previously histogrammed
 
 			dPreviouslyHistogrammedParticles.insert(locHistInfo);
-			if(ParticleCharge(locParticles[loc_j]->PID()) != 0) //charged
-				Fill_ChargedHists(static_cast<const DChargedTrackHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
-			else //neutral
-				Fill_NeutralHists(static_cast<const DNeutralParticleHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+			if(Is_FinalStateParticle(locParticles[loc_j]->PID())) { 
+				if(ParticleCharge(locParticles[loc_j]->PID()) != 0) //charged
+					Fill_ChargedHists(static_cast<const DChargedTrackHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+				else //neutral
+					Fill_NeutralHists(static_cast<const DNeutralParticleHypothesis*>(locParticles[loc_j]), locMCThrownMatching, locEventRFBunch);
+			}
 		}
+
+		// fill info on decaying particles, which is on the particle combo step level
+		if(((locParticleComboStep->Get_InitialParticle()!=nullptr) && !Is_FinalStateParticle(locParticleComboStep->Get_InitialParticle()->PID()))) {  // decaying particles
+			// FOR NOW: we only calculate these displaced vertex quantities if a kinematic fit 
+			// was performed where the vertex is constrained
+			// TODO: Cleverly handle the other cases
+
+			// pull out information related to the kinematic fit
+			if( !Get_UseKinFitResultsFlag() ) continue; 
+			if( locReactionVertexInfo == nullptr ) continue; 
+
+			// extract the info about the vertex, to make sure that the information that we 
+			// need to calculate displaced vertices is there
+			auto locStepVertexInfo = locReactionVertexInfo->Get_StepVertexInfo(loc_i);
+
+			Fill_DecayingHists(locParticleComboStep->Get_InitialParticle(), locParticleComboStep->Get_InitialKinFitParticle(), locStepVertexInfo);
+		}
+		
 	}
 
 	return true;
 }
+
+void DHistogramAction_PID::Fill_DecayingHists(const DKinematicData *locInitialParticle, std::shared_ptr<const DKinFitParticle> locKinFitParticle, const DReactionStepVertexInfo *locStepVertexInfo)
+{
+	DKinFitType locKinFitType = Get_Reaction()->Get_KinFitType();
+
+	//Particle_t locPID = static_cast<Particle_t>(locKinFitParticle->Get_PID());
+	//double locP = locKinFitParticle->Get_Momentum().Mag();
+	//double locTheta = locKinFitParticle->Get_Momentum().Theta()*180.0/TMath::Pi();
+	Particle_t locPID = locInitialParticle->PID();
+	double locP = locInitialParticle->momentum().Mag();
+	double locTheta = locInitialParticle->momentum().Theta()*180.0/TMath::Pi();
+
+	// comment
+	auto locParentVertexInfo = locStepVertexInfo->Get_ParentVertexInfo();
+	auto locVertexKinFitFlag = ((locKinFitType != d_P4Fit) && (locKinFitType != d_NoFit));
+
+	if(IsDetachedVertex(locPID) && locVertexKinFitFlag && (locParentVertexInfo != nullptr) && locStepVertexInfo->Get_FittableVertexFlag() && locParentVertexInfo->Get_FittableVertexFlag())
+	{
+		auto locPathLength = locKinFitParticle->Get_PathLength();
+		auto locPathLengthSigma = locKinFitParticle->Get_PathLengthUncertainty();
+		double locPathLengthSignificance = locPathLength / locPathLengthSigma;
+
+		dHistMap_FlightDistance[locPID]->Fill(locPathLength);
+		dHistMap_FlightDistanceVsP[locPID]->Fill(locPathLength, locP);
+		dHistMap_FlightDistanceVsTheta[locPID]->Fill(locPathLength, locTheta);
+
+		dHistMap_FlightSignificance[locPID]->Fill(locPathLengthSignificance);
+		dHistMap_FlightSignificanceVsP[locPID]->Fill(locPathLengthSignificance, locP);
+		dHistMap_FlightSignificanceVsTheta[locPID]->Fill(locPathLengthSignificance, locTheta);
+
+	}
+
+}
+
 
 void DHistogramAction_PID::Fill_ChargedHists(const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch)
 {
@@ -1375,7 +1480,16 @@ void DHistogramAction_InvariantMass::Initialize(JEventLoop* locEventLoop)
 
 void DHistogramAction_InvariantMass::Run_Update(JEventLoop* locEventLoop)
 {
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	locGeometry->GetTargetZ(dTargetZCenter);
+
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1419,15 +1533,37 @@ bool DHistogramAction_InvariantMass::Perform_Action(JEventLoop* locEventLoop, co
 		//don't break: e.g. if multiple pi0's, histogram invariant mass of each one
 	}
 
+	// calculate accidental scaling factor (if needed)
+	double locWeight = 1.;
+	if(dSubtractAccidentals) {
+		auto locIsFirstStepBeam = DAnalysis::Get_IsFirstStepBeam(Get_Reaction());
+		if(locIsFirstStepBeam) {
+			const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
+			const DKinematicData* locBeamParticle = locParticleCombo->Get_ParticleComboStep(0)->Get_InitialParticle();
+			
+			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
+
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
+				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
+		}
+	}
+
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
 	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
 	Lock_Action();
 	{
-		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
-			dHist_InvariantMass->Fill(locMassesToFill[loc_i]);
-		for(size_t loc_i = 0; loc_i < loc2DMassesToFill.size(); ++loc_i)
-			dHist_InvariantMassVsBeamE->Fill(locBeam->energy(), loc2DMassesToFill[loc_i]);
+		if(dSubtractAccidentals) {
+			for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
+				dHist_InvariantMass->Fill(locMassesToFill[loc_i], locWeight);
+			for(size_t loc_i = 0; loc_i < loc2DMassesToFill.size(); ++loc_i)
+				dHist_InvariantMassVsBeamE->Fill(locBeam->energy(), loc2DMassesToFill[loc_i], locWeight);
+		} else {
+			for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
+				dHist_InvariantMass->Fill(locMassesToFill[loc_i]);
+			for(size_t loc_i = 0; loc_i < loc2DMassesToFill.size(); ++loc_i)
+				dHist_InvariantMassVsBeamE->Fill(locBeam->energy(), loc2DMassesToFill[loc_i]);
+		}
 	}
 	Unlock_Action();
 
@@ -1477,7 +1613,16 @@ void DHistogramAction_MissingMass::Initialize(JEventLoop* locEventLoop)
 
 void DHistogramAction_MissingMass::Run_Update(JEventLoop* locEventLoop)
 {
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	locGeometry->GetTargetZ(dTargetZCenter);
+
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1501,6 +1646,21 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 
 		locMassesToFill.push_back(pair<double, double>(locMissingP4.M(), locMissingP4.P()));
 	}
+	
+	// calculate accidental scaling factor (if needed)
+	double locWeight = 1.;
+	if(dSubtractAccidentals) {
+		auto locIsFirstStepBeam = DAnalysis::Get_IsFirstStepBeam(Get_Reaction());
+		if(locIsFirstStepBeam) {
+			const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
+			const DKinematicData* locBeamParticle = locParticleCombo->Get_ParticleComboStep(0)->Get_InitialParticle();
+			
+			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
+
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
+				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
+		}
+	}
 
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
@@ -1509,9 +1669,16 @@ bool DHistogramAction_MissingMass::Perform_Action(JEventLoop* locEventLoop, cons
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
 		{
-			dHist_MissingMass->Fill(locMassesToFill[loc_i].first);
-			dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
-			dHist_MissingMassVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
+			// only fill histograms with weights if needed, to avoid complications
+			if(dSubtractAccidentals) {
+				dHist_MissingMass->Fill(locMassesToFill[loc_i].first, locWeight);
+				dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first, locWeight);
+				dHist_MissingMassVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first, locWeight);
+			} else {
+				dHist_MissingMass->Fill(locMassesToFill[loc_i].first);
+				dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
+				dHist_MissingMassVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
+			}
 		}
 	}
 	Unlock_Action();
@@ -1562,7 +1729,16 @@ void DHistogramAction_MissingMassSquared::Initialize(JEventLoop* locEventLoop)
 
 void DHistogramAction_MissingMassSquared::Run_Update(JEventLoop* locEventLoop)
 {
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	locGeometry->GetTargetZ(dTargetZCenter);
+
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1587,6 +1763,21 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 		locMassesToFill.push_back(pair<double, double>(locMissingP4.M2(), locMissingP4.P()));
 	}
 
+	// calculate accidental scaling factor (if needed)
+	double locWeight = 1.;
+	if(dSubtractAccidentals) {
+		auto locIsFirstStepBeam = DAnalysis::Get_IsFirstStepBeam(Get_Reaction());
+		if(locIsFirstStepBeam) {
+			const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
+			const DKinematicData* locBeamParticle = locParticleCombo->Get_ParticleComboStep(0)->Get_InitialParticle();
+			
+			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
+
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
+				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
+		}
+	}
+
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
 	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
@@ -1594,9 +1785,15 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(JEventLoop* locEventLoo
 	{
 		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
 		{
-			dHist_MissingMassSquared->Fill(locMassesToFill[loc_i].first);
-			dHist_MissingMassSquaredVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
-			dHist_MissingMassSquaredVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
+			if(dSubtractAccidentals) {
+				dHist_MissingMassSquared->Fill(locMassesToFill[loc_i].first, locWeight);
+				dHist_MissingMassSquaredVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first, locWeight);
+				dHist_MissingMassSquaredVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first, locWeight);
+			} else {
+				dHist_MissingMassSquared->Fill(locMassesToFill[loc_i].first);
+				dHist_MissingMassSquaredVsBeamE->Fill(locBeamEnergy, locMassesToFill[loc_i].first);
+				dHist_MissingMassSquaredVsMissingP->Fill(locMassesToFill[loc_i].second, locMassesToFill[loc_i].first);
+			}
 		}
 	}
 	Unlock_Action();
@@ -1638,7 +1835,16 @@ void DHistogramAction_2DInvariantMass::Initialize(JEventLoop* locEventLoop)
 
 void DHistogramAction_2DInvariantMass::Run_Update(JEventLoop* locEventLoop)
 {
+	DApplication* locApplication = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	DGeometry *locGeometry = locApplication->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
+	locGeometry->GetTargetZ(dTargetZCenter);
+
 	locEventLoop->GetSingle(dAnalysisUtilities);
+
+	//BEAM BUNCH PERIOD
+	vector<double> locBeamPeriodVector;
+	locEventLoop->GetCalib("PHOTON_BEAM/RF/beam_period", locBeamPeriodVector);
+	dBeamBunchPeriod = locBeamPeriodVector[0];
 }
 
 bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
@@ -1682,13 +1888,33 @@ bool DHistogramAction_2DInvariantMass::Perform_Action(JEventLoop* locEventLoop, 
 		}
 	}
 
+	// calculate accidental scaling factor (if needed)
+	double locWeight = 1.;
+	if(dSubtractAccidentals) {
+		auto locIsFirstStepBeam = DAnalysis::Get_IsFirstStepBeam(Get_Reaction());
+		if(locIsFirstStepBeam) {
+			const DEventRFBunch* locEventRFBunch = locParticleCombo->Get_EventRFBunch();
+			const DKinematicData* locBeamParticle = locParticleCombo->Get_ParticleComboStep(0)->Get_InitialParticle();
+			
+			double locDeltaTRF = locBeamParticle->time() - (locEventRFBunch->dTime + (locBeamParticle->z() - dTargetZCenter)/29.9792458);
+
+			if(locDeltaTRF > dBeamBunchPeriod/2.)
+				locWeight = -1./(2.*Get_Reaction()->Get_NumPlusMinusRFBunches());
+		}
+	}
+
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock
 	//Note, the mutex is unique to this DReaction + action_string combo: actions of same class with different hists will have a different mutex
 	Lock_Action();
 	{
-		for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
-			dHist_2DInvaraintMass->Fill(locMassesToFill[loc_i].first, locMassesToFill[loc_i].second);
+		if(dSubtractAccidentals) {
+			for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
+				dHist_2DInvaraintMass->Fill(locMassesToFill[loc_i].first, locMassesToFill[loc_i].second, locWeight);
+		} else {
+			for(size_t loc_i = 0; loc_i < locMassesToFill.size(); ++loc_i)
+				dHist_2DInvaraintMass->Fill(locMassesToFill[loc_i].first, locMassesToFill[loc_i].second);
+		}
 	}
 	Unlock_Action();
 
@@ -1836,6 +2062,13 @@ void DHistogramAction_KinFitResults::Initialize(JEventLoop* locEventLoop)
 		locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << ";Confidence Level (" << locNumConstraints;
 		locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 		dHist_ConfidenceLevel = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle.str(), dNumConfidenceLevelBins, 0.0, 1.0);
+
+		// Reduced chi^2 (chi^2/# d.o.f.)
+		locHistName = "ChiSq";
+		locHistTitle.str("");   // clear the ostringstream
+		locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << "; #chi^{2}/# d.o.f. (" << locNumConstraints;
+		locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+		dHist_ChiSq = GetOrCreate_Histogram<TH1I>(locHistName, locHistTitle.str(), dNumChiSqBins, 0.0, dMaxChiSq);
 
 		//beam (pulls & conlev)
 		Particle_t locInitialPID = Get_Reaction()->Get_ReactionStep(0)->Get_InitialPID();
@@ -2171,6 +2404,9 @@ bool DHistogramAction_KinFitResults::Perform_Action(JEventLoop* locEventLoop, co
 
 	// Get Confidence Level
 	double locConfidenceLevel = locKinFitResults->Get_ConfidenceLevel();
+	
+	// Get reduced chi^2
+	double locChiSq = locKinFitResults->Get_ChiSq()/locKinFitResults->Get_NDF() ;
 
 	// Get Pulls
 	map<const JObject*, map<DKinFitPullType, double> > locPulls; //DKinematicData is the MEASURED particle
@@ -2185,7 +2421,8 @@ bool DHistogramAction_KinFitResults::Perform_Action(JEventLoop* locEventLoop, co
 	Lock_Action();
 	{
 		dHist_ConfidenceLevel->Fill(locConfidenceLevel);
-
+		dHist_ChiSq->Fill(locChiSq);
+		
 		// beam
 		if(locBeamFlag)
 		{

--- a/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Reaction.h
@@ -86,9 +86,10 @@ class DHistogramAction_PID : public DAnalysisAction
 		dNum2DFOMBins(200), dMinP(0.0), dMaxP(10.0), dMaxBCALP(3.0), dMindEdX(0.0), dMaxdEdX(25.0), dMinBeta(-0.2), dMaxBeta(1.2), dMinBCALTheta(10.0), 
 		dMaxBCALTheta(140.0), dMinFCALTheta(0.0), dMaxFCALTheta(12.0), dMinCCALTheta(0.0), dMaxCCALTheta(2.0), dMinTheta(0.0), dMaxTheta(140.0), dMinEOverP(0.0), dMaxEOverP(4.0), dMinDeltaBeta(-1.0), 
 		dMaxDeltaBeta(1.0), dMinDeltadEdx(-30.0), dMaxDeltadEdx(30.0), dMinDeltaT(-10.0), dMaxDeltaT(10.0), dMinPull(-10.0), dMaxPull(10.0),
-	        dDIRCNumPhotonsBins(100), dDIRCThetaCBins(100), dDIRCLikelihoodBins(100),
+	    dDIRCNumPhotonsBins(100), dDIRCThetaCBins(100), dDIRCLikelihoodBins(100),
 		dDIRCMinNumPhotons(0), dDIRCMaxNumPhotons(100),
-                dDIRCMinThetaC(0.6), dDIRCMaxThetaC(1.0), dDIRCMinLikelihood(0), dDIRCMaxLikelihood(1000)
+        dDIRCMinThetaC(0.6), dDIRCMaxThetaC(1.0), dDIRCMinLikelihood(0), dDIRCMaxLikelihood(1000),
+        dNumFlightDistanceBins(200), dNumFlightSignificanceBins(200), dMaxFlightDistance(20.), dMaxFlightSignificance(40.)
 		{
 			dThrownPIDs.push_back(Gamma);  dThrownPIDs.push_back(Neutron);
 			dThrownPIDs.push_back(PiPlus);  dThrownPIDs.push_back(KPlus);  dThrownPIDs.push_back(Proton);
@@ -116,6 +117,9 @@ class DHistogramAction_PID : public DAnalysisAction
 		unsigned int dDIRCNumPhotonsBins, dDIRCThetaCBins, dDIRCLikelihoodBins, dDIRCMinNumPhotons, dDIRCMaxNumPhotons;
                 double dDIRCMinThetaC, dDIRCMaxThetaC;
                 double dDIRCMinLikelihood, dDIRCMaxLikelihood;
+                
+        unsigned int dNumFlightDistanceBins, dNumFlightSignificanceBins;
+        double dMaxFlightDistance, dMaxFlightSignificance;
 
 		deque<Particle_t> dThrownPIDs;
 
@@ -124,6 +128,7 @@ class DHistogramAction_PID : public DAnalysisAction
 
 		void Fill_ChargedHists(const DChargedTrackHypothesis* locChargedTrackHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
 		void Fill_NeutralHists(const DNeutralParticleHypothesis* locNeutralParticleHypothesis, const DMCThrownMatching* locMCThrownMatching, const DEventRFBunch* locEventRFBunch);
+		void Fill_DecayingHists(const DKinematicData *locInitiaParticle, std::shared_ptr<const DKinFitParticle> locDecayingParticle, const DReactionStepVertexInfo *locStepVertexInfo);
 
 		DetectorSystem_t SYS_CDC_AMP;
 
@@ -153,6 +158,14 @@ class DHistogramAction_PID : public DAnalysisAction
 		map<Particle_t, TH2I*> dHistMap_PVsTheta_NegativeBeta;
 
 		map<pair<Particle_t, Particle_t>, TH1I*> dHistMap_PIDFOMForTruePID;
+
+		map<Particle_t, TH1I*> dHistMap_FlightDistance; 
+		map<Particle_t, TH1I*> dHistMap_FlightSignificance; 
+
+		map<Particle_t, TH2I*> dHistMap_FlightDistanceVsP; 
+		map<Particle_t, TH2I*> dHistMap_FlightDistanceVsTheta; 
+		map<Particle_t, TH2I*> dHistMap_FlightSignificanceVsP; 
+		map<Particle_t, TH2I*> dHistMap_FlightSignificanceVsTheta; 
 
 		map<Particle_t, TH1I*> dHistMap_NumPhotons_DIRC;
                 map<Particle_t, TH2I*> dHistMap_ThetaCVsP_DIRC;
@@ -278,17 +291,17 @@ class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 class DHistogramAction_InvariantMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_InvariantMass(const DReaction* locReaction, Particle_t locInitialPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0) {}
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0), dSubtractAccidentals(locSubtractAccidentals) {}
 
 		//e.g. if g, p -> pi+, pi-, p
 			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
-		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_InvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_InvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
-		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0) {}
+		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dMinBeamE(0.0), dMaxBeamE(12.0), dSubtractAccidentals(locSubtractAccidentals) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -313,6 +326,10 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins;
 		double dMinBeamE, dMaxBeamE;
 
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
+		double dBeamBunchPeriod;
+
 	private:
 		const DAnalysisUtilities* dAnalysisUtilities = nullptr;
 		TH1I* dHist_InvariantMass;
@@ -325,11 +342,11 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 class DHistogramAction_MissingMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -347,20 +364,20 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		//But:
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
-		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex),
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
 
-		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+		DHistogramAction_MissingMass(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -385,6 +402,10 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
+		double dBeamBunchPeriod;
+
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
@@ -397,11 +418,11 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 class DHistogramAction_MissingMassSquared : public DAnalysisAction
 {
 	public:
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(0),
 		dMissingMassOffOfPIDs(deque<Particle_t>()), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -419,20 +440,20 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		//But:
 		//locMissingMassOffOfStepIndex = 0, locMissingMassOffOfPIDs = K+
 		//Then: Will histogram only missing-mass: g, p -> K+_1, (X)    and NOT K+_2!!!
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, deque<Particle_t> locMissingMassOffOfPIDs, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(locMissingMassOffOfPIDs), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
 
-		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
+		DHistogramAction_MissingMassSquared(const DReaction* locReaction, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, bool locUseKinFitResultsFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_MissingMassSquared", locUseKinFitResultsFlag, locActionUniqueString),
 		dNumMassBins(locNumMassBins), dMinMassSq(locMinMassSq), dMaxMassSq(locMaxMassSq), dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), 
 		dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)), dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450),
-		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0)
+		dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0), dSubtractAccidentals(locSubtractAccidentals)
 		{
 			dAnalysisUtilities = NULL;
 		}
@@ -457,6 +478,10 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
+		double dBeamBunchPeriod;
+
 	private:
 		TH1I* dHist_MissingMassSquared;
 		TH2I* dHist_MissingMassSquaredVsBeamE;
@@ -469,10 +494,10 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 class DHistogramAction_2DInvariantMass : public DAnalysisAction
 {
 	public:
-		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "") :
+		DHistogramAction_2DInvariantMass(const DReaction* locReaction, size_t locStepIndex, deque<Particle_t> locXPIDs, deque<Particle_t> locYPIDs, bool locUseKinFitResultsFlag, unsigned int locNumXBins, double locMinX, double locMaxX, unsigned int locNumYBins, double locMinY, double locMaxY, string locActionUniqueString = "", bool locSubtractAccidentals = false) :
 		DAnalysisAction(locReaction, "Hist_2DInvariantMass", locUseKinFitResultsFlag, locActionUniqueString),
 		dStepIndex(locStepIndex), dXPIDs(locXPIDs), dYPIDs(locYPIDs), dNumXBins(locNumXBins), dNumYBins(locNumYBins), 
-		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dAnalysisUtilities(NULL) {}
+		dMinX(locMinX), dMaxX(locMaxX), dMinY(locMinY), dMaxY(locMaxY), dSubtractAccidentals(locSubtractAccidentals), dAnalysisUtilities(NULL) {}
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -489,6 +514,10 @@ class DHistogramAction_2DInvariantMass : public DAnalysisAction
 		deque<Particle_t> dXPIDs, dYPIDs;
 		unsigned int dNumXBins, dNumYBins;
 		double dMinX, dMaxX, dMinY, dMaxY;
+
+		bool dSubtractAccidentals;
+		double dTargetZCenter;
+		double dBeamBunchPeriod;
 
 		const DAnalysisUtilities* dAnalysisUtilities;
 		TH2I* dHist_2DInvaraintMass;
@@ -532,22 +561,22 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 	public:
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString),
-		dHistDependenceFlag(false), dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dHistDependenceFlag(false), dNumConfidenceLevelBins(400), dNumChiSqBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
 		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
-		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
+		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dMaxChiSq(100.), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
 
 		DHistogramAction_KinFitResults(const DReaction* locReaction, double locPullHistConfidenceLevelCut, bool locHistDependenceFlag, string locActionUniqueString = "") :
 		DAnalysisAction(locReaction, "Hist_KinFitResults", true, locActionUniqueString), 
-		dHistDependenceFlag(locHistDependenceFlag), dNumConfidenceLevelBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
+		dHistDependenceFlag(locHistDependenceFlag), dNumConfidenceLevelBins(400), dNumChiSqBins(400), dNumPullBins(200), dNum2DPBins(200), dNum2DThetaBins(140), dNum2DPhiBins(180), dNum2DPullBins(100),
 		dNum2DConfidenceLevelBins(100), dNum2DBeamEBins(240), dMinPull(-4.0), dMaxPull(4.0), dMinP(0.0), dMaxP(10.0), dMinTheta(0.0), dMaxTheta(140.0),
-		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
+		dMinPhi(-180.0), dMaxPhi(180.0), dMinBeamE(0.0), dMaxBeamE(12.0), dMaxChiSq(100.), dPullHistConfidenceLevelCut(locPullHistConfidenceLevelCut) {}
 
 	private:
 		bool dHistDependenceFlag;
 
 	public:
-		unsigned int dNumConfidenceLevelBins, dNumPullBins, dNum2DPBins, dNum2DThetaBins, dNum2DPhiBins, dNum2DPullBins, dNum2DConfidenceLevelBins, dNum2DBeamEBins;
-		double dMinPull, dMaxPull, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinBeamE, dMaxBeamE;
+		unsigned int dNumConfidenceLevelBins, dNumChiSqBins, dNumPullBins, dNum2DPBins, dNum2DThetaBins, dNum2DPhiBins, dNum2DPullBins, dNum2DConfidenceLevelBins, dNum2DBeamEBins;
+		double dMinPull, dMaxPull, dMinP, dMaxP, dMinTheta, dMaxTheta, dMinPhi, dMaxPhi, dMinBeamE, dMaxBeamE, dMaxChiSq;
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop);
@@ -572,6 +601,7 @@ class DHistogramAction_KinFitResults : public DAnalysisAction
 
 		//below maps: int is step index (-1 for beam), 2nd is particle
 		TH1I* dHist_ConfidenceLevel;
+		TH1I* dHist_ChiSq;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsP;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsTheta;
 		map<pair<int, Particle_t>, TH2I*> dHistMap_ConfidenceLevel_VsPhi;

--- a/src/libraries/ANALYSIS/DReaction.cc
+++ b/src/libraries/ANALYSIS/DReaction.cc
@@ -70,6 +70,31 @@ vector<Particle_t> DReaction::Get_MissingPIDs(int locStepIndex, Charge_t locChar
 	return locFinalPIDs;
 }
 
+vector<Particle_t> DReaction::Get_DecayingPIDs(int locStepIndex, Charge_t locCharge, bool locIncludeDuplicatesFlag) const
+{
+	vector<Particle_t> locFinalPIDs;
+	for(size_t locLoopStepIndex = 0; locLoopStepIndex < dReactionSteps.size(); ++locLoopStepIndex)
+	{
+		if((locStepIndex != -1) && (int(locLoopStepIndex) != locStepIndex))
+			continue;
+
+		auto locStep = dReactionSteps[locLoopStepIndex];
+		for(size_t locPIDIndex = 0; locPIDIndex < locStep->Get_NumFinalPIDs(); ++locPIDIndex)
+		{
+			Particle_t locPID = locStep->Get_FinalPID(locPIDIndex);
+			if(Is_CorrectCharge(locPID, locCharge) && IsDetachedVertex(locPID) && !Is_FinalStateParticle(locPID))
+				locFinalPIDs.push_back(locPID);
+		}
+	}
+
+	if(!locIncludeDuplicatesFlag)
+	{
+		std::sort(locFinalPIDs.begin(), locFinalPIDs.end()); //must sort first or else std::unique won't do what we want!
+		locFinalPIDs.erase(std::unique(locFinalPIDs.begin(), locFinalPIDs.end()), locFinalPIDs.end());
+	}
+	return locFinalPIDs;
+}
+
 void DReaction::Set_MaxPhotonRFDeltaT(double locMaxPhotonRFDeltaT)
 {
 	cout << "WARNING: USING DReaction::Set_MaxPhotonRFDeltaT() IS DEPRECATED. PLEASE SWITCH TO Set_NumPlusMinusRFBunches()." << endl;

--- a/src/libraries/ANALYSIS/DReaction.h
+++ b/src/libraries/ANALYSIS/DReaction.h
@@ -88,6 +88,7 @@ class DReaction : public JObject
 		vector<Particle_t> Get_FinalPIDs(int locStepIndex = -1, bool locIncludeMissingFlag = true, bool locIncludeDecayingFlag = true,
 		Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
 		vector<Particle_t> Get_MissingPIDs(int locStepIndex = -1, Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
+		vector<Particle_t> Get_DecayingPIDs(int locStepIndex = -1, Charge_t locCharge = d_AllCharges, bool locIncludeDuplicatesFlag = true) const;
 
 		// GET ANALYSIS ACTIONS:
 		size_t Get_NumAnalysisActions(void) const{return dAnalysisActions.size();}

--- a/src/libraries/DANA/DApplication.cc
+++ b/src/libraries/DANA/DApplication.cc
@@ -246,12 +246,15 @@ DGeometry* DApplication::GetDGeometry(unsigned int run_number)
 	// built on a JGeometryFile object. If so, simply return it under the
 	// assumption we are still doing development with simulated data and
 	// a single set of geometry files.
-	Lock();
-	if(geometries.size()==1 && string("JGeometryXML")==geometries[0]->GetJGeometry()->className()){
-		Unlock();
-		return geometries[0];
-	}
-	Unlock();
+	//
+	// This isn't a good assumption anymore, disabling... [sdobbs, 1 June 2020]
+	//
+	//Lock();
+	//if(geometries.size()==1 && string("JGeometryXML")==geometries[0]->GetJGeometry()->className()){
+	//	Unlock();
+	//	return geometries[0];
+	//}
+	//Unlock();
 	
 	// First, get the JGeometry object using our JApplication
 	// base class. Then, use that to find the correct DGeometry

--- a/src/libraries/FCAL/DFCALShower.cc
+++ b/src/libraries/FCAL/DFCALShower.cc
@@ -7,6 +7,7 @@ DFCALShower::DFCALShower():ExyztCovariance(5)
   fEnergy = 0.;
   fTime = 0.;
   fPosition.SetXYZ(0., 0., 0.);
+  fPosition_log.SetXYZ(0., 0., 0.);
   fTimeTr = 1E3;
   fDocaTr = 1E3;
   fSumU = 0;
@@ -35,6 +36,11 @@ void DFCALShower::setTime(const double time)
 void DFCALShower::setPosition(const DVector3& aPosition ) 
 {
   fPosition = aPosition;
+}
+
+void DFCALShower::setPosition_log(const DVector3& aPosition_log ) 
+{
+  fPosition_log = aPosition_log;
 }
 
 void DFCALShower::setDocaTrack( const double docaTrack ){ fDocaTr = docaTrack; }

--- a/src/libraries/FCAL/DFCALShower.h
+++ b/src/libraries/FCAL/DFCALShower.h
@@ -31,6 +31,7 @@ class DFCALShower:public JObject{
   //  for the depth correction, the default vertex is in the target center
   DVector3 getPosition() const; 
   DVector3 getPositionError() const;
+  DVector3 getPosition_log() const;
   double getEnergy() const;  
   double getTime() const;
   double getDocaTrack() const;
@@ -42,7 +43,8 @@ class DFCALShower:public JObject{
   int getNumBlocks() const;
 
   // set shower information
-  void setPosition( const DVector3& aPosition );  
+  void setPosition( const DVector3& aPosition );
+  void setPosition_log( const DVector3& aPosition_log );
   void setEnergy( const double energy );  
   void setTime( const double time );
   void setDocaTrack( const double docaTrack );
@@ -138,6 +140,7 @@ class DFCALShower:public JObject{
   double fEnergy; 
   double fTime; 
   DVector3 fPosition;        // Shower position in the FCAL
+  DVector3 fPosition_log;    // log-weighted shower position
   double fTimeTr;
   double fDocaTr;
   double fSumU;
@@ -151,6 +154,11 @@ class DFCALShower:public JObject{
 inline DVector3 DFCALShower::getPosition() const
 {
   return fPosition;
+}
+
+inline DVector3 DFCALShower::getPosition_log() const
+{
+  return fPosition_log;
 }
 
 inline double DFCALShower::getEnergy() const

--- a/src/libraries/FCAL/DFCALShower_factory.h
+++ b/src/libraries/FCAL/DFCALShower_factory.h
@@ -38,6 +38,9 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
 				     double &Ecorrected,
 				     DVector3 &pos_corrected, double &errZ,
 				     const DVector3 *aVertex);
+  
+  void GetLogWeightedPosition( const DFCALCluster* cluster, DVector3 &pos_log, 
+  				     double Egamma, const DVector3 *aVertex  );
 
   unsigned int getMaxHit( const vector< const DFCALHit* >& hitVec ) const;
 
@@ -84,6 +87,8 @@ class DFCALShower_factory:public JFactory<DFCALShower>{
   int VERBOSE;
   string COVARIANCEFILENAME;
   TH2F *CovarianceLookupTable[5][5];
+  
+  double log_position_const;
 };
 
 

--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -1771,7 +1771,8 @@ bool DGeometry::GetCCALZ(double &z_ccal) const
    bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);
 
    if(!good){
-      _DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
+	  // NEED TO RETHINK ERROR REPORTING FOR OPTIONAL DETECTOR ELEMENTS
+      //_DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;  
       z_ccal = 1279.376;   
       return false;
    }else{
@@ -1809,8 +1810,7 @@ bool DGeometry::GetFCALPosition(double &x,double &y,double &z) const{
     return false;
   }else{
     x=ForwardEMcalpos[0],y=ForwardEMcalpos[1],z=ForwardEMcalpos[2];
-    _DBG_ << "FCAL position: (x,y,z)=(" << x <<"," << y << "," << z << ")"
-	  <<endl;
+    //_DBG_ << "FCAL position: (x,y,z)=(" << x <<"," << y << "," << z << ")"<<endl;
     return true;
   }
 }
@@ -1820,13 +1820,13 @@ bool DGeometry::GetCCALPosition(double &x,double &y,double &z) const{
   bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);
   
   if(!good){
-    _DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
+    //_DBG_<<"Unable to retrieve ComptonEMcal position."<<endl;
     x=0.,y=0.,z=0.;
     return false;
   }else{
     x=ComptonEMcalpos[0],y=ComptonEMcalpos[1],z=ComptonEMcalpos[2]; 
-    _DBG_ << "CCAL position: (x,y,z)=(" << ComptonEMcalpos[0] <<","
-	  << ComptonEMcalpos[1]<<","<<ComptonEMcalpos[2]<< ")" << endl;
+    //_DBG_ << "CCAL position: (x,y,z)=(" << ComptonEMcalpos[0] <<","
+	// << ComptonEMcalpos[1]<<","<<ComptonEMcalpos[2]<< ")" << endl;
     return true;
   }
 }
@@ -1840,7 +1840,7 @@ bool DGeometry::GetDIRCZ(double &z_dirc) const
   bool good = Get("//section/composition/posXYZ[@volume='DIRC']/@X_Y_Z",dirc_face);
 
   if(!good){
-    _DBG_<<"Unable to retrieve DIRC position."<<endl;
+    //_DBG_<<"Unable to retrieve DIRC position."<<endl;
     z_dirc=0.0;
     return false;
   }
@@ -1852,7 +1852,7 @@ bool DGeometry::GetDIRCZ(double &z_dirc) const
     Get("//composition[@name='DIRC']/posXYZ[@volume='DRCC']/@X_Y_Z", dirc_shift);
     z_dirc=dirc_face[2]+dirc_plane[2]+dirc_shift[2] + 0.8625; // last shift is the average center of quartz bar (585.862)
 
-    jout << "DIRC z position = " << z_dirc << " cm." << endl;
+    //jout << "DIRC z position = " << z_dirc << " cm." << endl;
     return true;
   }
 }
@@ -1866,7 +1866,7 @@ bool DGeometry::GetTRDZ(vector<double> &z_trd) const
    bool good = Get("//section/composition/posXYZ[@volume='TRDGEM']/@X_Y_Z",trd_origin);
    
    if(!good){
-     _DBG_<<"Unable to retrieve TRD position."<<endl;
+     //_DBG_<<"Unable to retrieve TRD position."<<endl;
      return false;
    }
    else{ 

--- a/src/libraries/TAGGER/DTAGHGeometry.cc
+++ b/src/libraries/TAGGER/DTAGHGeometry.cc
@@ -24,11 +24,26 @@
 
 const unsigned int DTAGHGeometry::kCounterCount = 274;
 
+// Only print messages for one thread whenever run number change
+static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+static set<int> runs_announced;
+    
+
 //---------------------------------
 // DTAGHGeometry    (Constructor)
 //---------------------------------
 DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
 {
+   // keep track of which runs we print out messages for
+   int32_t runnumber = loop->GetJEvent().GetRunNumber();
+   pthread_mutex_lock(&print_mutex);
+   bool print_messages = false;
+   if(runs_announced.find(runnumber) == runs_announced.end()){
+	  print_messages = true;
+	  runs_announced.insert(runnumber);
+   }
+   pthread_mutex_unlock(&print_mutex);
+
    /* read tagger set endpoint energy from calibdb */
    std::map<string,double> result1;
    loop->GetCalib("/PHOTON_BEAM/endpoint_energy", result1);
@@ -62,7 +77,6 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
       }
    }
 
-
    int status = 0;
    m_endpoint_energy_calib_GeV = 0.;
    
@@ -79,7 +93,8 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
      } else {
        m_endpoint_energy_calib_GeV  = result3["TAGGER_CALIB_ENERGY"];
 
-       printf(" Correct Beam Photon Energy  (TAGH)   %f \n\n", m_endpoint_energy_calib_GeV);
+	   if(print_messages)
+       	  jout << " Correct Beam Photon Energy (TAGH) = " << m_endpoint_energy_calib_GeV << " (GeV)" << std::endl;
 
      }
    }

--- a/src/libraries/TOF/DTOFHit_factory.cc
+++ b/src/libraries/TOF/DTOFHit_factory.cc
@@ -209,7 +209,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
       
     case 1:  // walk corrections based on Integral values
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 1"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 1"<<endl;
 	string locTOFTimewalkTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms";
 	if(eventLoop->GetCalib(locTOFTimewalkTable.c_str(), timewalk_parameters)){
 	  jout << "Error loading "<<locTOFTimewalkTable<<" !" << endl;
@@ -223,7 +223,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 
     case 2:  // walk correction based on peak Amplitudes single function 
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 2"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 2"<<endl;
 	USE_AMP_4WALKCORR = 1;
 	string locTOFTimewalkAMPTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms_AMP";
 	if(eventLoop->GetCalib(locTOFTimewalkAMPTable.c_str(), timewalk_parameters_AMP)){
@@ -238,7 +238,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
       
     case 3:
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 3"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 3"<<endl;
 	USE_NEWAMP_4WALKCORR = 1;
 	string locTOFChanOffsetNEWAMPTable = tofGeom.Get_CCDB_DirectoryName() + "/timing_offsets_NEWAMP";
 	if(eventLoop->GetCalib(locTOFChanOffsetNEWAMPTable.c_str(), raw_tdc_offsets)) {
@@ -253,7 +253,7 @@ jerror_t DTOFHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 
     case 4:
       {
-	cout<<"TOF: USE WALK CORRECTION TYPE 4"<<endl;
+	if(print_messages) jout<<"TOF: USE WALK CORRECTION TYPE 4"<<endl;
 	USE_NEW_WALK_NEW = 1;
 	string locTOFTimewalkNEWTable = tofGeom.Get_CCDB_DirectoryName() + "/timewalk_parms_5PAR";
 	if(eventLoop->GetCalib(locTOFTimewalkNEWTable.c_str(), timewalk_parameters_5PAR)){

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
@@ -16,6 +16,9 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	DReactionStep* locReactionStep = NULL;
 	DReaction* locReaction = NULL; //create with a unique name for each DReaction object. CANNOT (!) be "Thrown"
 
+	double locMinKinFitFOM = 1e-4;
+	gPARMS->SetDefaultParameter("REACTIONEFFIC:MINKINFITFOM", locMinKinFitFOM);
+
 	// DOCUMENTATION:
 	// ANALYSIS library: https://halldweb1.jlab.org/wiki/index.php/GlueX_Analysis_Software
 	// DReaction factory: https://halldweb1.jlab.org/wiki/index.php/Analysis_DReaction
@@ -64,14 +67,14 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	// Recommended: Analysis actions automatically performed by the DAnalysisResults factories to histogram useful quantities.
 		//These actions are executed sequentially, and are executed on each surviving (non-cut) particle combination 
 		//Pre-defined actions can be found in ANALYSIS/DHistogramActions_*.h and ANALYSIS/DCutActions.h
-		//If a histogram action is repeated, it should be created with a unique name (string) to distinguish them
+		//If a histogram action is repeated, it should be created with a unique name (string) to distinguish them	
 
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
 
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
 	deque<int> locRecoilIndices;  locRecoilIndices.push_back(2);
@@ -105,7 +108,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
 	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
@@ -131,14 +134,14 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(0); // KPlus
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 1.0, 2.0, "Lambda1520Recoil"));
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 1.0, 2.0, "Lambda1520Recoil_KinFit"));
 	
-	_data.push_back(locReaction); //Register the DReaction with the factory
+	//_data.push_back(locReaction); //Register the DReaction with the factory
 
 	/**************************************************** kpmisskm__B1_T1_U1_Lambda1520Effic ****************************************************/
 	
@@ -154,7 +157,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(0); // KPlus
@@ -177,7 +180,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(1); // Proton
@@ -200,7 +203,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(1); // Proton
@@ -223,7 +226,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(2); // KPlus
@@ -255,7 +258,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(1); // KPlus
@@ -288,7 +291,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUT ACTION FOR LAMBDA
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, AntiLambda, false, 100, 0.8, 1.3, "AntiLambdaMass"));
@@ -320,7 +323,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUT ACTION FOR LAMBDA
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, AntiLambda, false, 100, 0.8, 1.3, "AntiLambdaMass"));
@@ -352,7 +355,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUT ACTION FOR LAMBDA
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 100, 0.8, 1.3, "LambdaMass"));
@@ -384,7 +387,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUT ACTION FOR LAMBDA
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Lambda, false, 100, 0.8, 1.3, "LambdaMass"));
@@ -411,7 +414,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(1); locRecoilIndices.push_back(2); // Lambda = PiMinus+Proton 
@@ -444,7 +447,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(0); locRecoilIndices.push_back(2); // K* = Pi0+KPlus 
@@ -471,7 +474,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
-	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, 0.0)); //0% confidence level cut //require kinematic fit converges
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
 	
 	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
         locRecoilIndices.clear();  locRecoilIndices.push_back(0); locRecoilIndices.push_back(2); // K* = Pi0+KPlus 

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -166,6 +166,7 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 	//INIT
 	dSourceComboP4Handler = new DSourceComboP4Handler(nullptr, false);
 	dSourceComboTimeHandler = new DSourceComboTimeHandler(nullptr, nullptr, nullptr);
+	
 
 	auto locInputTuple = Parse_Input();
 	auto locReactions = Create_Reactions(locInputTuple);
@@ -190,9 +191,21 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 			_data.push_back(locReaction); //Register the DReaction with the factory
 			continue;
 		}
-
+		
+		// OTHER OPTIONAL CUTS
+		if(dFlightSignificanceCut>0.) {
+			auto locDecayingPIDs = locReaction->Get_DecayingPIDs();
+			for(auto locPID : locDecayingPIDs) {
+				stringstream ss;
+				ss << "FltDist" << dFlightSignificanceCut << "Cut_" << locPID;
+				locReaction->Add_AnalysisAction(new DCutAction_FlightSignificance(locReaction, true, dFlightSignificanceCut, locPID, ss.str()));
+			}
+		}
+		
 		// KINEMATIC FIT
 		locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+		if(dKinFitChiSqCut > 0.)
+			locReaction->Add_AnalysisAction(new DCutAction_KinFitChiSq(locReaction, dKinFitChiSqCut));
 
 		//POST-KINFIT PID CUTS
 		Add_PostKinfitTimingCuts(locReaction);

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.h
@@ -32,6 +32,10 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 		{
 			// This is so that the created DReaction objects persist throughout the life of the program instead of being cleared each event. 
 			SetFactoryFlag(PERSISTANT);
+			
+			gPARMS->SetDefaultParameter("REACTIONFILTER:KINFIT_CHISQCUT", dKinFitChiSqCut, "Maximum value of the kinematic fit chi^2/d.o.f. to keep (default: all)");
+			gPARMS->SetDefaultParameter("REACTIONFILTER:FLIGHTSIG_CUT", dFlightSignificanceCut, "Minimum value of the  (default: no cut)");
+
 		}
 		const char* Tag(void){return "ReactionFilter";}
 
@@ -64,6 +68,10 @@ class DReaction_factory_ReactionFilter : public jana::JFactory<DReaction>
 		DSourceComboP4Handler* dSourceComboP4Handler = nullptr;
 		DSourceComboTimeHandler* dSourceComboTimeHandler = nullptr;
 		deque<DReactionStep*> dReactionStepPool; //to prevent memory leaks
+		
+		double dKinFitChiSqCut = -1.;
+		double dFlightSignificanceCut = -1.;
+
 };
 
 #endif // _DReaction_factory_ReactionFilter_

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
@@ -23,6 +23,7 @@ using namespace jana;
 #include "PID/DVertex.h"
 #include "PID/DEventRFBunch.h"
 #include "HDDM/DEventWriterHDDM.h"
+#include "TOF/DTOFPoint.h"
 
 #include "GlueX.h"
 #include <vector>
@@ -50,31 +51,35 @@ JEventProcessor_pi0fcalskim::JEventProcessor_pi0fcalskim()
   WRITE_EVIO = 1;
   WRITE_HDDM = 0;
 
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_EVIO", WRITE_EVIO );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_HDDM", WRITE_HDDM );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_EVIO", WRITE_EVIO, "Save skim output as reduced EVIO files (default=1)" );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_HDDM", WRITE_HDDM, "Save skim output as HDDM (default=0)" );
 
 
-/*
-  MIN_MASS   = 0.03; // GeV
-  MAX_MASS   = 0.30; // GeV
-  MIN_E      =  1.0; // GeV (photon energy cut)
-  MIN_R      =   20; // cm  (cluster distance to beam line)
+
+  MIN_MASS   = 0.0; // GeV
+  //MAX_MASS   = 0.30; // GeV - old default
+  MAX_MASS   = 1.0; // GeV
+  MIN_E      = 0.5; // GeV (photon energy cut)
+  //MIN_R      =   20; // cm  (cluster distance to beam line) - not currently used
   MAX_DT     =   10; // ns  (cluster time diff. cut)
-  MAX_ETOT   =   12; // GeV (max total FCAL energy)
-  MIN_BLOCKS =    2; // minumum blocks per cluster
+  //MAX_ETOT   =   12; // GeV (max total FCAL energy) - not currently used
+  //MIN_BLOCKS =    2; // minumum blocks per cluster - not currently used
+
+  SAVE_TOF_HITS = 1;
 
   WRITE_ROOT = 0;
   WRITE_EVIO = 1;
 
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_MASS", MIN_MASS );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_MASS", MAX_MASS );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_E", MIN_E );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_R", MIN_R );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_DT", MAX_DT );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_ETOT", MAX_ETOT );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_BLOCKS", MIN_BLOCKS );
-  gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_ROOT", WRITE_ROOT );
-  */
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_MASS", MIN_MASS, "Minimum two-gamma invariant mass to save (default=0.0 GeV)" );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_MASS", MAX_MASS, "Maximum two-gamma invariant mass to save (default=1.0 GeV)" );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_E", MIN_E, "Minimum photon energy to consider (default = 0.5 GeV)" );
+  //gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_R", MIN_R );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_DT", MAX_DT, "Minimum Delta T cut between two photons (default = 10 ns)" );
+  //gPARMS->SetDefaultParameter( "PI0FCALSKIM:MAX_ETOT", MAX_ETOT );
+  //gPARMS->SetDefaultParameter( "PI0FCALSKIM:MIN_BLOCKS", MIN_BLOCKS );
+  //gPARMS->SetDefaultParameter( "PI0FCALSKIM:WRITE_ROOT", WRITE_ROOT );
+  gPARMS->SetDefaultParameter( "PI0FCALSKIM:SAVE_TOF_HITS", MAX_DT, "Save hits from TOF points (default=1)" );
+
 }
 
 //------------------
@@ -133,9 +138,11 @@ jerror_t JEventProcessor_pi0fcalskim::brun(JEventLoop *eventLoop, int32_t runnum
 jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
  
- vector< const DFCALShower* > locFCALShowers;
+  vector< const DFCALShower* > locFCALShowers;
+  vector< const DTOFPoint* > locTOFPoints;
   vector< const DVertex* > kinfitVertex;
   loop->Get(locFCALShowers);
+  loop->Get(locTOFPoints);
   loop->Get(kinfitVertex);
 
   vector< const DTrackTimeBased* > locTrackTimeBased;
@@ -162,6 +169,13 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
   }
 
   vector< const JObject* > locObjectsToSave;  
+
+  // save TOF points to help with background rejection, especially near the beam hole
+  if(SAVE_TOF_HITS) {
+	  for (unsigned int i = 0 ; i < locTOFPoints.size(); i++) {
+		locObjectsToSave.push_back(static_cast<const JObject *>(locTOFPoints[i]));
+	  }
+  }
 
   bool Candidate = false;
   
@@ -202,7 +216,7 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
       //for LH2 target
       //DVector3 pos_FCAL(0,0,625.406);
       
-      DVector3 pos_FCAL(0,0,638);
+      DVector3 pos_FCAL(0,0,638);   //TOFIX: shouldn't this come from the geometry??
       //at the end of the start counter; use this fall for fall '15 data
       // DVector3 pos_FCAL(0,0,692);
          //DVector3 pos_FCAL(0.0,0.0,650);
@@ -254,33 +268,33 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
 			
       for(unsigned int j=i+1; j<locFCALShowers.size(); j++)
       {
-	const DFCALShower *s2 = locFCALShowers[j];
-	if (find(matchedShowers.begin(), matchedShowers.end(),s2) != matchedShowers.end()) continue;
+		const DFCALShower *s2 = locFCALShowers[j];
+		if (find(matchedShowers.begin(), matchedShowers.end(),s2) != matchedShowers.end()) continue;
 	
-	vector<const DFCALCluster*> associated_clusters2;
-	s2->Get(associated_clusters2);
-	Double_t dx2 = s2->getPosition().X() - kinfitVertexX;
-	Double_t dy2 = s2->getPosition().Y() - kinfitVertexY;
-	Double_t dz2 = s2->getPosition().Z() - kinfitVertexZ; 
-	Double_t R2 = sqrt(dx2*dx2 + dy2*dy2 + dz2*dz2);
-	Double_t E2 = s2->getEnergy();
-	Double_t  t2 = s2->getTime();
+		vector<const DFCALCluster*> associated_clusters2;
+		s2->Get(associated_clusters2);
+		Double_t dx2 = s2->getPosition().X() - kinfitVertexX;
+		Double_t dy2 = s2->getPosition().Y() - kinfitVertexY;
+		Double_t dz2 = s2->getPosition().Z() - kinfitVertexZ; 
+		Double_t R2 = sqrt(dx2*dx2 + dy2*dy2 + dz2*dz2);
+		Double_t E2 = s2->getEnergy();
+		Double_t  t2 = s2->getTime();
 	
-	TLorentzVector sh2_p(E2*dx2/R2, E2*dy2/R2, E2*dz2/R2, E2);
-	TLorentzVector ptot = sh1_p+sh2_p;
-	Double_t inv_mass = ptot.M();
+		TLorentzVector sh2_p(E2*dx2/R2, E2*dy2/R2, E2*dz2/R2, E2);
+		TLorentzVector ptot = sh1_p+sh2_p;
+		Double_t inv_mass = ptot.M();
 
-    //Candidate |= (E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) ;
-        Candidate |= (E1 > 0.5 && E2 > 0.5 && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) ;
+		//Candidate |= (E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) ;
+        Candidate |= ( (E1 > MIN_MASS) && (E2 > MAX_MASS) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) );
 
         //if(E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) {
-        if(E1 > 0.5 && E2 > 0.5 && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) {
+        if( (E1 > MIN_MASS) && (E2 > MAX_MASS) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) ) {
             if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[i]) == locObjectsToSave.end())
                 locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
             if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[j]) == locObjectsToSave.end())
                 locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[j]));
         }
- 			}
+ 	  }
  	}		
  
  if( Candidate ){

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.cc
@@ -285,10 +285,10 @@ jerror_t JEventProcessor_pi0fcalskim::evnt(JEventLoop *loop, uint64_t eventnumbe
 		Double_t inv_mass = ptot.M();
 
 		//Candidate |= (E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) ;
-        Candidate |= ( (E1 > MIN_MASS) && (E2 > MAX_MASS) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) );
+        Candidate |= ( (E1 > MIN_E) && (E2 > MIN_E) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) );
 
         //if(E1 > 0.5 && E2 > 0.5 && s1->getPosition().Pt() > 20*k_cm && s2->getPosition().Pt() > 20*k_cm && (fabs (t1-t2) < 10) && (inv_mass<0.30) ) {
-        if( (E1 > MIN_MASS) && (E2 > MAX_MASS) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) ) {
+        if( (E1 > MIN_E) && (E2 > MIN_E) && (fabs(t1-t2) < MAX_DT) && (inv_mass>MIN_MASS) && (inv_mass<MAX_MASS) ) {
             if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[i]) == locObjectsToSave.end())
                 locObjectsToSave.push_back(static_cast<const JObject *>(locFCALShowers[i]));
             if(find(locObjectsToSave.begin(), locObjectsToSave.end(), locFCALShowers[j]) == locObjectsToSave.end())

--- a/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
+++ b/src/plugins/Utilities/pi0fcalskim/JEventProcessor_pi0fcalskim.h
@@ -41,6 +41,8 @@ class JEventProcessor_pi0fcalskim:public jana::JEventProcessor{
   double MAX_DT;
   double MAX_ETOT;
   int    MIN_BLOCKS;
+  
+  int SAVE_TOF_HITS;
 
   int WRITE_ROOT;
   int WRITE_EVIO;

--- a/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
+++ b/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
@@ -25,6 +25,8 @@ class JEventProcessor_syncskim:public jana::JEventProcessor{
 		SyncEvent synevt;
 		TFile *file;
 		TTree *tree;
+		
+		uint32_t SYNCSKIM_ROCID;
 
 		// Values to do linear regression to find slope and intercept correlating
 		// 250MHz clock time to unix timestamp


### PR DESCRIPTION
This code change in DTOFPoint_factory adds two variables that contain the energy deposition of
the particle separately for the two planes: dE1 and dE2. the energies are attenuated to the
center of the paddle representing the unbiased un-attenuated energy deposited matched to
what is seen in the MC simulation.
In addition a small bug is fixed in dTOFPaddle_facotory 