### PR TITLE
Make hd_dump process all events

### DIFF
--- a/src/programs/Analysis/hd_dump/MyProcessor.cc
+++ b/src/programs/Analysis/hd_dump/MyProcessor.cc
@@ -28,7 +28,7 @@ bool ACTIVATE_TAGGED_FOR_SUMMARY = false;
 bool QUIT_AFTER_FINDING_NTH = false;
 extern bool SPARSIFY_SUMMARY;
 
-int N_TO_FIND=1;
+int N_TO_FIND=0; // default to processing all events
 
 int n_found=0;
 

--- a/src/programs/Analysis/hd_dump/hd_dump.cc
+++ b/src/programs/Analysis/hd_dump/hd_dump.cc
@@ -138,7 +138,7 @@ void ParseCommandLineArguments(int &narg, char *argv[])
 		                QUIT_AFTER_FINDING_NTH = true;
 				SKIP_BORING_EVENTS = true;
 				PAUSE_BETWEEN_EVENTS = false;
-				if (strlen(argv[i])>2) {  // N_TO_FIND defaults to 1 if not specified
+				if (strlen(argv[i])>2) {  // N_TO_FIND defaults to 0(=all events) if not specified
 				  long int number_to_find = strtol(&argv[i][2],NULL,10);
 				  N_TO_FIND = (int)number_to_find;
 				}


### PR DESCRIPTION
Set default for N_TO_FIND to 0 so that all events are processed unless otherwise specified with -q#