### PR TITLE
look for mismatches in itrigger AND trigger time, filling the histo i…

### DIFF
--- a/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
+++ b/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
@@ -19,6 +19,7 @@
 
 	//Draw
 	locCanvas->cd();
+        gStyle->SetPalette(kCool);
         gStyle->SetOptStat(0);
         gStyle->SetGridStyle(1);
 	gPad->SetTicks();
@@ -33,7 +34,7 @@
 		locHist->GetYaxis()->SetLabelSize(0.035);
 		locHist->GetYaxis()->SetNdivisions(17);
 		locHist->GetYaxis()->CenterLabels(1);
-		locHist->Draw("colz2");
+		locHist->Draw("colz");  // don't use colz2, it is buggy in -b mode
 	}
 
 


### PR DESCRIPTION
…f more than one bit is off in both of these

The previous incarnation flagged too many trivial errors (cases where there was one bit off in itrigger, but it was a large value bit).  This updated version looks for multi-bit mismatches in itrigger and also in trigger time, assuming that the correct trigger time is the most popular one.  It increments the monitoring histogram if multi-bit mismatches are present in both itrigger and the trigger time.   This cleaned up the 'noise' entries and still identifies the buggy runs successfully. 

I changed the drawing script to use colz rather than colz2, after I found that colz2 colours in the zero-content histogram bins if the macro is run interactively, but if it is run in batch mode (much faster) using -b, it leaves them white.  Presumably this is a bug in root.  I changed the Palette so that the filled bins are shown in magenta rather than yellow, as it's easier for humans to spot magenta on white than yellow on white. 

Good run:
![itrig_072931_025](https://user-images.githubusercontent.com/15655254/129455650-3f9421c3-8e98-4d43-a589-e2f7c4828da0.png)

Bad run:
![itrig_072932_001](https://user-images.githubusercontent.com/15655254/129455681-be30a229-3d6e-4c8b-8e49-adf8069821f5.png)



