### PR TITLE
Update beam trip timestamp conversions

### DIFF
--- a/src/libraries/DAQ/DBeamCurrent_factory.cc
+++ b/src/libraries/DAQ/DBeamCurrent_factory.cc
@@ -14,6 +14,7 @@
 using namespace std;
 
 #include <DAQ/DCODAEventInfo.h>
+#include <DAQ/DCODAROCInfo.h>
 #include "DBeamCurrent_factory.h"
 using namespace jana;
 

--- a/src/libraries/DAQ/DBeamCurrent_factory.cc
+++ b/src/libraries/DAQ/DBeamCurrent_factory.cc
@@ -26,9 +26,11 @@ jerror_t DBeamCurrent_factory::init(void)
 {
 	BEAM_ON_MIN_nA  = 10.0;  // nA
 	BEAM_TRIP_MIN_T = 3.0;   // seconds
+	SYNCSKIM_ROCID  = 34;    // rocBCAL4
 	
 	gPARMS->SetDefaultParameter("BEAM_ON_MIN_nA", BEAM_ON_MIN_nA, "Minimum current in nA to consider the beam \"on\" by DBeamCurrent");
 	gPARMS->SetDefaultParameter("BEAM_TRIP_MIN_T", BEAM_TRIP_MIN_T, "Minimum amount of time in seconds that event is away from beam trips to be considered fiducial");
+	gPARMS->SetDefaultParameter("SYNCSKIM:ROCID", SYNCSKIM_ROCID, "ROC id from which to use timestamp. Set to 0 to use average timestamp from CODA EB. Default is 34 (rocBCAL4)");
 
 	ticks_per_sec      = 250.011E6; // 250MHz clock (may be overwritten with calib constant in brun)
 	rcdb_start_time    = 0;       // unix time of when 250MHz clock was reset. (overwritten below)
@@ -73,7 +75,6 @@ jerror_t DBeamCurrent_factory::brun(jana::JEventLoop *loop, int32_t runnumber)
 		rcdb_250MHz_offset_tics = stoull(mcalib["rcdb_250MHz_offset_tics"].c_str());
 		rcdb_start_time         = stoull(mcalib["rcdb_start_time"].c_str());
 	}
-
 	
 	// Parse text to create Boundary objects and maps of trip/recovery points
 	istringstream ss(electron_beam_current);
@@ -153,9 +154,29 @@ jerror_t DBeamCurrent_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
 	if(codainfos.empty()) return NOERROR;
 	const DCODAEventInfo *codainfo = codainfos[0];
 
+	// Get timestamp
+	uint64_t mytimestamp = 0.0;
+	if( SYNCSKIM_ROCID == 0 ){
+		// ROCID=0 means use the EB calculated avg. timestamp
+		// This used to be the default until problems were seen
+		// in the RunPeriod-2019-11 data.
+		mytimestamp = codainfo->avg_timestamp;
+	}else{
+		// Use timestamp from the specified ROC. The default is 
+		// ROCID=34 which is the rocBCAL4 crate.
+		vector<const DCODAROCInfo*> codarocinfos;
+		loop->Get(codarocinfos);
+		for( auto codarocinfo : codarocinfos ){
+			if( codarocinfo->rocid == SYNCSKIM_ROCID ){
+				mytimestamp = codarocinfo->timestamp;
+				break;
+			}
+		}
+	}
+
 	// Get tme relative to RCDB recorded start time of event
 	// (all times in trip map are recorded relative to this as well)	
-	double t = (codainfo->avg_timestamp - (double)rcdb_250MHz_offset_tics)/ticks_per_sec;
+	double t = (mytimestamp - (double)rcdb_250MHz_offset_tics)/ticks_per_sec;
 
 	// Find closest entry given current time
 	auto it = boundaries.begin();

--- a/src/libraries/DAQ/DBeamCurrent_factory.h
+++ b/src/libraries/DAQ/DBeamCurrent_factory.h
@@ -25,7 +25,7 @@ class DBeamCurrent_factory:public jana::JFactory<DBeamCurrent>{
 
 		double BEAM_ON_MIN_nA;
 		double BEAM_TRIP_MIN_T;
-		int    SYNCSKIM_ROCID;
+		uint32_t SYNCSKIM_ROCID;
 
 		vector<Boundary> boundaries; // key=time  val=Ibeam
 		vector<double> trip;

--- a/src/libraries/DAQ/DBeamCurrent_factory.h
+++ b/src/libraries/DAQ/DBeamCurrent_factory.h
@@ -25,6 +25,7 @@ class DBeamCurrent_factory:public jana::JFactory<DBeamCurrent>{
 
 		double BEAM_ON_MIN_nA;
 		double BEAM_TRIP_MIN_T;
+		int    SYNCSKIM_ROCID;
 
 		vector<Boundary> boundaries; // key=time  val=Ibeam
 		vector<double> trip;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -422,15 +422,7 @@ void JEventSource_EVIOpp::Dispatcher(void)
                         uint32_t M = (buff[1]>>24);
                         Nevents_read += M;  // (this is never really used)
 								if(dapp) dapp->AddNEventsRead( M ); // This is so the JANA ticker will reflect how many events were actually read
-								
-								if(PHYSICS_BLOCKS_SKIPPED<3){
-									_DBG_<<"hdevio->GetCurrentBlockType() = " << hdevio->GetCurrentBlockType() << endl;
-									DumpBinary(buff, nullptr, 8);
-								}
 								continue;
-					 }else{
-					 	_DBG_<<"hdevio->GetCurrentBlockType() = " << hdevio->GetCurrentBlockType() << endl;
-						DumpBinary(buff, nullptr, 8);
 					 }
 				}
 

--- a/src/plugins/Utilities/syncskim/ConversionParms.h
+++ b/src/plugins/Utilities/syncskim/ConversionParms.h
@@ -1,0 +1,32 @@
+
+#include <TObject.h>
+
+// This is used to hold the 2 parameters used
+// to convert the timestamp to unix time. In
+// the original implementation, these values
+// were only printed to the screen and a script
+// captured them via std.out. The plugin has
+// now been upgraded for use in the offline
+// monitoring as well. Thus, we save the values
+// in the ROOT file too. 
+//
+// This is done using a TTree instead of a simple
+// histogram so when the offmon job merges the
+// root files for all files in the run, the 
+// individual values are still available. The
+// first and last event numbers are recorded
+// here so we know what range of events each set
+// of values corresponds to in case the merging
+// of the trees does not preserve order.
+
+class ConversionParms:public TObject
+{
+	public:
+		UInt_t    run_number;
+		ULong64_t first_event_number;
+		ULong64_t last_event_number;
+		ULong64_t tics_per_sec;
+		ULong64_t unix_start_time;
+		
+		ClassDef(ConversionParms ,1)
+};

--- a/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
+++ b/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
@@ -15,6 +15,7 @@
 #include <TFile.h>
 #include <TTree.h>
 #include <SyncEvent.h>
+#include <ConversionParms.h>
 
 class JEventProcessor_syncskim:public jana::JEventProcessor{
 	public:
@@ -23,8 +24,10 @@ class JEventProcessor_syncskim:public jana::JEventProcessor{
 		const char* className(void){return "JEventProcessor_syncskim";}
 
 		SyncEvent synevt;
+		ConversionParms convparms;
 		TFile *file;
 		TTree *tree;
+		TTree *conversion_tree;
 		
 		uint32_t SYNCSKIM_ROCID;
 

--- a/src/plugins/Utilities/syncskim/get_parms2.C
+++ b/src/plugins/Utilities/syncskim/get_parms2.C
@@ -1,0 +1,24 @@
+
+// This is an alternate method to print the parameters used to
+// convert timestamps to unix time. This gets the values from
+// the conversion_tree in the file synskim.root. You can run it
+// like this (with the syncskim.root file in the same directory.
+//
+// root -l syncskim.root
+
+
+void get_parms2(void)
+{
+
+	auto chain = new TChain("conversion_tree", "conversion params chain");
+	chain->AddFile("syncskim.root");
+	
+	ULong_t tics_per_sec;
+	ULong_t unix_start_time;
+	chain->SetBranchAddress("tics_per_sec", &tics_per_sec);
+	chain->SetBranchAddress("unix_start_time", &unix_start_time);
+	chain->GetEntry(0);
+	
+	cout << endl << "timestamp to unix time conversion: tics_per_sec=" << tics_per_sec << " unix_start_time=" << unix_start_time << endl << endl;
+}
+


### PR DESCRIPTION
This updates the DBeamPhoton factory to use the rocBCAL4 timestamp instead of the EB calculated avg. timestamp.
It also fixes the syncskim plugin to properly use this everywhere. The conversion values calculated at the end of the job are also now written to a dedicated tree so we don't need to rely on capturing the stdout of the plugin.

This also fixes a problem in syncskim that it was not locking the ROOT mutex during fini when writing and closing the syncskim.root file.

Some debug statements accidentally left in from another recent PR were removed as well.