### PR TITLE
change histogram dimensions to accomodate the new bigger TOF with mor…

### DIFF
--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
@@ -637,13 +637,13 @@ jerror_t JEventProcessor_TOF_calib::MakeHistograms(void){
     ROOTFile->cd("TOFcalib");
 
 
-    TOFTDCtime = new TH2F("TOFTDCtime","TOF CAEN TDC times", 8000, 0., 4000., 176, 0., 176.);
-    TOFADCtime = new TH2F("TOFADCtime","TOF ADC times", 800, 0., 400., 176, 0., 176.);
+    TOFTDCtime = new TH2F("TOFTDCtime","TOF CAEN TDC times", 8000, 0., 4000., 200, 0., 200.);
+    TOFADCtime = new TH2F("TOFADCtime","TOF ADC times", 800, 0., 400., 200, 0., 200.);
 
     TOFEnergy = new TH2F("TOFEnergy","TOF Energy Integral (no ped subraction)",
-			 176, 0., 176., 100, 0., 20000.);
-    TOFPeak = new TH2F("TOFPeak","TOF Peak Amplitude",176, 0., 176., 100, 0., 4100.);
-    TOFPedestal = new TH2F("TOFPedestal","TOF Pedestal",176, 0., 176., 300, 0., 600.);
+			 200, 0., 200., 100, 0., 20000.);
+    TOFPeak = new TH2F("TOFPeak","TOF Peak Amplitude",200, 0., 200., 100, 0., 4100.);
+    TOFPedestal = new TH2F("TOFPedestal","TOF Pedestal",200, 0., 200., 300, 0., 600.);
 
 
     t3 = new TTree("t3","TOF Hits");


### PR DESCRIPTION
…e paddles. the dimensions were changed from 176 to 200 to cover any issues.

The histograms show values as a function of paddle number. These number extended only to 176
reflecting the PMT counts of the old version 1 TOF. The new geometry has 184 PMTs. the histogram
dimensions were changed to 200 to cover any future increase as well.