### PR TITLE
Justin's proposed fix for the Beam__IsGenerator flag in the analysis …

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1515,7 +1515,9 @@ void DEventWriterROOT::Fill_BeamData(DTreeFillData* locTreeFillData, unsigned in
 	//MATCHING
 	if(locMCThrownMatching != NULL)
 	{
-		Bool_t locIsGeneratorFlag = (locMCThrownMatching->Get_TaggedMCGENBeamPhoton() == locBeamPhoton) ? kTRUE : kFALSE;
+	        // Tag the thrown beam photon by comparing energy, time and counter
+	        const DBeamPhoton* locBeamPhotonTaggedMCGEN = locMCThrownMatching->Get_TaggedMCGENBeamPhoton();
+		Bool_t locIsGeneratorFlag = (locBeamPhotonTaggedMCGEN->energy() == locBeamPhoton->energy() && locBeamPhotonTaggedMCGEN->dCounter == locBeamPhoton->dCounter && locBeamPhotonTaggedMCGEN->time() == locBeamPhoton->time()) ? kTRUE : kFALSE;
 		locTreeFillData->Fill_Array<Bool_t>(Build_BranchName(locParticleBranchName, "IsGenerator"), locIsGeneratorFlag, locArrayIndex);
 	}
 


### PR DESCRIPTION
…trees for MC. It can be used to select only the thrown beam photon and ignore the accidentals, that way no accidental correction is necessary for MC.