### PR TITLE
Sdobbs bug fixes 20200630

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
+++ b/src/libraries/ANALYSIS/DAnalysisResults_factory.cc
@@ -283,6 +283,10 @@ jerror_t DAnalysisResults_factory::evnt(JEventLoop* locEventLoop, uint64_t event
 	if(dDebugLevel > 0)
 		cout << "Analyze event: " << eventnumber << endl;
 
+	//CHECK EVENT TYPE
+	if(!locEventLoop->GetJEvent().GetStatusBit(kSTATUS_PHYSICS_EVENT))
+		return NOERROR;
+
 	//CHECK TRIGGER TYPE
 	const DTrigger* locTrigger = NULL;
 	locEventLoop->GetSingle(locTrigger);

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -454,7 +454,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::fini(void)
 
 	japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
-    SortDirectories();
+    //SortDirectories();    // THIS CRASHES SOMETIMES, SHOULD FIGURE OUT WHY
 
 	return NOERROR;
 }


### PR DESCRIPTION
- prevent a crash in BCAL_attenlength_gainratio which is affecting monitoring jobs.  the cause is pretty obscure, looks like it will take awhile to get to the bottom of this
- suppress warning messages by preventing non-physics events from going into the comboing pipeline.  not quite sure how they were getting through in the first place...