### PR TITLE
Skip physics event blocks

### DIFF
--- a/src/libraries/DANA/DApplication.h
+++ b/src/libraries/DANA/DApplication.h
@@ -60,6 +60,16 @@ class DApplication:public JApplication{
 		pthread_rwlock_t* GetRootFillLock( JEventProcessor *proc ) {
 			return root_fill_rw_lock.count( proc ) == 0 ? nullptr : root_fill_rw_lock[proc];
 		}
+		
+		// Theses methods allow setting of the JApplication protected
+		// members that are used to keep track of events read and processed.
+		// This is done here since changing the JANA source would require
+		// time to propagate whereas this is motivated by changes to
+		// JEventSourceEVIOpp and can be propagated with those much easier.
+		void SetNEventsRead( uint64_t newval ){ NEvents_read = newval; }
+		void SetNEventsProcessed( uint64_t newval ){ NEvents = newval; }
+		void AddNEventsRead( uint64_t newval ){ NEvents_read += newval; }
+		void AddNEventsProcessed( uint64_t newval ){ NEvents += newval; }
 
 	protected:
 	

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -749,7 +749,7 @@ HDEVIO::BLOCKTYPE HDEVIO::GetCurrentBlockType(void)
 //------------------------
 uint64_t HDEVIO::GetCurrentBlockNevents(void)
 {
-    return NB_block_record.block_type;
+    return NB_block_record.evio_events.size();
 }
 //------------------------
 // GetEVIOBlockRecords
@@ -974,7 +974,8 @@ void HDEVIO::MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br)
 			case 0x0070: er.event_type = kBT_BOR;        break;
 			case 0xFF50:
 			case 0xFF51:
-			case 0xFF70:
+			case 0xFF70:  // SEB
+			case 0xFF78:  // SEB w/ sync
 				er.event_type = kBT_PHYSICS;
 				er.first_event  = eh->physics.first_event_lo;
 				er.first_event += ((uint64_t)eh->physics.first_event_hi)<<32;

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -435,7 +435,10 @@ bool HDEVIO::readSparse(uint32_t *user_buff, uint32_t user_buff_len, bool allow_
 		
 		EVIOEventRecord &er = sparse_block_iter->evio_events[sparse_event_idx];
 
-		uint32_t event_len = er.event_len;
+        // Copy event record type into block record as the type so calls to GetCurrentBlockType will be valid.
+        sparse_block_iter->block_type = er.event_type;
+
+        uint32_t event_len = er.event_len;
 		last_event_len = event_len;
 	
 		// Check if user buffer is big enough to hold block
@@ -583,6 +586,9 @@ bool HDEVIO::readNoFileBuff(uint32_t *user_buff, uint32_t user_buff_len, bool al
 
 	// Grab next event record
 	EVIOEventRecord &er = br.evio_events.front();
+
+	// Copy event record type into block record as the type so calls to GetCurrentBlockType will be valid.
+	br.block_type = er.event_type;
 	
 	uint32_t event_len = er.event_len;
 	last_event_len = event_len;
@@ -717,6 +723,34 @@ uint32_t HDEVIO::AddToEventMask(string type_str)
 	return 0;
 }
 
+//------------------------
+// GetCurrentBlockType
+//
+// Returns the type of the current block. This will be the
+// one corresponding to the last call to something like
+// readNoFileBuff(). Note that the "block_type" field is
+// actually copied from the "event_type" field of the last
+// event presented from the block. I believe (though an not
+// 100% sure) that all events in a block are of the same type.
+// Even if that is true, it could change in the future. Thus,
+// we report the block type based on the event last given to
+// the caller.
+//------------------------
+HDEVIO::BLOCKTYPE HDEVIO::GetCurrentBlockType(void)
+{
+    return NB_block_record.block_type;
+}
+
+//------------------------
+// GetCurrentBlockNevents
+//
+// Returns the number of events in the current EVIO block.
+//
+//------------------------
+uint64_t HDEVIO::GetCurrentBlockNevents(void)
+{
+    return NB_block_record.block_type;
+}
 //------------------------
 // GetEVIOBlockRecords
 //------------------------

--- a/src/libraries/DAQ/HDEVIO.h
+++ b/src/libraries/DAQ/HDEVIO.h
@@ -218,6 +218,8 @@ class HDEVIO{
 		uint32_t SetEventMask(uint32_t mask);
 		uint32_t SetEventMask(string types_str);
 		uint32_t AddToEventMask(string type_str);
+		BLOCKTYPE GetCurrentBlockType(void); // from last read block
+        uint64_t  GetCurrentBlockNevents(void); // from last read block
 		vector<EVIOBlockRecord>& GetEVIOBlockRecords(void);
 		
 	protected:

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -146,6 +146,10 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		std::chrono::high_resolution_clock::time_point tend;
 
 		uint32_t BLOCKS_TO_SKIP;
+		uint32_t PHYSICS_BLOCKS_TO_SKIP;
+		uint32_t PHYSICS_BLOCKS_SKIPPED;
+        uint32_t PHYSICS_BLOCKS_TO_KEEP;
+        uint32_t PHYSICS_BLOCKS_KEPT;
 		uint32_t MAX_PARSED_EVENTS;
 		mutex PARSED_EVENTS_MUTEX;
 		condition_variable PARSED_EVENTS_CV;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -27,6 +27,7 @@
 #include <DAQ/Df250EmulatorAlgorithm.h>
 #include <DAQ/Df125EmulatorAlgorithm.h>
 
+#include <DANA/DApplication.h>
 #include <DANA/DStatusBits.h>
 
 /// How this Event Source Works
@@ -138,8 +139,10 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		               void AddEmulatedObjectsToCallStack(JEventLoop *loop, string caller, string callee);
 		               void AddROCIDtoParseList(uint32_t rocid){ ROCIDS_TO_PARSE.insert(rocid); }
 		      set<uint32_t> GetROCIDParseList(uint32_t rocid){ return ROCIDS_TO_PARSE; }
+		               void DumpBinary(const uint32_t *iptr, const uint32_t *iend, uint32_t MaxWords=0, const uint32_t *imark=NULL);
 
-		
+
+		DApplication *dapp = NULL;
 		bool DONE;
 		bool DISPATCHER_END;
 		std::chrono::high_resolution_clock::time_point tstart;


### PR DESCRIPTION
This allows one to skip a specific number of blocks of physics events at the EVIO source and keep a number after that. This makes it quicker to jump to the middle of the file and start processing events there.

This also fixes an issue where blocks of physics events where the sync flag is set where being marked as "unknown" instead of "physics". 