### PR TITLE
Extend beam fiducial histograms to cover up to 4 hour run

### DIFF
--- a/src/libraries/DANA/DApplication.h
+++ b/src/libraries/DANA/DApplication.h
@@ -60,6 +60,16 @@ class DApplication:public JApplication{
 		pthread_rwlock_t* GetRootFillLock( JEventProcessor *proc ) {
 			return root_fill_rw_lock.count( proc ) == 0 ? nullptr : root_fill_rw_lock[proc];
 		}
+		
+		// Theses methods allow setting of the JApplication protected
+		// members that are used to keep track of events read and processed.
+		// This is done here since changing the JANA source would require
+		// time to propagate whereas this is motivated by changes to
+		// JEventSourceEVIOpp and can be propagated with those much easier.
+		void SetNEventsRead( uint64_t newval ){ NEvents_read = newval; }
+		void SetNEventsProcessed( uint64_t newval ){ NEvents = newval; }
+		void AddNEventsRead( uint64_t newval ){ NEvents_read += newval; }
+		void AddNEventsProcessed( uint64_t newval ){ NEvents += newval; }
 
 	protected:
 	

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -749,7 +749,7 @@ HDEVIO::BLOCKTYPE HDEVIO::GetCurrentBlockType(void)
 //------------------------
 uint64_t HDEVIO::GetCurrentBlockNevents(void)
 {
-    return NB_block_record.block_type;
+    return NB_block_record.evio_events.size();
 }
 //------------------------
 // GetEVIOBlockRecords
@@ -974,7 +974,8 @@ void HDEVIO::MapEvents(BLOCKHEADER_t &bh, EVIOBlockRecord &br)
 			case 0x0070: er.event_type = kBT_BOR;        break;
 			case 0xFF50:
 			case 0xFF51:
-			case 0xFF70:
+			case 0xFF70:  // SEB
+			case 0xFF78:  // SEB w/ sync
 				er.event_type = kBT_PHYSICS;
 				er.first_event  = eh->physics.first_event_lo;
 				er.first_event += ((uint64_t)eh->physics.first_event_hi)<<32;

--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -435,7 +435,10 @@ bool HDEVIO::readSparse(uint32_t *user_buff, uint32_t user_buff_len, bool allow_
 		
 		EVIOEventRecord &er = sparse_block_iter->evio_events[sparse_event_idx];
 
-		uint32_t event_len = er.event_len;
+        // Copy event record type into block record as the type so calls to GetCurrentBlockType will be valid.
+        sparse_block_iter->block_type = er.event_type;
+
+        uint32_t event_len = er.event_len;
 		last_event_len = event_len;
 	
 		// Check if user buffer is big enough to hold block
@@ -583,6 +586,9 @@ bool HDEVIO::readNoFileBuff(uint32_t *user_buff, uint32_t user_buff_len, bool al
 
 	// Grab next event record
 	EVIOEventRecord &er = br.evio_events.front();
+
+	// Copy event record type into block record as the type so calls to GetCurrentBlockType will be valid.
+	br.block_type = er.event_type;
 	
 	uint32_t event_len = er.event_len;
 	last_event_len = event_len;
@@ -717,6 +723,34 @@ uint32_t HDEVIO::AddToEventMask(string type_str)
 	return 0;
 }
 
+//------------------------
+// GetCurrentBlockType
+//
+// Returns the type of the current block. This will be the
+// one corresponding to the last call to something like
+// readNoFileBuff(). Note that the "block_type" field is
+// actually copied from the "event_type" field of the last
+// event presented from the block. I believe (though an not
+// 100% sure) that all events in a block are of the same type.
+// Even if that is true, it could change in the future. Thus,
+// we report the block type based on the event last given to
+// the caller.
+//------------------------
+HDEVIO::BLOCKTYPE HDEVIO::GetCurrentBlockType(void)
+{
+    return NB_block_record.block_type;
+}
+
+//------------------------
+// GetCurrentBlockNevents
+//
+// Returns the number of events in the current EVIO block.
+//
+//------------------------
+uint64_t HDEVIO::GetCurrentBlockNevents(void)
+{
+    return NB_block_record.block_type;
+}
 //------------------------
 // GetEVIOBlockRecords
 //------------------------

--- a/src/libraries/DAQ/HDEVIO.h
+++ b/src/libraries/DAQ/HDEVIO.h
@@ -218,6 +218,8 @@ class HDEVIO{
 		uint32_t SetEventMask(uint32_t mask);
 		uint32_t SetEventMask(string types_str);
 		uint32_t AddToEventMask(string type_str);
+		BLOCKTYPE GetCurrentBlockType(void); // from last read block
+        uint64_t  GetCurrentBlockNevents(void); // from last read block
 		vector<EVIOBlockRecord>& GetEVIOBlockRecords(void);
 		
 	protected:

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -146,6 +146,10 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		std::chrono::high_resolution_clock::time_point tend;
 
 		uint32_t BLOCKS_TO_SKIP;
+		uint32_t PHYSICS_BLOCKS_TO_SKIP;
+		uint32_t PHYSICS_BLOCKS_SKIPPED;
+        uint32_t PHYSICS_BLOCKS_TO_KEEP;
+        uint32_t PHYSICS_BLOCKS_KEPT;
 		uint32_t MAX_PARSED_EVENTS;
 		mutex PARSED_EVENTS_MUTEX;
 		condition_variable PARSED_EVENTS_CV;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -27,6 +27,7 @@
 #include <DAQ/Df250EmulatorAlgorithm.h>
 #include <DAQ/Df125EmulatorAlgorithm.h>
 
+#include <DANA/DApplication.h>
 #include <DANA/DStatusBits.h>
 
 /// How this Event Source Works
@@ -138,8 +139,10 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 		               void AddEmulatedObjectsToCallStack(JEventLoop *loop, string caller, string callee);
 		               void AddROCIDtoParseList(uint32_t rocid){ ROCIDS_TO_PARSE.insert(rocid); }
 		      set<uint32_t> GetROCIDParseList(uint32_t rocid){ return ROCIDS_TO_PARSE; }
+		               void DumpBinary(const uint32_t *iptr, const uint32_t *iend, uint32_t MaxWords=0, const uint32_t *imark=NULL);
 
-		
+
+		DApplication *dapp = NULL;
 		bool DONE;
 		bool DISPATCHER_END;
 		std::chrono::high_resolution_clock::time_point tstart;

--- a/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
+++ b/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
@@ -35,6 +35,7 @@ static TH1I *psflux_num_events;
 static TH1F *hFiducialTime;
 static TH1I *hBeamCurrentTime;
 static TH1I *hBeamCurrentTimeFiducial;
+static TH1I *hBeamCurrentTimeFiducialCut;
 static TH2I *hPS_tdiffVsE;
 static TH2I *hPSC_tdiffVsE;
 static TH2I *hPSPSC_tdiffVsE;
@@ -116,8 +117,9 @@ jerror_t JEventProcessor_PS_flux::init(void)
     // book hists
     psflux_num_events = new TH1I("psflux_num_events","PS flux number of events",3,0.5,3.5);
     hFiducialTime = new TH1F("fiducialTime", "Fiducial time", 1, 0, 1);
-    hBeamCurrentTime = new TH1I("beamCurrentTime", "; Event time from DBeamCurrent for all events (seconds)", 1000, 0, 500);
-    hBeamCurrentTimeFiducial = new TH1I("beamCurrentTimeFiducial", "; Event time from DBeamCurrent for fiducial events (seconds)", 1000, 0, 500);
+    hBeamCurrentTime = new TH1I("beamCurrentTime", "; Event time from DBeamCurrent for all events (seconds)", 14400, 0, 14400);
+    hBeamCurrentTimeFiducial = new TH1I("beamCurrentTimeFiducial", "; Fiducial flag for event time from DBeamCurrent (seconds)", 14400, 0, 14400);
+    hBeamCurrentTimeFiducialCut = new TH1I("beamCurrentTimeFiducialCut", "; Event time from DBeamCurrent for fiducial events (seconds)", 14400, 0, 14400);
 
     //
     gDirectory->mkdir("PSC_PS")->cd();
@@ -323,6 +325,7 @@ jerror_t JEventProcessor_PS_flux::evnt(JEventLoop *loop, uint64_t eventnumber)
 	    if(beamCurrent[0]->is_fiducial) {
 	    	    int timeBin = hBeamCurrentTimeFiducial->FindBin(beamCurrent[0]->t);
 		    hBeamCurrentTimeFiducial->SetBinContent(timeBin, 1);
+			 hBeamCurrentTimeFiducialCut->Fill(beamCurrent[0]->t);
   	    }
     }
 


### PR DESCRIPTION
This extends two histograms in the PS_flux plugin to cover out to 14400 seconds(=4hr) instead of just the first 500 seconds of a run. A 3rd histogram was added to give a slightly different view of the fiducial map. By extending these, they can be used to verify the correctness of the fiducial map for the entire run.

Please note that this change only includes 1 file. This pull request is being made from a branch copied from a branch which has a pending PR. If you look at this before that is merged, you will see many other changes.