### PR TITLE
Aaust src plugin fix plus sdobbs

### DIFF
--- a/src/plugins/Analysis/src-ct/1p1pi1pi0/DEventProcessor_1p1pi1pi0.cc
+++ b/src/plugins/Analysis/src-ct/1p1pi1pi0/DEventProcessor_1p1pi1pi0.cc
@@ -111,6 +111,8 @@ jerror_t DEventProcessor_1p1pi1pi0::init(void)
 //------------------
 jerror_t DEventProcessor_1p1pi1pi0::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
+  dKinFitUtils = new DKinFitUtils_GlueX(eventLoop);
+  dKinFitter = new DKinFitter(dKinFitUtils);
 
   return NOERROR;
 }
@@ -230,12 +232,11 @@ jerror_t DEventProcessor_1p1pi1pi0::evnt(JEventLoop *loop, uint64_t eventnumber)
   if (nHyp != 1)
     return NOERROR;
       
+  LockState(); //ACQUIRE PROCESSOR LOCK
+
   map<Particle_t, vector<const DChargedTrackHypothesis*> > thisHyp = hypothesisList[0];
   const DChargedTrackHypothesis * hyp_pr = thisHyp[Proton][0];
   const DChargedTrackHypothesis * hyp_pim = thisHyp[PiMinus][0];
-  
-  DKinFitUtils_GlueX *dKinFitUtils = new DKinFitUtils_GlueX(loop);
-  DKinFitter *dKinFitter = new DKinFitter(dKinFitUtils);
   
   dKinFitUtils->Reset_NewEvent();
   dKinFitter->Reset_NewEvent();
@@ -266,8 +267,10 @@ jerror_t DEventProcessor_1p1pi1pi0::evnt(JEventLoop *loop, uint64_t eventnumber)
   dKinFitter->Fit_Reaction();
   
   dTreeFillData.Fill_Single<Double_t>("CL",dKinFitter->Get_ConfidenceLevel());
-  if (dKinFitter->Get_ConfidenceLevel() == 0)
+  if (dKinFitter->Get_ConfidenceLevel() == 0){
+    UnlockState(); //RELEASE PROCESSOR LOCK
     return NOERROR;
+  }
   
   TVector3 vertex;
   double vertex_x = 0;
@@ -377,6 +380,8 @@ jerror_t DEventProcessor_1p1pi1pi0::evnt(JEventLoop *loop, uint64_t eventnumber)
   //FILL TTREE
   dTreeInterface->Fill(dTreeFillData);
   
+  UnlockState(); //RELEASE PROCESSOR LOCK
+
   return NOERROR;
 
 }

--- a/src/plugins/Analysis/src-ct/1p1pi1pi0/DEventProcessor_1p1pi1pi0.h
+++ b/src/plugins/Analysis/src-ct/1p1pi1pi0/DEventProcessor_1p1pi1pi0.h
@@ -44,6 +44,9 @@ class DEventProcessor_1p1pi1pi0:public JEventProcessor{
   jerror_t erun(void);						///< Called everytime run number changes, provided brun has been called.
   jerror_t fini(void);						///< Called after last event of last event source has been processed.
   
+  DKinFitUtils_GlueX *dKinFitUtils;
+  DKinFitter *dKinFitter;
+
   void GetHypotheses(vector<const DChargedTrack *> &tracks,
 		     map<Particle_t, int> &particles,
 		     map<Particle_t, vector<const DChargedTrackHypothesis*> > &assignmentHypothesis,

--- a/src/plugins/Analysis/src-ct/1p2pi/DEventProcessor_1p2pi.cc
+++ b/src/plugins/Analysis/src-ct/1p2pi/DEventProcessor_1p2pi.cc
@@ -194,10 +194,10 @@ jerror_t DEventProcessor_1p2pi::evnt(JEventLoop *loop, uint64_t eventnumber)
       locFullConstrainParticles.insert(myPiPlus);
       locFullConstrainParticles.insert(myPiMinus);
       locFullConstrainParticles.insert(myProton);
-
+      
       //shared_ptr<DKinFitConstraint_Vertex> locProductionVertexConstraint =  dKinFitUtils->Make_VertexConstraint(locFullConstrainParticles, NoParticles, proton_track->position());
 	  // maybe use a better vertex guess
-      shared_ptr<DKinFitConstraint_Vertex> locProductionVertexConstraint =  dKinFitUtils->Make_VertexConstraint(locFullConstrainParticles, NoParticles, proton_track->position());
+      shared_ptr<DKinFitConstraint_Vertex> locProductionVertexConstraint =  dKinFitUtils->Make_VertexConstraint(locFullConstrainParticles, NoParticles, locTRoughPosition);
 
       dKinFitter->Add_Constraint(locProductionVertexConstraint);
 

--- a/src/plugins/Analysis/src-ct/1p2pi/DEventProcessor_1p2pi.h
+++ b/src/plugins/Analysis/src-ct/1p2pi/DEventProcessor_1p2pi.h
@@ -8,6 +8,7 @@ using namespace jana;
 #include <TRIGGER/DTrigger.h>
 #include <PID/DBeamPhoton.h>
 
+#include "ANALYSIS/DAnalysisUtilities.h"
 #include "ANALYSIS/DTreeInterface.h"
 #include <KINFITTER/DKinFitter.h>
 #include <ANALYSIS/DKinFitUtils_GlueX.h>
@@ -40,6 +41,8 @@ class DEventProcessor_1p2pi:public JEventProcessor{
 
 		DKinFitUtils_GlueX *dKinFitUtils;
 		DKinFitter *dKinFitter;
+		const DAnalysisUtilities* dAnalysisUtilities;
+
 
   		void GetHypotheses(vector<const DChargedTrack *> &tracks,
 		     map<Particle_t, int> &particles,


### PR DESCRIPTION
Quoting @sdobbs for reference:

- in multi-threaded JANA, you get one factory object per thread, but there's only ever one plugin object, that means in this case only one DKinFitter object, with multiple threads trying to access it per evnt() function call
- short-term solution here: put the fitting in a lock
- better: put the fitting, etc. into a factory local to the plugin (see p2pi_hists)