### PR TITLE
Charged AntiSigma Analysis

### DIFF
--- a/src/libraries/ANALYSIS/DSourceComboP4Handler.cc
+++ b/src/libraries/ANALYSIS/DSourceComboP4Handler.cc
@@ -144,8 +144,13 @@ void DSourceComboP4Handler::Define_DefaultCuts(void)
 	dInvariantMassCuts.emplace(Sigma0, std::make_pair(1.1, 1.3));
 	dInvariantMassCuts.emplace(SigmaPlus, dInvariantMassCuts[Sigma0]);
 	dInvariantMassCuts.emplace(SigmaMinus, dInvariantMassCuts[Sigma0]);
+	dInvariantMassCuts.emplace(AntiSigma0, dInvariantMassCuts[Sigma0]);
+	dInvariantMassCuts.emplace(AntiSigmaPlus, dInvariantMassCuts[Sigma0]);
+	dInvariantMassCuts.emplace(AntiSigmaMinus, dInvariantMassCuts[Sigma0]);
 	dInvariantMassCuts.emplace(XiMinus, std::make_pair(1.1, 1.5));
 	dInvariantMassCuts.emplace(Xi0, dInvariantMassCuts[XiMinus]);
+	dInvariantMassCuts.emplace(AntiXi0, dInvariantMassCuts[XiMinus]);
+	dInvariantMassCuts.emplace(AntiXiPlus, dInvariantMassCuts[XiMinus]);
 	dInvariantMassCuts.emplace(OmegaMinus, std::make_pair(1.32, 2.22));
 	dInvariantMassCuts.emplace(Lambda_c, std::make_pair(2.0, 2.6));
 

--- a/src/libraries/ANALYSIS/DSourceComboVertexer.cc
+++ b/src/libraries/ANALYSIS/DSourceComboVertexer.cc
@@ -315,6 +315,10 @@ void DSourceComboVertexer::Calc_VertexTimeOffsets_WithBeam(const DReactionVertex
 		auto locVertex = Calc_Vertex(locIsProductionVertexFlag, locChargedSourceParticles, locDecayingParticles, locVertexParticles);
 		dConstrainingParticlesByCombo.emplace(locFullComboProductionTuple, locVertexParticles);
 
+		//neither decaying particle is fully contrained
+		if (locDecayingParticles.size() == 0)
+		  continue;
+
 		//CALC AND STORE TIME OFFSET
 		auto locFullReactionTuple_TimeOffset = std::make_tuple(true, locReactionFullCombo, locBeamParticle);
 

--- a/src/libraries/FCAL/DFCALGeometry.cc
+++ b/src/libraries/FCAL/DFCALGeometry.cc
@@ -185,8 +185,8 @@ DFCALGeometry::channel( int row, int column ) const
 	}
 	else{
 		
-	  cerr << "ERROR: request for channel number of inactive block!  row " 
-	       << row << " column " <<  column << endl;
+	  // cerr << "ERROR: request for channel number of inactive block!  row "
+	  //      << row << " column " <<  column << endl;
 		return -1;
 	}
 }


### PR DESCRIPTION
This PR prevents the crash reported in Issue #522 . It was verified that some events from a signal MC sample successfully pass the selection. Since the reaction is extremely rare, we have to use a full run period to evaluate the selection with real data.