### PR TITLE
modify HistMacro_RF_p1.C to generate RF selftiming pictures for HYDRA AI

### DIFF
--- a/src/plugins/monitoring/RF_online/HistMacro_RF_p1.C
+++ b/src/plugins/monitoring/RF_online/HistMacro_RF_p1.C
@@ -31,9 +31,13 @@
 	locCanvas->cd(1);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetLogy(1);
 	if(locHist_FDCRF_SelfDeltaT != NULL)
 	{
 		TH1I* locHist = locHist_FDCRF_SelfDeltaT;
+		locHist->SetTitle("RF FDC Self timing");
+		locHist->GetXaxis()->Rebin(14);
+
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
 		locHist->GetXaxis()->SetLabelSize(0.05);
@@ -44,9 +48,13 @@
 	locCanvas->cd(2);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetLogy(1);
 	if(locHist_TOFRF_SelfDeltaT != NULL)
 	{
 		TH1I* locHist = locHist_TOFRF_SelfDeltaT;
+		locHist->SetTitle("RF TOF Self timing");
+		locHist->GetXaxis()->Rebin(12);
+
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
 		locHist->GetXaxis()->SetLabelSize(0.05);
@@ -57,9 +65,13 @@
 	locCanvas->cd(3);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetLogy(1);
 	if(locHist_TAGHRF_SelfDeltaT != NULL)
 	{
 		TH1I* locHist = locHist_TAGHRF_SelfDeltaT;
+		locHist->SetTitle("RF TAGH Self timing");
+		locHist->GetXaxis()->Rebin(14);
+
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
 		locHist->GetXaxis()->SetLabelSize(0.05);
@@ -70,13 +82,35 @@
 	locCanvas->cd(4);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetLogy(1);
 	if(locHist_PSCRF_SelfDeltaT != NULL)
 	{
 		TH1I* locHist = locHist_PSCRF_SelfDeltaT;
+		locHist->SetTitle("RF PSC Self timing");
+		locHist->GetXaxis()->Rebin(14);
+
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
 		locHist->GetXaxis()->SetLabelSize(0.05);
 		locHist->GetYaxis()->SetLabelSize(0.05);
 		locHist->Draw();
 	}
+
+#ifdef ROOTSPY_MACROS
+	// ------ The following is used by RSAI --------
+	if( rs_GetFlag("Is_RSAI")==1 ){
+	  auto min_events = rs_GetFlag("MIN_EVENTS_RSAI");
+	  if( min_events < 1 ) min_events = 1E5;
+	  if( Nevents >= min_events ) {
+	    cout << "RF Flagging AI check after " << Nevents << " events (>=" << min_events << ")" << endl;
+	    rs_SavePad("RF_FDC_selftiming", 1);
+	    rs_SavePad("RF_TOF_selftiming", 2);
+	    rs_SavePad("RF_TAGH_selftiming", 3);
+	    rs_SavePad("RF_PSC_selftiming", 4);
+
+	    rs_ResetAllMacroHistos("//RF_online");
+	  }
+	}
+#endif
+	
 }


### PR DESCRIPTION
this will create four pictures of the RF self timing peak from FDC, TOF, TAGH and PSC TDC data to be monitored using HYDRA. 