### PR TITLE
Change needed to make ROOT 6.24 work with halld_recon

### DIFF
--- a/src/libraries/DIRC/DDIRCLutReader.cc
+++ b/src/libraries/DIRC/DDIRCLutReader.cc
@@ -38,7 +38,7 @@ DDIRCLutReader::DDIRCLutReader(JApplication *japp, unsigned int run_number)
 	if(!lut_file.empty()) {
 		jout<<"Reading DIRC LUT TTree from "<<lut_file<<" ..."<<endl;
 		
-		auto saveDir = gDirectory;
+		TDirectory *saveDir = gDirectory;
 		TFile *fLut = new TFile(lut_file.c_str());
 		if( !fLut->IsOpen() ){
 			jerr << "Unable to open " << lut_file << "!!" << endl;


### PR DESCRIPTION
So this was a fun one, which should resolve issue #584 

Basically:  the global ROOT variable gDirectory in hd_root (which we rely on for various things, including the functions in HistogramTools.h) is usually kept set to the root directory of the main output file ("hd_root.root").  When moving from ROOT 6.08.06 to 6.24.04, at some point it was getting set to the blank memory-only "file", causing great confusion to users of HistogramTools.h (among others) since their histograms were not getting saved to the file.

After a lot of trial and error (thanks to @aaust and @markito3) we tracked this problem down to this line.  Figuring the exact cause will take some deep C++ pondering, but note the different definitions of gDirectory:
ROOT 6.08.06 - `#define gDirectory (TDirectory::CurrentDirectory())`
ROOT 6.24.04 - `#define gDirectory (ROOT::Internal::TDirectoryAtomicAdapter(TDirectory::CurrentDirectory()))`

clearly the `auto` keyword does not like this second definition.  No clue why it fails silently.

So this should resolve the issue (and is about 10 times longer than the actual change).

Two other things we should consider:
* Finding a better solution than relying on gDirectory to be properly set
* Deprecating HistogramTools.h, since it is easy to use, but has some non-trivially non-standard semantics and is also a performance issue (locks and unlocks every time a histogram is filled)
