### PR TITLE
Fix uninitialised variable bug flagged by valgrind

### DIFF
--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -1819,6 +1819,7 @@ jerror_t DTrackFitterKalmanSIMD::PropagateForward(int length,int &i,
       forward_traj[my_i].rho_Z_over_A=temp.rho_Z_over_A;
       forward_traj[my_i].K_rho_Z_over_A=temp.K_rho_Z_over_A;
       forward_traj[my_i].LnI=temp.LnI;
+      forward_traj[my_i].Z=temp.Z;
       forward_traj[my_i].S=S;
    } 
    else{
@@ -2021,6 +2022,7 @@ jerror_t DTrackFitterKalmanSIMD::SetReferenceTrajectory(DMatrix5x1 &S){
       temp.num_hits=0;
       temp.B=0.;
       temp.K_rho_Z_over_A=temp.rho_Z_over_A=temp.LnI=0.;
+      temp.Z=0.;
       temp.Q=Zero5x5; 
 
       // last S vector


### PR DESCRIPTION
This branch fixes a flaw exposed by the introduction of the Reverse Kalman filter that only impacts electrons and positrons, and only after the first iteration of the reverse filter.   Valgrind did not generate these uninitialized variable errors for the previous version of the code (before the introduction of the reverse filter)  -- this fix does not impact the fitted track results, and does not appear to have any significant impact on track matching to the outer detectors, because the code falls back to the old extrapolation technique if the reverse filter fails.