### PR TITLE
Nsj add pid cmdline args

### DIFF
--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -231,7 +231,7 @@ DParticleID::DParticleID(JEventLoop *loop)
   JCalibration *jcalib = dapp->GetJCalibration(loop->GetJEvent().GetRunNumber());
 	
   if( jcalib->GetCalib("/CDC/dedx_theta/dedx_amp_theta_correction", dedx_theta_file_name) ) {
-    jout << "Can't find requested /CDC/dedx_theta/dedx_amp_theta_correction in CCDB for this run!"
+    if(print_messages) jout << "Can't find requested /CDC/dedx_theta/dedx_amp_theta_correction in CCDB for this run!"
     << endl;
 	
   } else if( dedx_theta_file_name.find("file_name") != dedx_theta_file_name.end() 

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -243,20 +243,18 @@ DParticleID::DParticleID(JEventLoop *loop)
       JResourceManager *jresman = dapp->GetJResourceManager(loop->GetJEvent().GetRunNumber());
       dedx_theta_correction_file = jresman->GetResource(dedx_theta_file_name["file_name"]);
 
-      if(print_messages)  jout << "Looking for " << dedx_theta_correction_file << endl;
-
     }
-	
-    if(print_messages) jout<<"Reading CDC dedx theta correction data from "<<dedx_theta_correction_file<<" ..."<<endl;
-  	
-    // check to see if we actually have a file
+
+    // check to see if we actually have a filename
     if(dedx_theta_correction_file.empty()) {
       if(print_messages) {
-      	jerr << "... empty file" << endl;
-      	jerr <<"Cannot read CDC dedx theta correction file" << endl;
+      	jerr <<"Cannot read CDC dedx theta correction filename from CCDB" << endl;
       }
       exit(-1); // RESOURCE_UNAVAILABLE;
     }
+
+    if(print_messages) jout<<"Reading CDC dedx theta correction data from "<<dedx_theta_correction_file<<" ..."<<endl;
+  	
 	
     FILE *dedxfile = fopen(dedx_theta_correction_file.c_str(),"r");
     fscanf(dedxfile,"%i values of theta\n",&cdc_npoints_theta);

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -315,6 +315,9 @@ class DParticleID:public jana::JObject
 		double ONESIDED_PADDLE_MIDPOINT_MAG; //+/- this number for North/South
 		// time cut for cdc hits
 		double CDC_TIME_CUT_FOR_DEDX;
+        
+                bool CDC_CORRECT_DEDX_THETA;   // use the correction for dE/dx with theta
+                bool CDC_TRUNCATE_DEDX;            // dE/dx truncation: ignore hits with highest dE
 
 		double dTargetZCenter;
 


### PR DESCRIPTION
This adds command line switches which are by default on:
PID:CDC_CORRECT_DEDX_THETA
PID:CDC_TRUNCATE_DEDX

There was a bit of faffing over the error handling.  It needs CCDB live or sqlite more recent than July 28 in order to load in the dE/dx correction grid.  If that isn't found, it exits, unless the correction was switched off in the cmd line in which case it doesn't look for the file.  