### PR TITLE
Nsj plugin mod

### DIFF
--- a/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
+++ b/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
@@ -41,6 +41,11 @@
 #ifdef ROOTSPY_MACROS
 	// ------ The following is used by RSAI --------
 	if( rs_GetFlag("Is_RSAI")==1 ){
+
+          double Nevents = 1.0;
+          TH1I *hevents = (TH1I*)gDirectory->FindObjectAny("num_events");
+          if(hevents) Nevents = (double)num_events->GetBinContent(1);
+
 	  auto min_events = rs_GetFlag("MIN_EVENTS_RSAI");
 	  if( min_events < 1 ) min_events = 1E4;
 	  if( Nevents >= min_events ) {

--- a/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
+++ b/src/plugins/monitoring/fa125_itrig/HistMacro_fa125_itrig.C
@@ -1,4 +1,5 @@
 // hnamepath: /fa125_itrig/errcount
+// hnamepath: /fa125_itrig/num_events
 
 {
 	TDirectory *locTopDirectory = gDirectory;
@@ -43,7 +44,9 @@
 	if( rs_GetFlag("Is_RSAI")==1 ){
 
           double Nevents = 1.0;
-          TH1I *hevents = (TH1I*)gDirectory->FindObjectAny("num_events");
+
+          TH1I *hevents = (TH1I*)gDirectory->Get("/fa125_itrig/num_events");
+
           if(hevents) Nevents = (double)num_events->GetBinContent(1);
 
 	  auto min_events = rs_GetFlag("MIN_EVENTS_RSAI");
@@ -51,7 +54,8 @@
 	  if( Nevents >= min_events ) {
 	    cout << "RF Flagging AI check after " << Nevents << " events (>=" << min_events << ")" << endl;
 	    rs_SavePad("fa125_itrig", 1);
-	    rs_ResetAllMacroHistos("//fa125_itrig");
+	    rs_ResetAllMacroHistos("//HistMacro_fa125_itrig");
+
 	  }
 	}
 #endif

--- a/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.cc
+++ b/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.cc
@@ -6,7 +6,8 @@
 //
 
 // Looks for differences between Df125triggertime's itrigger and the eventnumber,
-// which could indicate the fadc getting out of sync
+// which could indicate the fadc getting out of sync.
+// Also compares the trigger time of each fadc to that of the others.
 
 // Increments a 2D histogram(roc,slot) each time a difference is found.
 // For normal runs the histogram looks like noise; bad runs look as if there are hot channels, with larger z scale.
@@ -37,8 +38,8 @@ using namespace jana;
 #include <TMath.h>
 #include <TBits.h>
 
-static TH2I *hdiffs=NULL;
-
+static TH2I *hdiffs = NULL;
+static TH1I *hevents = NULL;
 static TTree *tree = NULL;
 
 
@@ -83,12 +84,12 @@ jerror_t JEventProcessor_fa125_itrig::init(void)
   }
 
 
-  japp->RootWriteLock();
-
   TDirectory *main = gDirectory;
   gDirectory->mkdir("fa125_itrig")->cd();
 
   hdiffs = new TH2I("errcount","Count of fa125 itrigger time errors; roc ; slot", 15, 1, 16, 17, 3, 20);
+
+  hevents = new TH1I("num_events","Number of events", 1, 0.0, 1.0);
 
   for (int i=0; i<70; i++) rocmap[i] = 0;  // rocmap[rocid] = bin number for roc rocid in histogram
 
@@ -155,8 +156,6 @@ jerror_t JEventProcessor_fa125_itrig::init(void)
 
   main->cd();
 
-  japp->RootUnLock();
-
 
   return NOERROR;
 }
@@ -177,6 +176,8 @@ jerror_t JEventProcessor_fa125_itrig::evnt(JEventLoop *loop, uint64_t eventnumbe
 {
 	// This is called for every event. 
 
+  // Event count used by RootSpy->RSAI so it knows how many events have been seen.
+  hevents->Fill(0.5);
 
   ULong64_t timestamp = 0;
 
@@ -274,15 +275,17 @@ jerror_t JEventProcessor_fa125_itrig::evnt(JEventLoop *loop, uint64_t eventnumbe
       tdiff = most_popular_time - ttime;
 
       // count the bits differing between ttime and most popular time
-      // ttime often differs by 1 between L and R halves of the crate 
+      // ttime often differs by 1 between L and R halves of the crate, this is not important. 
       // single bit differences in more significant bits happen infrequently when other output is ok
 
       ULong64_t posdiff;
 
+      // Compare right-shifted ttime and most_popular_time to ignore LSB.
+
       if (ttime > most_popular_time) {
-        posdiff = ttime - most_popular_time;
+        posdiff = (ttime>>1) - (most_popular_time>>1);
       } else {
-        posdiff = most_popular_time - ttime;
+        posdiff = (most_popular_time>>1) - (ttime>>1);
       }
 
       UInt_t diffcount_ttime = 0;


### PR DESCRIPTION
A bunch of minor changes, mostly for RSAI and in the macro.

Changes to the plugin:

Added a number of events histogram, for RSAI.

Removed rootlocks from the init function as they are not needed there.

Removed the least sig bit from the trigger times before comparing them, as these often differ by 1 between the L and R halves of the crate (I think the clock signal does not reach them at exactly the same time).  Look for any 2 or more bits different in the remainder of the trigger time words, and flag an error if that happens when there are also 2 or more bits wrong in itrigger.   