### PR TITLE
Added option q to quit after a specified number of events containing …

### DIFF
--- a/src/programs/Analysis/hd_dump/MyProcessor.cc
+++ b/src/programs/Analysis/hd_dump/MyProcessor.cc
@@ -25,7 +25,12 @@ bool PRINT_SUMMARY_ALL = false;
 bool PRINT_SUMMARY_HEADER = false;
 bool PRINT_STATUS_BITS = false;
 bool ACTIVATE_TAGGED_FOR_SUMMARY = false;
+bool QUIT_AFTER_FINDING_NTH = false;
 extern bool SPARSIFY_SUMMARY;
+
+int N_TO_FIND=1;
+
+int n_found=0;
 
 set<string> toprint;
 set<string> tosummarize;
@@ -187,13 +192,17 @@ jerror_t MyProcessor::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
 			string name =fac_info[i].dataClassName;
 			string tag = fac_info[i].tag;
 			eventLoop->Print(name,tag.c_str());
-
+                        
 			if(LIST_ASSOCIATED_OBJECTS)PrintAssociatedObjects(eventLoop, &fac_info[i]);
 		}catch(...){
 			// exception thrown
 		}
 	}
 	
+        n_found++; // keep count of number of events printed
+
+        if (n_found==N_TO_FIND) eventLoop->QuitProgram();
+
 	// If the program is quitting, then don't bother waiting for the user
 	if(eventLoop->GetJApplication()->GetQuittingStatus())return NOERROR;
 	

--- a/src/programs/Analysis/hd_dump/MyProcessor.h
+++ b/src/programs/Analysis/hd_dump/MyProcessor.h
@@ -24,6 +24,9 @@ extern bool PRINT_SUMMARY_ALL;
 extern bool PRINT_SUMMARY_HEADER;
 extern bool PRINT_STATUS_BITS;
 extern bool ACTIVATE_TAGGED_FOR_SUMMARY;
+extern bool QUIT_AFTER_FINDING_NTH;
+
+extern int N_TO_FIND;
 
 extern set<string> toprint;
 extern set<string> tosummarize;

--- a/src/programs/Analysis/hd_dump/hd_dump.cc
+++ b/src/programs/Analysis/hd_dump/hd_dump.cc
@@ -134,6 +134,15 @@ void ParseCommandLineArguments(int &narg, char *argv[])
 			case 'D':
 				toprint.insert(&argv[i][2]);
 				break;
+     		        case 'q':
+		                QUIT_AFTER_FINDING_NTH = true;
+				SKIP_BORING_EVENTS = true;
+				PAUSE_BETWEEN_EVENTS = false;
+				if (strlen(argv[i])>2) {  // N_TO_FIND defaults to 1 if not specified
+				  long int number_to_find = strtol(&argv[i][2],NULL,10);
+				  N_TO_FIND = (int)number_to_find;
+				}
+				break;
 			case 'p':
 				PAUSE_BETWEEN_EVENTS = false;
 				break;
@@ -195,12 +204,13 @@ void Usage(void)
 	cout<<endl;
 	cout<<"   -h        Print this message"<<endl;
 	cout<<"   -Dname    Print the data of type \"name\" (can be used multiple times)"<<endl;
-	cout<<"   -A        Print ALL data types (overrides and -DXXX options)"<<endl;
+	cout<<"   -A        Print ALL data types (overrides -s and -DXXX options)"<<endl;
 	cout<<"   -L        List available factories and exit"<<endl;
 	cout<<"   -p        Don't pause for keystroke between events (def. is to pause)"<<endl;
 	cout<<"   -s        Skip events which don't have any of the specified data types"<<endl;
+	cout<<"   -qn       Quit after printing n events (default n=1), skip boring events, and don't pause"<<endl;
 	cout<<"   -a        List types and number of associated objects"<<endl;
-	cout<<"   -S        Don't supress printing of factories with no objects in summary"<<endl;
+	cout<<"   -S        Don't suppress printing of factories with no objects in summary"<<endl;
 	cout<<"   -c        Print summary header lisiting for select factories."<<endl;
 	cout<<"   -V        Print summary header lisiting for all factories."<<endl;
 	cout<<"             (warning: this activates every single factory!)"<<endl;


### PR DESCRIPTION
…the selected data types have been printed

I added an option to count the number of events printed, skip the events which don't contain the specified data types and also skip the pauses, and exit automatically when the required number of events has been printed.   The default is 1.  
eg hd_dump -q2 -DCODAEventInfo [rootfile] will print the information for the first 2 instances of DCODAEventInfo and then quit.

The new functionality is that the user does not have to guess how many events are needed in order to find the first n  instances of whatever they're looking for, and also that they don't have to hit Q to make the program exit, so it's easier to use it in scripts.  The existing code can be made to exit automatically using -PEVENTS_TO_KEEP, but that does not guarantee that the required number of data factory objects has been found - if prestart happened a few minutes before go, then there can be a huge number of epics events at the start of the first file.  