### PR TITLE
Nsj add pid cmdline args

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -231,7 +231,7 @@ DParticleID::DParticleID(JEventLoop *loop)
   JCalibration *jcalib = dapp->GetJCalibration(loop->GetJEvent().GetRunNumber());
 	
   if( jcalib->GetCalib("/CDC/dedx_theta/dedx_amp_theta_correction", dedx_theta_file_name) ) {
-    jout << "Can't find requested /CDC/dedx_theta/dedx_amp_theta_correction in CCDB for this run!"
+    if(print_messages) jout << "Can't find requested /CDC/dedx_theta/dedx_amp_theta_correction in CCDB for this run!"
     << endl;
 	
   } else if( dedx_theta_file_name.find("file_name") != dedx_theta_file_name.end() 

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -315,6 +315,9 @@ class DParticleID:public jana::JObject
 		double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
 		// time cut for cdc hits
 		double CDC_TIME_CUT_FOR_DEDX;
+        
+                bool CDC_CORRECT_DEDX_THETA;   // use the correction for dE/dx with theta
+                bool CDC_TRUNCATE_DEDX;            // dE/dx truncation: ignore hits with highest dE
 
 		double dTargetZCenter;
 


### PR DESCRIPTION
This adds command line arguments PID:CDC_TRUNCATE_DEDX and PID:CDC_CORRECT_DEDX_THETA which can be used to switch off the dE/dx truncation and the dE/dx correction with theta.  By default they are switched on. 

It also suppresses an error message if it has been printed once already.