### PR TITLE
Set REST beam photon energy based on tagger counter

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -64,6 +64,9 @@ DEventSourceREST::DEventSourceREST(const char* source_name)
    USE_CCDB_FCAL_COVARIANCE = false;
    gPARMS->SetDefaultParameter("REST:USE_CCDB_FCAL_COVARIANCE", USE_CCDB_FCAL_COVARIANCE, 
    		"Load REST BFAL Shower covariance matrices from CCDB instead of the file.");
+   		
+   gPARMS->SetDefaultParameter("REST:JANACALIBCONTEXT", REST_JANA_CALIB_CONTEXT);
+   calib_generator = new JCalibrationGeneratorCCDB;  // keep this around in case we need to use it
 }
 
 //----------------
@@ -77,6 +80,13 @@ DEventSourceREST::~DEventSourceREST()
   if (ifs) {
     delete ifs;
   }
+  
+  for(auto &entry : dJCalib_olds)
+  	delete entry.second;
+  for(auto &entry : dTAGHGeoms)
+  	delete entry.second;
+  for(auto &entry : dTAGMGeoms)
+  	delete entry.second;
 }
 
 //----------------
@@ -166,13 +176,16 @@ jerror_t DEventSourceREST::GetEvent(JEvent &event)
 	     break;
          }
 
-         //set REST calib context
-         const hddm_r::CcdbContextList& locContextStrings = re.getCcdbContexts();
-         hddm_r::CcdbContextList::iterator Contextiter;
-         for (Contextiter = locContextStrings.begin(); Contextiter != locContextStrings.end(); ++Contextiter) {
-        	 string REST_JANA_CALIB_CONTEXT = Contextiter->getText();
-             gPARMS->SetDefaultParameter("REST:JANACALIBCONTEXT", REST_JANA_CALIB_CONTEXT);
-         }
+         // set REST calib context - use this to load calibration constants that were used
+         // to create the REST files, if needed, but let this be overridden by command-line options
+         if( REST_JANA_CALIB_CONTEXT == "" ) {
+			 const hddm_r::CcdbContextList& locContextStrings = re.getCcdbContexts();
+			 hddm_r::CcdbContextList::iterator Contextiter;
+			 for (Contextiter = locContextStrings.begin(); Contextiter != locContextStrings.end(); ++Contextiter) {
+				 REST_JANA_CALIB_CONTEXT = Contextiter->getText();
+				 jout << " REST file next CCDB context = " << REST_JANA_CALIB_CONTEXT << endl;  // DEBUG?
+			 }
+		 }
 
          record->clear();
          while (record->getReconstructedPhysicsEvents().size() == 0) {
@@ -234,9 +247,13 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 
    JEventLoop* locEventLoop = event.GetJEventLoop();
    string dataClassName = factory->GetDataClassName();
-   
+
+   DApplication* dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+   JCalibration *jcalib = dapp->GetJCalibration(event.GetRunNumber());
+
+     
 	//Get target center
-		//multiple reader threads can access this object: need lock
+	//multiple reader threads can access this object: need lock
 	bool locNewRunNumber = false;
 	unsigned int locRunNumber = event.GetRunNumber();
 	LockRead();
@@ -246,7 +263,6 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 	UnlockRead();
 	if(locNewRunNumber)
 	{
-		DApplication* dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
 		DGeometry* locGeometry = dapp->GetDGeometry(locEventLoop->GetJEvent().GetRunNumber());
 		double locTargetCenterZ = 0.0;
 		locGeometry->GetTargetZ(locTargetCenterZ);
@@ -271,6 +287,7 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 				jout << "Error loading /DIRC/South/channel_status !" << endl;
 		}
 		
+
 		LockRead();
 		{
 			dTargetCenterZMap[locRunNumber] = locTargetCenterZ;
@@ -291,9 +308,16 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 			     << " dy/dz=" << dBeamDirMap[locRunNumber].Y() 
 			     << endl;
 
+			// tagger related configs for reverse mapping tagger energy to counter number
+			if( REST_JANA_CALIB_CONTEXT != "" ) {
+				JCalibration *jcalib_old = calib_generator->MakeJCalibration(jcalib->GetURL(), locRunNumber, REST_JANA_CALIB_CONTEXT );
+				dTAGHGeoms[locRunNumber] = new DTAGHGeometry(jcalib_old, locRunNumber);
+				dTAGMGeoms[locRunNumber] = new DTAGMGeometry(jcalib_old, locRunNumber);
+				dJCalib_olds[locRunNumber] = jcalib_old;
+			}
 		}
 		UnlockRead();
-		
+				
 		// do multiple things to limit the number of locks
 		// make sure that we have a handle to the FCAL shower factory
 		if(USE_CCDB_FCAL_COVARIANCE) {
@@ -590,40 +614,64 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
    hddm_r::TagmBeamPhotonList::iterator locTAGMiter;
    for(locTAGMiter = locTagmBeamPhotonList.begin(); locTAGMiter != locTagmBeamPhotonList.end(); ++locTAGMiter)
    {
-      if (locTAGMiter->getJtag() != tag)
-         continue;
+		if (locTAGMiter->getJtag() != tag)
+		 continue;
 
-      DBeamPhoton* gamma = new DBeamPhoton();
+		DBeamPhoton* gamma = new DBeamPhoton();
+		
+		// load the counter number (if it exists) and set the energy based on the counter
+		unsigned int column = 0;
+		hddm_r::TagmChannelList &locTagmChannelList = locTAGMiter->getTagmChannels();
+		if (locTagmChannelList.size() > 0) {
+			// it's easy if the column is already set 
+			column = locTagmChannelList().getColumn();
+		} else {
+			// if the TAGM column isn't saved in the REST file, then we do one of two things
+			//   1) if there's no special CCDB context associated with the file, we can just
+			//      reverse engineer the counter, assuming the latest CCDB
+			//   2) If there is a special CCDB context specified, then use that instead
+			if (dJCalib_olds[locRunNumber] == nullptr) {
+				if (!tagmGeom->E_to_column(locTAGMiter->getE(), column)) {
+					column = 0;
+				}
+			} else {
+				if (!dTAGMGeoms[locRunNumber]->E_to_column(locTAGMiter->getE(), column)) {
+					column = 0;
+				}
+			}
 
-		DVector3 mom(0.0, 0.0, locTAGMiter->getE());
+			if(column == 0)
+				std::cerr << "Error in DEventSourceREST - tagger microscope could not look up column for energy "
+				    << locTAGMiter->getE() << std::endl;
+		}
+		
+		// this shouldn't happen
+		//if(column == -1) {
+		if(column == 0) {
+			std::cerr << "Error in DEventSourceREST - TAGM column incorrectly set!"
+					  << std::endl;
+			exit(18);
+		}
+
+		double Elo = tagmGeom->getElow(column);
+		double Ehi = tagmGeom->getEhigh(column);
+		double Ebeam = (Elo + Ehi)/2.;
+
+		// read the rest of the data from the REST file
+		DVector3 mom(0.0, 0.0, Ebeam);
 		gamma->setPID(Gamma);
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(locTAGMiter->getT());
 		gamma->dSystem = SYS_TAGM;
+		gamma->dCounter = column;
 
-	      auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
-	      locCovarianceMatrix->ResizeTo(7, 7);
-	      locCovarianceMatrix->Zero();
+		auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
+		locCovarianceMatrix->ResizeTo(7, 7);
+		locCovarianceMatrix->Zero();
 		gamma->setErrorMatrix(locCovarianceMatrix);
-
-      hddm_r::TagmChannelList &locTagmChannelList = locTAGMiter->getTagmChannels();
-      if (!tagmGeom->E_to_column(locTAGMiter->getE(), gamma->dCounter))
-         gamma->dCounter = 0;
-      if (locTagmChannelList.size() > 0) {
-         if ((int)gamma->dCounter != locTagmChannelList().getColumn()) {
-            std::cerr << "Error in DEventSourceREST - tagger microscope energy "
-                         "lookup mismatch:" << std::endl
-                      << "   TAGM column = " << locTagmChannelList().getColumn()
-                      << std::endl
-                      << "   Etag = " << locTAGMiter->getE()
-                      << std::endl
-                      << "   lookup finds TAGM column = " << gamma->dCounter
-                      << std::endl;
-            exit(17);
-         }
-      }
-      dbeam_photons.push_back(gamma);
+      
+      	dbeam_photons.push_back(gamma);
    }
 
    const hddm_r::TaghBeamPhotonList &locTaghBeamPhotonList = record->getTaghBeamPhotons();
@@ -635,34 +683,54 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 
       DBeamPhoton* gamma = new DBeamPhoton();
 
+		// load the counter number (if it exists) and set the energy based on the counter
+		unsigned int counter = 0;
+		hddm_r::TaghChannelList &locTaghChannelList = locTAGHiter->getTaghChannels();
+		if (locTaghChannelList.size() > 0) {
+			// it's easy if the column is already set 
+			counter = locTaghChannelList().getCounter();
+		} else {
+			// if the TAGM column isn't saved in the REST file, then we do one of two things
+			//   1) if there's no special CCDB context associated with the file, we can just
+			//      reverse engineer the counter, assuming the latest CCDB
+			//   2) If there is a special CCDB context specified, then use that instead
+			if (dJCalib_olds[locRunNumber] == nullptr) {
+				if (!taghGeom->E_to_counter(locTAGHiter->getE(), counter)) {
+					counter = 0;
+				}
+			} else {
+				if (!dTAGHGeoms[locRunNumber]->E_to_counter(locTAGHiter->getE(), counter)) {
+					counter = 0;
+				}
+			}
+
+			if(counter == 0)
+				std::cerr << "Error in DEventSourceREST - tagger hodoscope could not look up counter for energy "
+				    << locTAGHiter->getE() << std::endl;
+		}
+
+		// this shouldn't happen
+		//if(counter == -1) {
+		if(counter == 0) {
+			std::cerr << "Error in DEventSourceREST - TAGH counter incorrectly set!"
+					  << std::endl;
+			exit(18);
+		}
+
+
 		DVector3 mom(0.0, 0.0, locTAGHiter->getE());
 		gamma->setPID(Gamma);
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(locTAGHiter->getT());
 		gamma->dSystem = SYS_TAGH;
+		gamma->dCounter = counter;
 
 	      auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
 	      locCovarianceMatrix->ResizeTo(7, 7);
 	      locCovarianceMatrix->Zero();
 		gamma->setErrorMatrix(locCovarianceMatrix);
 
-      hddm_r::TaghChannelList &locTaghChannelList = locTAGHiter->getTaghChannels();
-      if (!taghGeom->E_to_counter(locTAGHiter->getE(), gamma->dCounter))
-         gamma->dCounter = 0;
-      if (locTaghChannelList.size() > 0) {
-         if ((int)gamma->dCounter != locTaghChannelList().getCounter()) {
-            std::cerr << "Error in DEventSourceREST - tagger hodoscope energy "
-                         "lookup mismatch:" << std::endl
-                      << "   TAGH column = " << locTaghChannelList().getCounter()
-                      << std::endl
-                      << "   Etag = " << locTAGHiter->getE()
-                      << std::endl
-                      << "   lookup finds TAGH column = " << gamma->dCounter
-                      << std::endl;
-            exit(17);
-         }
-      }
       dbeam_photons.push_back(gamma);
    }
 

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -645,12 +645,9 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 				    << locTAGMiter->getE() << std::endl;
 		}
 		
-		// this shouldn't happen
-		//if(column == -1) {
+		// sometimes the simulation will set photons that miss the tagger counters to have a column of zero - skip these
 		if(column == 0) {
-			std::cerr << "Error in DEventSourceREST - TAGM column incorrectly set!"
-					  << std::endl;
-			exit(18);
+			continue;
 		}
 
 		double Elo = tagmGeom->getElow(column);
@@ -709,14 +706,10 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 				    << locTAGHiter->getE() << std::endl;
 		}
 
-		// this shouldn't happen
-		//if(counter == -1) {
+		// sometimes the simulation will set photons that miss the tagger counters to have a column of zero - skip these
 		if(counter == 0) {
-			std::cerr << "Error in DEventSourceREST - TAGH counter incorrectly set!"
-					  << std::endl;
-			exit(18);
+			continue;
 		}
-
 
 		DVector3 mom(0.0, 0.0, locTAGHiter->getE());
 		gamma->setPID(Gamma);

--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -16,6 +16,8 @@
 #include <JANA/JEventSource.h>
 #include <JANA/jerror.h>
 #include <JANA/JCalibration.h>
+#include <JANA/JCalibrationCCDB.h>
+#include <JANA/JCalibrationGeneratorCCDB.h>
 
 #include "hddm_r.hpp"
 
@@ -124,6 +126,14 @@ class DEventSourceREST:public JEventSource
 
    std::ifstream *ifs;		// input hddm file ifstream
    hddm_r::istream *fin;	// provides hddm layer on top of ifstream
+   
+   string REST_JANA_CALIB_CONTEXT = "";
+   JCalibrationGeneratorCCDB *calib_generator;
+   
+   	map<unsigned int, JCalibration *> dJCalib_olds; //unsigned int is run number
+   	map<unsigned int, DTAGHGeometry *> dTAGHGeoms; //unsigned int is run number
+   	map<unsigned int, DTAGMGeometry *> dTAGMGeoms; //unsigned int is run number
+
 };
 
 #endif //_JEVENT_SOURCEREST_H_

--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -126,7 +126,10 @@ void DBeamPhoton_factory::Set_BeamPhoton(DBeamPhoton* gamma, const DTAGMHit* hit
     gamma->setPosition(pos);
     gamma->setTime(hit->t);
     gamma->dCounter = hit->column;
-    gamma->dSystem = SYS_TAGM;
+    if(gamma->dCounter == 0)   // handle photons from simulation that miss tagger counters
+    	gamma->dSystem = SYS_NULL;
+    else
+    	gamma->dSystem = SYS_TAGM;
     gamma->AddAssociatedObject(hit);
 
 	auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
@@ -144,7 +147,10 @@ void DBeamPhoton_factory::Set_BeamPhoton(DBeamPhoton* gamma, const DTAGHHit* hit
     gamma->setPosition(pos);
     gamma->setTime(hit->t);
     gamma->dCounter = hit->counter_id;
-    gamma->dSystem = SYS_TAGH;
+    if(gamma->dCounter == 0)   // handle photons from simulation that miss tagger counters
+    	gamma->dSystem = SYS_NULL;
+    else
+	    gamma->dSystem = SYS_TAGH;
     gamma->AddAssociatedObject(hit);
 
 	auto locCovarianceMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();

--- a/src/libraries/PID/DBeamPhoton_factory_MCGEN.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_MCGEN.cc
@@ -3,6 +3,9 @@
 using namespace std;
 
 #include "DBeamPhoton_factory_MCGEN.h"
+#include "TAGGER/DTAGHGeometry.h"
+#include "TAGGER/DTAGMGeometry.h"
+
 using namespace jana;
 
 //------------------
@@ -62,9 +65,30 @@ jerror_t DBeamPhoton_factory_MCGEN::evnt(jana::JEventLoop *locEventLoop, uint64_
 		}
 	}
 
+	// extract the TAGH geometry
+   vector<const DTAGHGeometry*> taghGeomVect;
+   eventLoop->Get(taghGeomVect);
+   if (taghGeomVect.empty())
+      return NOERROR;
+   const DTAGHGeometry* taghGeom = taghGeomVect[0];
+
+   // extract the TAGM geometry
+   vector<const DTAGMGeometry*> tagmGeomVect;
+   eventLoop->Get(tagmGeomVect);
+   if (tagmGeomVect.empty())
+      return NOERROR;
+   const DTAGMGeometry* tagmGeom = tagmGeomVect[0];
+
+
 	//Photon is NOT TAGGED //Create a beam object from the DMCReaction
 	auto *locBeamPhoton = new DBeamPhoton;
 	*(DKinematicData*)locBeamPhoton = locMCReactions[0]->beam;
+	if(tagmGeom->E_to_column(locBeamPhoton->energy(), locBeamPhoton->dCounter))
+		locBeamPhoton->dSystem = SYS_TAGM;
+	else if(taghGeom->E_to_counter(locBeamPhoton->energy(), locBeamPhoton->dCounter))
+		locBeamPhoton->dSystem = SYS_TAGH;
+	else
+		locBeamPhoton->dSystem = SYS_NULL;
 	_data.push_back(locBeamPhoton);
 
 	return NOERROR;

--- a/src/libraries/PID/DBeamPhoton_factory_TRUTH.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_TRUTH.cc
@@ -51,7 +51,10 @@ jerror_t DBeamPhoton_factory_TRUTH::evnt(jana::JEventLoop *locEventLoop, uint64_
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(tagm_hits[ih]->t);
-	    gamma->dSystem = SYS_TAGM;
+		if(gamma->dCounter == 0)   // handle photons from simulation that miss tagger counters
+			gamma->dSystem = SYS_NULL;
+		else
+		    gamma->dSystem = SYS_TAGM;
 		gamma->dCounter = tagm_hits[ih]->column;
 		gamma->AddAssociatedObject(tagm_hits[ih]);
 		_data.push_back(gamma);
@@ -67,7 +70,10 @@ jerror_t DBeamPhoton_factory_TRUTH::evnt(jana::JEventLoop *locEventLoop, uint64_
 		gamma->setMomentum(mom);
 		gamma->setPosition(pos);
 		gamma->setTime(tagh_hits[ih]->t);
-	    gamma->dSystem = SYS_TAGH;
+		if(gamma->dCounter == 0)   // handle photons from simulation that miss tagger counters
+			gamma->dSystem = SYS_NULL;
+		else
+		    gamma->dSystem = SYS_TAGH;
 		gamma->dCounter = tagh_hits[ih]->counter_id;
 		gamma->AddAssociatedObject(tagh_hits[ih]);
 		_data.push_back(gamma);

--- a/src/libraries/TAGGER/DTAGHGeometry.cc
+++ b/src/libraries/TAGGER/DTAGHGeometry.cc
@@ -19,8 +19,6 @@
 #include <iostream>
 #include <map>
 
-#include <JANA/JApplication.h>
-#include <JANA/JEvent.h>
 #include "DTAGHGeometry.h"
 
 const unsigned int DTAGHGeometry::kCounterCount = 274;
@@ -35,17 +33,102 @@ static set<int> runs_announced;
 //---------------------------------
 DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
 {
-   // keep track of which runs we print out messages for
-   int32_t runnumber = loop->GetJEvent().GetRunNumber();
-   pthread_mutex_lock(&print_mutex);
-   bool print_messages = false;
-   if(runs_announced.find(runnumber) == runs_announced.end()){
+	// keep track of which runs we print out messages for
+	int32_t runnumber = loop->GetJEvent().GetRunNumber();
+	pthread_mutex_lock(&print_mutex);
+	bool print_messages = false;
+	if(runs_announced.find(runnumber) == runs_announced.end()){
 	  print_messages = true;
 	  runs_announced.insert(runnumber);
-   }
-   pthread_mutex_unlock(&print_mutex);
+	}
+	pthread_mutex_unlock(&print_mutex);
 
+	JEvent &event = loop->GetJEvent();
+	DApplication* dapp = dynamic_cast<DApplication*>(loop->GetJApplication());
+	JCalibrationCCDB *jcalib =  dynamic_cast<JCalibrationCCDB*>( dapp->GetJCalibration(event.GetRunNumber()) );
+
+	Initialize(jcalib, print_messages);
+}
+
+//---------------------------------
+// DTAGHGeometry    (Constructor)
+//---------------------------------
+DTAGHGeometry::DTAGHGeometry(JCalibration *jcalib, int32_t runnumber)
+{
+	pthread_mutex_lock(&print_mutex);
+	bool print_messages = false;
+	if(runs_announced.find(runnumber) == runs_announced.end()){
+	  print_messages = true;
+	  runs_announced.insert(runnumber);
+	}
+	pthread_mutex_unlock(&print_mutex);
+
+	Initialize(jcalib, print_messages);
+}
+
+//---------------------------------
+// Initialize
+//---------------------------------
+void DTAGHGeometry::Initialize(JCalibration *jcalib, bool print_messages)
+{
    /* read tagger set endpoint energy from calibdb */
+   std::map<string,double> result1;
+   jcalib->Get("/PHOTON_BEAM/endpoint_energy", result1);
+   if (result1.find("PHOTON_BEAM_ENDPOINT_ENERGY") == result1.end()) {
+      std::cerr << "Error in DTAGHGeometry constructor: "
+                << "failed to read photon beam endpoint energy "
+                << "from calibdb at /PHOTON_BEAM/endpoint_energy" << std::endl;
+      m_endpoint_energy_GeV = 0;
+   }
+   else {
+      m_endpoint_energy_GeV = result1["PHOTON_BEAM_ENDPOINT_ENERGY"];
+   }
+
+   /* read hodoscope counter energy bounds from calibdb */
+   std::vector<std::map<string,double> > result2;
+   jcalib->Get("/PHOTON_BEAM/hodoscope/scaled_energy_range", result2);
+   if (result2.size() != kCounterCount) {
+      jerr << "Error in DTAGHGeometry constructor: "
+           << "failed to read photon beam scaled_energy_range table "
+           << "from calibdb at /PHOTON_BEAM/hodoscope/scaled_energy_range" << std::endl;
+      for (unsigned int i=0; i <= TAGH_MAX_COUNTER; ++i) {
+         m_counter_xlow[i] = 0;
+         m_counter_xhigh[i] = 0;
+      }
+   }
+   else {
+      for (unsigned int i=0; i < result2.size(); ++i) {
+	int ctr = (result2[i])["counter"];
+         m_counter_xlow[ctr] = (result2[i])["xlow"];
+         m_counter_xhigh[ctr] = (result2[i])["xhigh"];
+      }
+   }
+
+   int status = 0;
+   m_endpoint_energy_calib_GeV = 0.;
+   
+   std::map<string,double> result3;
+   status = jcalib->Get("/PHOTON_BEAM/hodoscope/endpoint_calib",result3);
+   
+   
+   if(!status){
+     if (result3.find("TAGGER_CALIB_ENERGY") == result3.end()) {
+       std::cerr << "Error in DTAGHGeometry constructor: "
+		 <<  "failed to read  endpoint_calib field "
+		 <<  "from /PHOTON_BEAM/hodoscope/endpoint_calib table" << std::endl;
+       
+     } else {
+       m_endpoint_energy_calib_GeV  = result3["TAGGER_CALIB_ENERGY"];
+
+	   if(print_messages)
+       	  jout << " Correct Beam Photon Energy (TAGH) = " << m_endpoint_energy_calib_GeV << " (GeV)" << std::endl;
+
+     }
+   }
+   
+   
+   /*
+   // read tagger set endpoint energy from calibdb 
    std::map<string,double> result1;
    loop->GetCalib("/PHOTON_BEAM/endpoint_energy", result1);
    if (result1.find("PHOTON_BEAM_ENDPOINT_ENERGY") == result1.end()) {
@@ -58,7 +141,7 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
       m_endpoint_energy_GeV = result1["PHOTON_BEAM_ENDPOINT_ENERGY"];
    }
 
-   /* read hodoscope counter energy bounds from calibdb */
+   // read hodoscope counter energy bounds from calibdb 
    std::vector<std::map<string,double> > result2;
    loop->GetCalib("/PHOTON_BEAM/hodoscope/scaled_energy_range", result2);
    if (result2.size() != kCounterCount) {
@@ -99,7 +182,8 @@ DTAGHGeometry::DTAGHGeometry(JEventLoop *loop)
 
      }
    }
-   
+   */
+
 }
 
 DTAGHGeometry::~DTAGHGeometry() { }

--- a/src/libraries/TAGGER/DTAGHGeometry.h
+++ b/src/libraries/TAGGER/DTAGHGeometry.h
@@ -11,7 +11,14 @@
 
 #include <JANA/JFactory.h>
 #include <JANA/JObject.h>
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+#include <JANA/JCalibration.h>
+#include <JANA/JCalibrationCCDB.h>
+#include <JANA/JCalibrationGeneratorCCDB.h>
 using namespace jana;
+
+#include <DANA/DApplication.h>
 
 #include "units.h"
 
@@ -23,7 +30,10 @@ class DTAGHGeometry : public JObject {
    JOBJECT_PUBLIC(DTAGHGeometry);
 
    DTAGHGeometry(JEventLoop *loop);
+   DTAGHGeometry(JCalibration *jcalib, int32_t runnumber);
    ~DTAGHGeometry();
+
+   void Initialize(JCalibration *jcalib, bool print_messages);
 
    static const unsigned int kCounterCount;
 

--- a/src/libraries/TAGGER/DTAGMGeometry.h
+++ b/src/libraries/TAGGER/DTAGMGeometry.h
@@ -12,7 +12,14 @@
 
 #include <JANA/JFactory.h>
 #include <JANA/JObject.h>
+#include <JANA/JApplication.h>
+#include <JANA/JEvent.h>
+#include <JANA/JCalibration.h>
+#include <JANA/JCalibrationCCDB.h>
+#include <JANA/JCalibrationGeneratorCCDB.h>
 using namespace jana;
+
+#include <DANA/DApplication.h>
 
 #include "units.h"
 
@@ -26,7 +33,10 @@ class DTAGMGeometry : public JObject {
    JOBJECT_PUBLIC(DTAGMGeometry);
 
    DTAGMGeometry(JEventLoop *loop);
+   DTAGMGeometry(JCalibration *jcalib, int32_t runnumber);
    ~DTAGMGeometry();
+
+   void Initialize(JCalibration *jcalib, bool print_messages);
 
    static const unsigned int kRowCount;
    static const unsigned int kColumnCount;


### PR DESCRIPTION
This fun piece of code sets the energy of DBeamPhoton objects loaded from a REST file based on the counter number, so you can use the latest tagger energy calibration in your analysis.

There are two main cases to consider:
1. If the REST file contains the counter number for each hit, then the selected CCDB context is used to set the beam photon energy, and the saved energy is ignored.  This works in cases where the counter is properly stored, like in recently generated simulations.  (If your simulations don't have the counter info, they are too old and should be regenerated anyway).
2. If the REST file doesn't contain counter number information, then a reverse lookup is performed to figure out the counter number from the stored photon energy, then the latest energy calibration is applied.  This needs to be done to all current reconstructed data, say for an analysis launch.

But how is the reverse lookup properly applied, you may ask?  Practically, you need to specify the CCDB context corresponding to that used to generate the REST file on the command line, e.g. -PREST:JANACALIBCONTEXT="calibtime=2018-05-10-11-05-00"

In principle, this should have been more seamless, since the CCDB context is stored within the REST file.  However, the event containing this and other metadata is not always (or even often!) saved as the first event in the file, so we have to force the issue.  The cause of this misordering is a question for another pull request...