### PR TITLE
update to evio_writer to help with jobs running over multiple input files

### DIFF
--- a/src/plugins/Utilities/evio_writer/DEventWriterEVIO.cc
+++ b/src/plugins/Utilities/evio_writer/DEventWriterEVIO.cc
@@ -335,12 +335,19 @@ bool DEventWriterEVIO::Open_OutputFile(JEventLoop* locEventLoop, string locOutpu
         if(currentEventSource != locEventSource) {
             currentEventSource = locEventSource;
 
+            // first clear all of the objects being referenced
             for( auto entry : Get_EVIOOutputters() )
                 delete entry.second;
             for( auto entry : Get_EVIOBufferWriters() )
                 delete entry.second;
+            // and close the threads so that they don't use extra CPU with their idle spin-locks
             for( auto entry : Get_EVIOOutputThreads() )
                 pthread_cancel(entry.second);
+
+            // now clear all of the entries in these maps
+            Get_EVIOOutputters().clear();
+            Get_EVIOBufferWriters().clear();
+            Get_EVIOOutputThreads().clear();
         }
 
     }

--- a/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
+++ b/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
@@ -1,4 +1,3 @@
-
 #ifndef _DEventWriterEVIO_
 #define _DEventWriterEVIO_
 
@@ -8,6 +7,7 @@
 
 #include <JANA/JObject.h>
 #include <JANA/JEventLoop.h>
+#include <JANA/JEventSource.h>
 #include <JANA/JApplication.h>
 
 #include <DAQ/JEventSource_EVIO.h>
@@ -70,7 +70,8 @@ class DEventWriterEVIO : public JObject
 		bool COMPACT;
 		bool PREFER_EMULATED;
 		bool DEBUG_FILES;
-
+        bool CLOSE_FILES;
+        
 	protected:
 		bool Open_OutputFile(JEventLoop* locEventLoop, string locOutputFileName) const;
 		

--- a/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
+++ b/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
@@ -60,7 +60,7 @@ class DEventWriterEVIO : public JObject
 		bool Write_EVIOBuffer(JEventLoop* locEventLoop, uint32_t *locOutputBuffer, uint32_t locOutputBufferSize, string locOutputFileNameSubString) const;
 
 		string Get_OutputFileName(JEventLoop* locEventLoop, string locOutputFileNameSubString) const;
-        void SetDetectorsToWriteOut(string detector_list, string locOutputFileNameSubString) const;
+        void SetDetectorsToWriteOut(JEventLoop* locEventLoop, string detector_list, string locOutputFileNameSubString) const;
 
         bool Is_MergingFiles() const { return dMergeFiles; }
         void Set_MergeFiles(bool in_flag) { dMergeFiles = in_flag; }


### PR DESCRIPTION
Added an option EVIOOUT:CLOSE_FILES which closes all files held open by evio_writer when the input source changes.  This could reasonably be a default, but it's only lightly tested, so I'm keeping this just as an option for now.  Note that if multiple input files have the same name, the corresponding output files get clobbered for now.

This should solve the issue reported by @rjones30 where the number of output threads continually grew when running over a large number of small input files, and eventually use a lot of CPU time.