### PR TITLE
A few temporary TAGH fixes from the 2020 runs

### DIFF
--- a/src/plugins/Calibration/TAGH_timewalk/scripts/gaussian_fits.C
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/gaussian_fits.C
@@ -36,10 +36,11 @@ void WriteGaussianFitResults(ofstream &fout, TH1 *h, int counter, int ph_bin) {
     RooDataHist data("data","data",RooArgList(x),h);
     // model: add a narrow and wide gaussian with same mean
     RooRealVar mean("mean","mean",mode,xlow,xhigh);
+    RooRealVar mean2("mean2","mean2",mode,xlow,xhigh);
     RooRealVar sigma1("sigma1","sigma1",0.2,0.01,0.4);//0.01,0.6
     RooGaussian gauss1("gauss1","gauss1",x,mean,sigma1);
     RooRealVar sigma2("sigma2","sigma2",0.7,0.3,3.0);//0.3,2.5
-    RooGaussian gauss2("gauss2","gauss2",x,mean,sigma2);
+    RooGaussian gauss2("gauss2","gauss2",x,mean2,sigma2);
     // f1: fraction of entries in first gaussian
     RooRealVar f1("f1","f1",0.75,0.01,1.);
     RooAddPdf doubleGauss("doubleGauss","doubleGauss",RooArgList(gauss1,gauss2),RooArgList(f1));

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/offsets/offsets.C
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/offsets/offsets.C
@@ -51,12 +51,14 @@ void WriteTAGHTDCOffsets(double *y, const int N, double &c1_tdc) {
     TString sep = "        ";
     for (int i = 0; i < N; i++) {
         double offset = y_ccdb[i] + y[i];
+	/*
         if (i == 0) c1_tdc = offset;
         if (y_ccdb[i] == 0.0 && y[i] == 0.0) {
             offset = 0.0;
         } else {
             offset -= c1_tdc;
         }
+	*/
         fout << i + 1 << sep << offset << endl;
     }
     fout.close();
@@ -71,12 +73,14 @@ void WriteTAGHADCOffsets(double *y_tdcadc, double *y, const int N, double &c1_ad
     TString sep = "        ";
     for (int i = 0; i < N; i++) {
         double offset = y_ccdb[i] + y[i] - y_tdcadc[i];
+	/*
         if (i == 0) c1_adc = offset;
         if (y_ccdb[i] == 0.0 && y[i] == 0.0) {
             offset = 0.0;
         } else {
             offset -= c1_adc;
         }
+	*/
         fout << i + 1 << sep << offset << endl;
     }
     fout.close();

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/timewalk_fits.C
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/timewalk_fits.C
@@ -78,7 +78,8 @@ void WriteTimewalkFitResults(ofstream &fout, ofstream &fout_ccdb, ofstream &fout
     if (f.GetNDF() == 0 || f.GetChisquare()/f.GetNDF() > 15.0) {
      	fout_badchans << counter << endl;   
     }
-    if (f.GetNDF() == 0 || f.GetChisquare()/f.GetNDF() > 100.) {   // allow for bad fits to channels with hardware problems
+    //if (f.GetNDF() == 0 || f.GetChisquare()/f.GetNDF() > 100.) {   // allow for bad fits to channels with hardware problems
+    if (f.GetNDF() == 0 || f.GetChisquare()/f.GetNDF() > 1000.) {   // allow for bad fits to channels with hardware problems
         WriteNA(fout,fout_ccdb,counter);
         return;
     }


### PR DESCRIPTION
- move to double Gaussian fit with separate means
- allow fits with bad chi^2 to accomodate problem channels
- stop pegging all the offsets to the first channel, as is done with other TAGH calibration procedures currently