### PR TITLE
Pid fom updates

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -648,6 +648,9 @@ void DEventWriterROOT::Create_Branches_ChargedHypotheses(DTreeBranchRegister& lo
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Measured"), dInitNumTrackArraySize);
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_Measured"), dInitNumTrackArraySize);
 
+	// Global PID
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "PIDFOM"), locArraySizeString, dInitNumTrackArraySize);
+
 	//TRACKING INFO
 	locBranchRegister.Register_FundamentalArray<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Tracking"), locArraySizeString, dInitNumTrackArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Tracking"), locArraySizeString, dInitNumTrackArraySize);
@@ -1575,6 +1578,9 @@ void DEventWriterROOT::Fill_ChargedHypo(DTreeFillData* locTreeFillData, unsigned
 	DLorentzVector locDP4 = locChargedTrackHypothesis->lorentzMomentum();
 	TLorentzVector locP4_Measured(locDP4.Px(), locDP4.Py(), locDP4.Pz(), locDP4.E());
 	locTreeFillData->Fill_Array<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_Measured"), locP4_Measured, locArrayIndex);
+
+	// Global PID
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "PIDFOM"), locChargedTrackHypothesis->Get_FOM(), locArrayIndex);
 
 	//TRACKING INFO
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Tracking"), locTrackTimeBased->Ndof, locArrayIndex);

--- a/src/libraries/ANALYSIS/DParticleComboCreator.cc
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.cc
@@ -320,7 +320,7 @@ const DChargedTrackHypothesis* DParticleComboCreator::Create_ChargedHypo(const D
 	auto locOrigHypo = locChargedTrack->Get_Hypothesis(locPID);
 	auto locNewHypo = dChargedTrackHypothesisFactory->Get_Resource();
 	dCreated_ChargedHypo.push_back(locNewHypo);
-	locNewHypo->Share_FromInput(locOrigHypo, true, false, true); //share all but timing info
+	locNewHypo->Share_FromInput(locOrigHypo, true, false, true, true); //share all but timing info
 
 	auto locTrackPOCAX4 = dSourceComboTimeHandler->Get_ChargedPOCAToVertexX4(locOrigHypo, locIsProductionVertex, locReactionFullCombo, locVertexPrimaryFullCombo, locBeamParticle, false, locVertex);
 	locNewHypo->Set_TimeAtPOCAToVertex(locTrackPOCAX4.T());
@@ -691,12 +691,12 @@ const DChargedTrackHypothesis* DParticleComboCreator::Create_ChargedHypo_KinFit(
 	//therefore, just use measured timing info (pre-kinfit)
 	if(locKinFitParticle->Get_CommonTParamIndex() >= 0)
 	{
-		locNewHypo->Share_FromInput(locOrigHypo, true, true, false); //share all but kinematics
+	  locNewHypo->Share_FromInput(locOrigHypo, true, true, true, false); //share all but kinematics
 		return locNewHypo;
 	}
 
 	//only share tracking info (not timing or kinematics)
-	locNewHypo->Share_FromInput(locOrigHypo, true, false, false);
+	locNewHypo->Share_FromInput(locOrigHypo, true, false, false, false);
 
 	//update timing info
 	if(locKinFitParticle->Get_CommonVxParamIndex() >= 0) //a vertex was fit

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -734,29 +734,45 @@ jerror_t DEventSourceREST::Extract_DTOFPoint(hddm_r::HDDM *record,
       tofpoint->tErr = iter->getTerr();
 
       //Status
-		const hddm_r::TofStatusList& locTofStatusList = iter->getTofStatuses();
-	   hddm_r::TofStatusList::iterator locStatusIterator = locTofStatusList.begin();
-		if(locStatusIterator == locTofStatusList.end())
-		{
-			tofpoint->dHorizontalBar = 0;
-			tofpoint->dVerticalBar = 0;
-			tofpoint->dHorizontalBarStatus = 3;
-			tofpoint->dVerticalBarStatus = 3;
-		}
-		else //should only be 1
-		{
-			for(; locStatusIterator != locTofStatusList.end(); ++locStatusIterator)
-			{
-				int locStatus = locStatusIterator->getStatus(); //horizontal_bar + 45*vertical_bar + 45*45*horizontal_status + 45*45*4*vertical_status
-				tofpoint->dVerticalBarStatus = locStatus/(45*45*4);
-				locStatus %= 45*45*4; //Assume compiler optimizes multiplication
-				tofpoint->dHorizontalBarStatus = locStatus/(45*45);
-				locStatus %= 45*45;
-				tofpoint->dVerticalBar = locStatus/45;
-				tofpoint->dHorizontalBar = locStatus % 45;
-			}
-		}
-
+      const hddm_r::TofStatusList& locTofStatusList = iter->getTofStatuses();
+      hddm_r::TofStatusList::iterator locStatusIterator = locTofStatusList.begin();
+      if(locStatusIterator == locTofStatusList.end())
+	{
+	  tofpoint->dHorizontalBar = 0;
+	  tofpoint->dVerticalBar = 0;
+	  tofpoint->dHorizontalBarStatus = 3;
+	  tofpoint->dVerticalBarStatus = 3;
+	}
+      else //should only be 1
+	{
+	  for(; locStatusIterator != locTofStatusList.end(); ++locStatusIterator)
+	    {
+	      int locStatus = locStatusIterator->getStatus(); //horizontal_bar + 45*vertical_bar + 45*45*horizontal_status + 45*45*4*vertical_status
+	      tofpoint->dVerticalBarStatus = locStatus/(45*45*4);
+	      locStatus %= 45*45*4; //Assume compiler optimizes multiplication
+	      tofpoint->dHorizontalBarStatus = locStatus/(45*45);
+	      locStatus %= 45*45;
+	      tofpoint->dVerticalBar = locStatus/45;
+	      tofpoint->dHorizontalBar = locStatus % 45;
+	    }
+	}
+      // Energy deposition
+      const hddm_r::TofEnergyDepositionList& locTofEnergyDepositionList = iter->getTofEnergyDepositions();
+      hddm_r::TofEnergyDepositionList::iterator locEnergyDepositionIterator = locTofEnergyDepositionList.begin();
+      if(locEnergyDepositionIterator == locTofEnergyDepositionList.end())
+	{
+	  tofpoint->dE1 = 0.;
+	  tofpoint->dE2 = 0.;
+	}
+      else //should only be 1
+	{
+	  for(; locEnergyDepositionIterator != locTofEnergyDepositionList.end(); ++locEnergyDepositionIterator)
+	    {
+	      tofpoint->dE1 = locEnergyDepositionIterator->getDE1();
+	      tofpoint->dE2 = locEnergyDepositionIterator->getDE2();
+	    }
+	}
+      
       data.push_back(tofpoint);
    }
 
@@ -1534,6 +1550,24 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          locTOFHitMatchParams->dDeltaYToHit = tofIter->getDeltay();
 
          locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex], locTOFPoints[locHitIndex], std::const_pointer_cast<const DTOFHitMatchParams>(locTOFHitMatchParams));
+	 
+	 // dE/dx per plane
+	 const hddm_r::TofDedxList& locTofDedxList = tofIter->getTofDedxs();
+	 hddm_r::TofDedxList::iterator locTofDedxIterator = locTofDedxList.begin();
+	 if(locTofDedxIterator == locTofDedxList.end())
+	   {
+	     locTOFHitMatchParams->dEdx1 = 0.;
+	     locTOFHitMatchParams->dEdx2 = 0.;
+	   }
+	 else //should only be 1
+	   {
+	     for(; locTofDedxIterator != locTofDedxList.end(); ++locTofDedxIterator)
+	       {
+		 locTOFHitMatchParams->dEdx1 = locTofDedxIterator->getDEdx1();
+		 locTOFHitMatchParams->dEdx2 = locTofDedxIterator->getDEdx2();
+	       }
+	   }
+	 
       }
 
       const hddm_r::BcalDOCAtoTrackList &bcaldocaList = iter->getBcalDOCAtoTracks();

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -349,6 +349,10 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 		int locStatus = tofpoints[i]->dHorizontalBar + 45*tofpoints[i]->dVerticalBar;
 		locStatus += 45*45*tofpoints[i]->dHorizontalBarStatus + 45*45*4*tofpoints[i]->dVerticalBarStatus;
 		tofstatus().setStatus(locStatus);
+		// Energy deposition for each plane
+		hddm_r::TofEnergyDepositionList tofEnergyDeposition = tof().addTofEnergyDepositions(1);
+		tofEnergyDeposition().setDE1(tofpoints[i]->dE1);
+		tofEnergyDeposition().setDE2(tofpoints[i]->dE2);
 	}
 
 	// push any DSCHit objects to the output record
@@ -555,6 +559,11 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 
 				tofList().setDeltax(locTOFHitMatchParamsVector[loc_k]->dDeltaXToHit);
 				tofList().setDeltay(locTOFHitMatchParamsVector[loc_k]->dDeltaYToHit);
+				// dEdx for each plane
+				hddm_r::TofDedxList tofDedx = tofList().addTofDedxs(1);
+				tofDedx().setDEdx1(locTOFHitMatchParamsVector[loc_k]->dEdx1);
+				tofDedx().setDEdx2(locTOFHitMatchParamsVector[loc_k]->dEdx2);
+
 			}
 
 			vector<shared_ptr<const DSCHitMatchParams>> locSCHitMatchParamsVector;

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -92,6 +92,7 @@
          Note that if it's a single-ended bar, the status cannot be 3. 
       -->
       <tofStatus maxOccurs="1" minOccurs="0" status="int"/>
+      <tofEnergyDeposition maxOccurs="1" minOccurs="0" dE1="float" dE2="float"/>
     </tofPoint>
     <dircHit maxOccurs="unbounded" minOccurs="0" jtag="string" ch="int" t="float" tunit="ns" tot = "float" />
     <RFtime minOccurs="0" jtag="string"
@@ -124,7 +125,9 @@
                 track="int" hit="int"
                 dEdx="float" thit="float" thitvar="float" ehit="float"
                 deltax="float" deltay="float" pathlength="float" tflight="float" tflightvar="float"
-                tunit="ns" lunit="cm" dEdx_unit="GeV/cm"/>
+                tunit="ns" lunit="cm" dEdx_unit="GeV/cm">
+	<tofDedx maxOccurs="1" minOccurs="0" dEdx1="float" dEdx2="float"/>
+      </tofMatchParams>
       <scMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" hit="int"
                 dEdx="float" thit="float" thitvar="float" ehit="float"

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -63,10 +63,11 @@ class DFCALShowerMatchParams
 
 class DTOFHitMatchParams
 {
-	public:
-		DTOFHitMatchParams(void) : dTOFPoint(NULL),
-		dHitTime(0.0), dHitTimeVariance(0.0), dHitEnergy(0.0), dEdx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), 
-		dPathLength(0.0), dDeltaXToHit(0.0), dDeltaYToHit(0.0){}
+ public:
+ DTOFHitMatchParams(void) : dTOFPoint(NULL),
+    dHitTime(0.0), dHitTimeVariance(0.0), dHitEnergy(0.0), dEdx(0.0),
+    dEdx1(0.0), dEdx2(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), 
+    dPathLength(0.0), dDeltaXToHit(0.0), dDeltaYToHit(0.0){}
 
 		const DTOFPoint* dTOFPoint;
 
@@ -75,6 +76,8 @@ class DTOFHitMatchParams
 		double dHitEnergy; //This can be different from DTOFPoint::dE, if the DTOFPoint was (e.g.) an unmatched, single-ended paddle
 
 		double dEdx; //dE/dx; dE: the energy lost by the track, dx: the distance the track traveled through the detector system (dHitEnergy/dEdx)
+		double dEdx1; // dE/dx for plane 1
+		double dEdx2; // dE/dx for plane 2
 		double dFlightTime; //flight time from DKinematicData::position() to the hit
 		double dFlightTimeVariance;
 		double dPathLength; //path length from DKinematicData::position() to the hit

--- a/src/libraries/PID/DKinematicPools.cc
+++ b/src/libraries/PID/DKinematicPools.cc
@@ -5,6 +5,7 @@
 //Declare thread_local resource pools
 thread_local shared_ptr<DResourcePool<DKinematicData::DKinematicInfo>> DKinematicData::dResourcePool_KinematicInfo = std::make_shared<DResourcePool<DKinematicData::DKinematicInfo>>();
 thread_local shared_ptr<DResourcePool<DChargedTrackHypothesis::DTimingInfo>> DChargedTrackHypothesis::dResourcePool_TimingInfo = std::make_shared<DResourcePool<DChargedTrackHypothesis::DTimingInfo>>();
+thread_local shared_ptr<DResourcePool<DChargedTrackHypothesis::DEOverPInfo>> DChargedTrackHypothesis::dResourcePool_EOverPInfo = std::make_shared<DResourcePool<DChargedTrackHypothesis::DEOverPInfo>>();
 thread_local shared_ptr<DResourcePool<DChargedTrackHypothesis::DTrackingInfo>> DChargedTrackHypothesis::dResourcePool_TrackingInfo = std::make_shared<DResourcePool<DChargedTrackHypothesis::DTrackingInfo>>();
 thread_local shared_ptr<DResourcePool<DNeutralParticleHypothesis::DTimingInfo>> DNeutralParticleHypothesis::dResourcePool_TimingInfo = std::make_shared<DResourcePool<DNeutralParticleHypothesis::DTimingInfo>>();
 

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -998,8 +998,8 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DTOFPoi
 	locTOFHitMatchParams->dHitTime = locHitTime;
 	locTOFHitMatchParams->dHitTimeVariance = locHitTimeVariance;
 	locTOFHitMatchParams->dHitEnergy = locHitEnergy;
-
-	locTOFHitMatchParams->dEdx = locHitEnergy/dx;
+	locTOFHitMatchParams->dEdx1 = locTOFPoint->dE1/dx;
+	locTOFHitMatchParams->dEdx2 = locTOFPoint->dE2/dx;
 	locTOFHitMatchParams->dFlightTime = locFlightTime;
 	locTOFHitMatchParams->dFlightTimeVariance = locFlightTimeVariance;
 	locTOFHitMatchParams->dPathLength = locPathLength;
@@ -1297,8 +1297,8 @@ bool DParticleID::Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t>&e
 	locTOFHitMatchParams->dHitTime = locHitTime;
 	locTOFHitMatchParams->dHitTimeVariance = locHitTimeVariance;
 	locTOFHitMatchParams->dHitEnergy = locHitEnergy;
-
-	locTOFHitMatchParams->dEdx = locHitEnergy/dx;
+	locTOFHitMatchParams->dEdx1 = locTOFPoint->dE1/dx;
+	locTOFHitMatchParams->dEdx2 = locTOFPoint->dE2/dx;
 	locTOFHitMatchParams->dFlightTime = locFlightTime;
 	locTOFHitMatchParams->dFlightTimeVariance = locFlightTimeVariance;
 	locTOFHitMatchParams->dPathLength = locPathLength;

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -3301,7 +3301,7 @@ void DParticleID::Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHyp
 	const DTrackTimeBased *track=locChargedTrackHypothesis->Get_TrackTimeBased();
 	double p=track->momentum().Mag();
 
-	// Add dEdx from SC for protons/antiprotons
+	// Add dEdx from SC and/or TOF for protons/antiprotons
 	if (locChargedTrackHypothesis->PID()==Proton
 	    || locChargedTrackHypothesis->PID()==AntiProton){
 	   shared_ptr<const DSCHitMatchParams>scparms=locChargedTrackHypothesis->Get_SCHitMatchParams();
@@ -3312,6 +3312,23 @@ void DParticleID::Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHyp
 	     double chisq=diff*diff/(sigma*sigma);
 	     locChiSq_Total+=chisq;
 	     locNDF_Total+=1;
+	   }
+	   shared_ptr<const DTOFHitMatchParams>tofparms=locChargedTrackHypothesis->Get_TOFHitMatchParams();
+	   if (tofparms!=NULL){
+	     double beta=p/track->energy();
+	     double mean=GetProtondEdxMean_TOF(beta);
+	     double sigma=GetProtondEdxSigma_TOF(beta);
+	     double diff=0.;
+	     if (tofparms->dEdx1>0.){
+	       diff=tofparms->dEdx1-mean;
+	       locChiSq_Total+=diff*diff/(sigma*sigma);
+	       locNDF_Total+=1;
+	     } 
+	     if (tofparms->dEdx2>0.){
+	       diff=tofparms->dEdx2-mean;
+	       locChiSq_Total+=diff*diff/(sigma*sigma);
+	       locNDF_Total+=1;
+	     }
 	   }
 	}
 	// Add E/p for electrons/positrons

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -3324,6 +3324,8 @@ void DParticleID::Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHyp
 	    double diff=bcalparms->dBCALShower->E/p-E_over_p_mean;
 	    double sigma=GetEOverPSigma(SYS_BCAL,p);
 	    double chisq=diff*diff/(sigma*sigma);
+	    locChargedTrackHypothesis->Set_ChiSq_EOverP(SYS_BCAL,chisq,1);
+
 	    locChiSq_Total+=chisq;
 	    locNDF_Total+=1;
 	  } 
@@ -3332,6 +3334,8 @@ void DParticleID::Calc_ChargedPIDFOM(DChargedTrackHypothesis* locChargedTrackHyp
 	    double diff=fcalparms->dFCALShower->getEnergy()/p-E_over_p_mean;
 	    double sigma=GetEOverPSigma(SYS_FCAL,p);
 	    double chisq=diff*diff/(sigma*sigma);
+	    locChargedTrackHypothesis->Set_ChiSq_EOverP(SYS_FCAL,chisq,1);
+
 	    locChiSq_Total+=chisq;
 	    locNDF_Total+=1;
 	  }

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -94,6 +94,8 @@ class DParticleID:public jana::JObject
 		virtual jerror_t GetdEdxSigma_CDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const=0;
 		virtual jerror_t GetdEdxMean_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locMeandEdx, Particle_t locPIDHypothesis) const=0;
 		virtual jerror_t GetdEdxSigma_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const=0;
+		virtual double GetProtondEdxMean_TOF(double locBeta) const=0;
+		virtual double GetProtondEdxSigma_TOF(double locBeta) const=0;
 		virtual double GetProtondEdxMean_SC(double locBeta) const=0;
 		virtual double GetProtondEdxSigma_SC(double locBeta) const=0;
 		virtual double GetTimeVariance(DetectorSystem_t detector,

--- a/src/libraries/PID/DParticleID_PID1.cc
+++ b/src/libraries/PID/DParticleID_PID1.cc
@@ -60,12 +60,14 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     map<string,double> &row = vals[0];
     ddEdxSigmaParams_CDC_N_dependence.push_back(row["p1"]);
     ddEdxSigmaParams_CDC_N_dependence.push_back(row["p2"]); 
-    ddEdxSigmaParams_CDC_N_dependence.push_back(row["p3"]); 
+    ddEdxSigmaParams_CDC_N_dependence.push_back(row["p3"]);
+    /*
     cout << "CDC dEdx N dependence:";
     for (unsigned int i=0;i<ddEdxSigmaParams_CDC_N_dependence.size();i++){
       cout << " " << ddEdxSigmaParams_CDC_N_dependence[i];
     }
     cout<< endl;
+    */
   }
   if (jcalib->Get("CDC/dEdxSigma",vals)==false){
     for(unsigned int i=0; i<vals.size(); i++){
@@ -141,11 +143,13 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     ddEdxSigmaParams_FDC_N_dependence.push_back(row["p1"]);
     ddEdxSigmaParams_FDC_N_dependence.push_back(row["p2"]); 
     ddEdxSigmaParams_FDC_N_dependence.push_back(row["p3"]);
+    /*
     cout << "FDC dEdx N dependence:";
     for (unsigned int i=0;i<ddEdxSigmaParams_FDC_N_dependence.size();i++){
       cout << " " << ddEdxSigmaParams_FDC_N_dependence[i];
     }
     cout<< endl;
+    */
   }
   if (jcalib->Get("FDC/dEdxSigma",vals)==false){
     for(unsigned int i=0; i<vals.size(); i++){
@@ -188,6 +192,21 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     ddEdxSigmaParams_SC_Proton.push_back(row["s3"]);
     ddEdxSigmaParams_SC_Proton.push_back(row["s4"]);
   }
+  if (jcalib->Get("TOF/dEdxProtonMean",vals)==false){ 
+    map<string,double> &row = vals[0];
+    ddEdxMeanParams_TOF_Proton.push_back(row["m1"]);
+    ddEdxMeanParams_TOF_Proton.push_back(row["m2"]);
+    ddEdxMeanParams_TOF_Proton.push_back(row["m3"]);
+    ddEdxMeanParams_TOF_Proton.push_back(row["m4"]);
+  } 
+  if (jcalib->Get("TOF/dEdxProtonSigma",vals)==false){  
+    map<string,double> &row = vals[0];
+    ddEdxSigmaParams_TOF_Proton.push_back(row["s1"]);
+    ddEdxSigmaParams_TOF_Proton.push_back(row["s2"]);
+    ddEdxSigmaParams_TOF_Proton.push_back(row["s3"]);
+    ddEdxSigmaParams_TOF_Proton.push_back(row["s4"]);
+  }
+
 
   loop->GetSingle(dTOFGeometry);
   string locTOFTimeSigmasTable = dTOFGeometry->Get_CCDB_DirectoryName() + "/TimeSigmas";
@@ -365,6 +384,14 @@ double DParticleID_PID1::GetEOverPSigma(DetectorSystem_t detector,
   return mean;
 }
 
+double DParticleID_PID1::GetProtondEdxMean_TOF(double locBeta) const{
+  double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);
+  return 0.001*Function_dEdx(locBetaGammaValue, ddEdxMeanParams_TOF_Proton);  
+}
+double DParticleID_PID1::GetProtondEdxSigma_TOF(double locBeta) const{
+  double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);
+  return 0.001*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_TOF_Proton);  
+}
 
 double DParticleID_PID1::GetProtondEdxMean_SC(double locBeta) const{
   double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);

--- a/src/libraries/PID/DParticleID_PID1.cc
+++ b/src/libraries/PID/DParticleID_PID1.cc
@@ -427,7 +427,9 @@ jerror_t DParticleID_PID1::GetdEdxMean_CDC(double locBeta, unsigned int locNumHi
 
 jerror_t DParticleID_PID1::GetdEdxSigma_CDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const
 {
-  double Nscale=3.1*pow(double(locNumHitsUsedFordEdx),-0.67)+0.06;
+  double Nscale=ddEdxSigmaParams_CDC_N_dependence[0]
+    *pow(double(locNumHitsUsedFordEdx),ddEdxSigmaParams_CDC_N_dependence[1])
+    +ddEdxSigmaParams_CDC_N_dependence[2];
   double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);
   if((locPIDHypothesis == Electron) || (locPIDHypothesis == Positron)){
     locSigmadEdx = Nscale*Function_dEdx(locBetaGammaValue, ddEdxSigmaParams_CDC_Electron)/1000000.0;

--- a/src/libraries/PID/DParticleID_PID1.cc
+++ b/src/libraries/PID/DParticleID_PID1.cc
@@ -55,6 +55,17 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     ddEdxSigmaParams_CDC_Electron.push_back(row["s2"]);
     ddEdxSigmaParams_CDC_Electron.push_back(row["s3"]);
     ddEdxSigmaParams_CDC_Electron.push_back(row["s4"]);
+  } 
+  if (jcalib->Get("CDC/dEdxNdep",vals)==false){
+    map<string,double> &row = vals[0];
+    ddEdxSigmaParams_CDC_N_dependence.push_back(row["p1"]);
+    ddEdxSigmaParams_CDC_N_dependence.push_back(row["p2"]); 
+    ddEdxSigmaParams_CDC_N_dependence.push_back(row["p3"]); 
+    cout << "CDC dEdx N dependence:";
+    for (unsigned int i=0;i<ddEdxSigmaParams_CDC_N_dependence.size();i++){
+      cout << " " << ddEdxSigmaParams_CDC_N_dependence[i];
+    }
+    cout<< endl;
   }
   if (jcalib->Get("CDC/dEdxSigma",vals)==false){
     for(unsigned int i=0; i<vals.size(); i++){
@@ -124,6 +135,17 @@ DParticleID_PID1::DParticleID_PID1(JEventLoop *loop):DParticleID(loop)
     ddEdxSigmaParams_FDC_Electron.push_back(row["s2"]);
     ddEdxSigmaParams_FDC_Electron.push_back(row["s3"]);
     ddEdxSigmaParams_FDC_Electron.push_back(row["s4"]);
+  }
+  if (jcalib->Get("FDC/dEdxNdep",vals)==false){
+    map<string,double> &row = vals[0];
+    ddEdxSigmaParams_FDC_N_dependence.push_back(row["p1"]);
+    ddEdxSigmaParams_FDC_N_dependence.push_back(row["p2"]); 
+    ddEdxSigmaParams_FDC_N_dependence.push_back(row["p3"]);
+    cout << "FDC dEdx N dependence:";
+    for (unsigned int i=0;i<ddEdxSigmaParams_FDC_N_dependence.size();i++){
+      cout << " " << ddEdxSigmaParams_FDC_N_dependence[i];
+    }
+    cout<< endl;
   }
   if (jcalib->Get("FDC/dEdxSigma",vals)==false){
     for(unsigned int i=0; i<vals.size(); i++){
@@ -378,21 +400,22 @@ jerror_t DParticleID_PID1::GetdEdxMean_CDC(double locBeta, unsigned int locNumHi
 
 jerror_t DParticleID_PID1::GetdEdxSigma_CDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const
 {
+  double Nscale=3.1*pow(double(locNumHitsUsedFordEdx),-0.67)+0.06;
   double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);
   if((locPIDHypothesis == Electron) || (locPIDHypothesis == Positron)){
-    locSigmadEdx = Function_dEdx(locBetaGammaValue, ddEdxSigmaParams_CDC_Electron)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdx(locBetaGammaValue, ddEdxSigmaParams_CDC_Electron)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == Proton) || (locPIDHypothesis == AntiProton)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_Proton)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_Proton)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == KPlus) || (locPIDHypothesis == KMinus)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_KPlus)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_KPlus)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == PiPlus) || (locPIDHypothesis == PiMinus)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_PiPlus)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_CDC_PiPlus)/1000000.0;
     return NOERROR;
   }
   
@@ -424,21 +447,24 @@ jerror_t DParticleID_PID1::GetdEdxMean_FDC(double locBeta, unsigned int locNumHi
 
 jerror_t DParticleID_PID1::GetdEdxSigma_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const
 {
+  double Nscale=ddEdxSigmaParams_FDC_N_dependence[0]
+    *pow(double(locNumHitsUsedFordEdx),ddEdxSigmaParams_FDC_N_dependence[1])
+    +ddEdxSigmaParams_FDC_N_dependence[2];
   double locBetaGammaValue = locBeta/sqrt(1.0 - locBeta*locBeta);
   if((locPIDHypothesis == Electron) || (locPIDHypothesis == Positron)){
-    locSigmadEdx = Function_dEdx(locBetaGammaValue, ddEdxSigmaParams_FDC_Electron)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdx(locBetaGammaValue, ddEdxSigmaParams_FDC_Electron)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == Proton) || (locPIDHypothesis == AntiProton)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_Proton)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_Proton)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == KPlus) || (locPIDHypothesis == KMinus)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_KPlus)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_KPlus)/1000000.0;
     return NOERROR;
   }
   if((locPIDHypothesis == PiPlus) || (locPIDHypothesis == PiMinus)){
-    locSigmadEdx = Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_PiPlus)/1000000.0;
+    locSigmadEdx = Nscale*Function_dEdxSigma(locBetaGammaValue, ddEdxSigmaParams_FDC_PiPlus)/1000000.0;
     return NOERROR;
   }
 

--- a/src/libraries/PID/DParticleID_PID1.h
+++ b/src/libraries/PID/DParticleID_PID1.h
@@ -45,10 +45,12 @@ class DParticleID_PID1:public DParticleID{
 	vector<float> dEOverPMeanParams_BCAL;
 	vector<float> dEOverPMeanParams_FCAL;
 
+	vector<float> ddEdxSigmaParams_FDC_N_dependence;
 	vector<float> ddEdxSigmaParams_FDC_Proton;
 	vector<float> ddEdxSigmaParams_FDC_KPlus;
 	vector<float> ddEdxSigmaParams_FDC_PiPlus;
 	vector<float> ddEdxSigmaParams_FDC_Electron;
+	vector<float> ddEdxSigmaParams_CDC_N_dependence;
 	vector<float> ddEdxSigmaParams_CDC_Proton;
 	vector<float> ddEdxSigmaParams_CDC_KPlus;
 	vector<float> ddEdxSigmaParams_CDC_PiPlus;

--- a/src/libraries/PID/DParticleID_PID1.h
+++ b/src/libraries/PID/DParticleID_PID1.h
@@ -20,6 +20,8 @@ class DParticleID_PID1:public DParticleID{
 	jerror_t GetdEdxSigma_CDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const;
 	jerror_t GetdEdxMean_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locMeandEdx, Particle_t locPIDHypothesis) const;
 	jerror_t GetdEdxSigma_FDC(double locBeta, unsigned int locNumHitsUsedFordEdx, double& locSigmadEdx, Particle_t locPIDHypothesis) const;
+	double GetProtondEdxMean_TOF(double locBeta) const;
+	double GetProtondEdxSigma_TOF(double locBeta) const;
 	double GetProtondEdxMean_SC(double locBeta) const;
 	double GetProtondEdxSigma_SC(double locBeta) const;
 	double GetEOverPMean(DetectorSystem_t detector,double p) const;
@@ -41,6 +43,7 @@ class DParticleID_PID1:public DParticleID{
 	vector<float> ddEdxMeanParams_CDC_PiPlus;
 	vector<float> ddEdxMeanParams_CDC_Electron;
 	vector<float> ddEdxMeanParams_SC_Proton;
+	vector<float> ddEdxMeanParams_TOF_Proton;
 
 	vector<float> dEOverPMeanParams_BCAL;
 	vector<float> dEOverPMeanParams_FCAL;
@@ -56,6 +59,7 @@ class DParticleID_PID1:public DParticleID{
 	vector<float> ddEdxSigmaParams_CDC_PiPlus;
 	vector<float> ddEdxSigmaParams_CDC_Electron;
 	vector<float> ddEdxSigmaParams_SC_Proton;
+	vector<float> ddEdxSigmaParams_TOF_Proton;
 
 	vector<float> dTimeSigmaParams_TOF_Proton;
 	vector<float> dTimeSigmaParams_TOF_KPlus;


### PR DESCRIPTION
Various updates to PIDFOM scheme:
1) Add PIDFOM to tree output
2) Change how E/p is handled, using shared pointers and a dEOverPInfo subclass
3) Add dE/dx from TOF for proton ID
4) Add dependence of dE/dx in CDC and FDC on the number of hits used in the calculation