### PR TITLE
fix error for using Rebin in TAxis class rather than histogram class

### DIFF
--- a/src/plugins/monitoring/RF_online/HistMacro_RF_p1.C
+++ b/src/plugins/monitoring/RF_online/HistMacro_RF_p1.C
@@ -36,7 +36,7 @@
 	{
 		TH1I* locHist = locHist_FDCRF_SelfDeltaT;
 		locHist->SetTitle("RF FDC Self timing");
-		locHist->GetXaxis()->Rebin(14);
+		locHist->Rebin(14);
 
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
@@ -53,7 +53,7 @@
 	{
 		TH1I* locHist = locHist_TOFRF_SelfDeltaT;
 		locHist->SetTitle("RF TOF Self timing");
-		locHist->GetXaxis()->Rebin(12);
+		locHist->Rebin(12);
 
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
@@ -70,7 +70,7 @@
 	{
 		TH1I* locHist = locHist_TAGHRF_SelfDeltaT;
 		locHist->SetTitle("RF TAGH Self timing");
-		locHist->GetXaxis()->Rebin(14);
+		locHist->Rebin(14);
 
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);
@@ -87,7 +87,7 @@
 	{
 		TH1I* locHist = locHist_PSCRF_SelfDeltaT;
 		locHist->SetTitle("RF PSC Self timing");
-		locHist->GetXaxis()->Rebin(14);
+		locHist->Rebin(14);
 
 		locHist->GetXaxis()->SetTitleSize(0.05);
 		locHist->GetYaxis()->SetTitleSize(0.05);


### PR DESCRIPTION
I did introduce a bug when doing a Rebining of the X axis of the self timing plots for the RF signals
did not realize that the method Rebin() is part of the TH1 class not the TAxis class.

