### PR TITLE
Add blind-spot veto

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -752,7 +752,7 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	//KINEMATICS //is combo-dependent: P4 defined by X4, X4 defined by other tracks
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Measured"), dInitNumNeutralArraySize);
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "P4_Measured"), dInitNumNeutralArraySize);
-
+	
 	//PID QUALITY
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Beta_Timing"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locArraySizeString, dInitNumNeutralArraySize);
@@ -761,12 +761,15 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	//SHOWER INFO
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Shower"), dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locArraySizeString, dInitNumNeutralArraySize);
+	
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCAL"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCALPreshower"), locArraySizeString, dInitNumNeutralArraySize);
 	if(BCAL_VERBOSE_OUTPUT) {
@@ -1945,12 +1948,14 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locNeutralParticleHypothesis->Get_ChiSq(), locArrayIndex);
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Timing"), locNeutralParticleHypothesis->Get_NDF(), locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locNeutralShower->dQuality, locArrayIndex);
-	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locNeutralShower->dTOFVeto, locArrayIndex);
-	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locNeutralShower->dSCVeto, locArrayIndex);
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locNeutralShower->dSC_BCAL_match, locArrayIndex);
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locNeutralShower->dSC_FCAL_match, locArrayIndex);
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
-
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locNeutralShower->dTOF_FCAL_x_min, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locNeutralShower->dTOF_FCAL_y_min, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locNeutralShower->dSC_BCAL_phi_min, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locNeutralShower->dSC_FCAL_phi_min, locArrayIndex);
+	
 	//SHOWER ENERGY
 	DetectorSystem_t locDetector = locNeutralShower->dDetectorSystem;
 	double locBCALEnergy = (locDetector == SYS_BCAL) ? locNeutralShower->dEnergy : 0.0;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -761,6 +761,8 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	//SHOWER INFO
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Shower"), dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCAL"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCALPreshower"), locArraySizeString, dInitNumNeutralArraySize);
 	if(BCAL_VERBOSE_OUTPUT) {
@@ -1939,6 +1941,8 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locNeutralParticleHypothesis->Get_ChiSq(), locArrayIndex);
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Timing"), locNeutralParticleHypothesis->Get_NDF(), locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locNeutralShower->dQuality, locArrayIndex);
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locNeutralShower->dTOFVeto, locArrayIndex);
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locNeutralShower->dSCVeto, locArrayIndex);
 
 	//SHOWER ENERGY
 	DetectorSystem_t locDetector = locNeutralShower->dDetectorSystem;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -10,7 +10,7 @@ static bool STORE_PULL_INFO = false;
 static bool STORE_ERROR_MATRIX_INFO = false;
 static bool STORE_MC_TRAJECTORIES = false;
 
-static bool STORE_VETO_INFO = false;
+static bool STORE_SC_VETO_INFO = false;
 
 void DEventWriterROOT::Initialize(JEventLoop* locEventLoop)
 {
@@ -279,8 +279,8 @@ TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegist
 	if(gPARMS->Exists("ANALYSIS:STORE_MC_TRAJECTORIES")) 
 		{gPARMS->GetParameter("ANALYSIS:STORE_MC_TRAJECTORIES",STORE_MC_TRAJECTORIES); cout << "ANALYSIS:STORE_MC_TRAJECTORIES set to " << STORE_MC_TRAJECTORIES << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
 
-	if(gPARMS->Exists("ANALYSIS:STORE_VETO_INFO"))
-	    {gPARMS->GetParameter("ANALYSIS:STORE_VETO_INFO",STORE_VETO_INFO); cout << "ANALYSIS:STORE_VETO_INFO set to " << STORE_VETO_INFO << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
+	if(gPARMS->Exists("ANALYSIS:STORE_SC_VETO_INFO"))
+	    {gPARMS->GetParameter("ANALYSIS:STORE_SC_VETO_INFO",STORE_SC_VETO_INFO); cout << "ANALYSIS:STORE_SC_VETO_INFO set to " << STORE_SC_VETO_INFO << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
 
 	if(locKinFitType != d_NoFit)
 	{
@@ -766,17 +766,16 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	//SHOWER INFO
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Shower"), dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locArraySizeString, dInitNumNeutralArraySize);
-	if (STORE_VETO_INFO) {
+	if (STORE_SC_VETO_INFO) {
 	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
 	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
 	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
 	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
-	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locArraySizeString, dInitNumNeutralArraySize);
-	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locArraySizeString, dInitNumNeutralArraySize);
 	}
-	
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locArraySizeString, dInitNumNeutralArraySize);
+		
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCAL"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCALPreshower"), locArraySizeString, dInitNumNeutralArraySize);
 	if(BCAL_VERBOSE_OUTPUT) {
@@ -1955,16 +1954,16 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locNeutralParticleHypothesis->Get_ChiSq(), locArrayIndex);
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Timing"), locNeutralParticleHypothesis->Get_NDF(), locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locNeutralShower->dQuality, locArrayIndex);
-	if (STORE_VETO_INFO) {
+	if (STORE_SC_VETO_INFO) {
 	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locNeutralShower->dSC_BCAL_match, locArrayIndex);
 	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locNeutralShower->dSC_FCAL_match, locArrayIndex);
-	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
-	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locNeutralShower->dTOF_FCAL_x_min, locArrayIndex);
-	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locNeutralShower->dTOF_FCAL_y_min, locArrayIndex);
 	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locNeutralShower->dSC_BCAL_phi_min, locArrayIndex);
 	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locNeutralShower->dSC_FCAL_phi_min, locArrayIndex);
 	}
-
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locNeutralShower->dTOF_FCAL_x_min, locArrayIndex);
+	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locNeutralShower->dTOF_FCAL_y_min, locArrayIndex);
+	
 	//SHOWER ENERGY
 	DetectorSystem_t locDetector = locNeutralShower->dDetectorSystem;
 	double locBCALEnergy = (locDetector == SYS_BCAL) ? locNeutralShower->dEnergy : 0.0;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -10,6 +10,8 @@ static bool STORE_PULL_INFO = false;
 static bool STORE_ERROR_MATRIX_INFO = false;
 static bool STORE_MC_TRAJECTORIES = false;
 
+static bool STORE_VETO_INFO = false;
+
 void DEventWriterROOT::Initialize(JEventLoop* locEventLoop)
 {
 	dInitNumThrownArraySize = 20;
@@ -276,6 +278,9 @@ TMap* DEventWriterROOT::Create_UserInfoMaps(DTreeBranchRegister& locBranchRegist
     	{gPARMS->GetParameter("ANALYSIS:STORE_ERROR_MATRIX_INFO",STORE_ERROR_MATRIX_INFO); cout << "ANALYSIS:STORE_ERROR_MATRIX_INFO set to " << STORE_ERROR_MATRIX_INFO << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
 	if(gPARMS->Exists("ANALYSIS:STORE_MC_TRAJECTORIES")) 
 		{gPARMS->GetParameter("ANALYSIS:STORE_MC_TRAJECTORIES",STORE_MC_TRAJECTORIES); cout << "ANALYSIS:STORE_MC_TRAJECTORIES set to " << STORE_MC_TRAJECTORIES << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
+
+	if(gPARMS->Exists("ANALYSIS:STORE_VETO_INFO"))
+	    {gPARMS->GetParameter("ANALYSIS:STORE_VETO_INFO",STORE_VETO_INFO); cout << "ANALYSIS:STORE_VETO_INFO set to " << STORE_VETO_INFO << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;}
 
 	if(locKinFitType != d_NoFit)
 	{
@@ -761,14 +766,16 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	//SHOWER INFO
 	locBranchRegister.Register_ClonesArray<TLorentzVector>(Build_BranchName(locParticleBranchName, "X4_Shower"), dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locArraySizeString, dInitNumNeutralArraySize);
-	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locArraySizeString, dInitNumNeutralArraySize);
+	if (STORE_VETO_INFO) {
+	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locArraySizeString, dInitNumNeutralArraySize);
+	  locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locArraySizeString, dInitNumNeutralArraySize);
+	}
 	
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCAL"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCALPreshower"), locArraySizeString, dInitNumNeutralArraySize);
@@ -1948,14 +1955,16 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ChiSq_Timing"), locNeutralParticleHypothesis->Get_ChiSq(), locArrayIndex);
 	locTreeFillData->Fill_Array<UInt_t>(Build_BranchName(locParticleBranchName, "NDF_Timing"), locNeutralParticleHypothesis->Get_NDF(), locArrayIndex);
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locNeutralShower->dQuality, locArrayIndex);
-	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locNeutralShower->dSC_BCAL_match, locArrayIndex);
-	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locNeutralShower->dSC_FCAL_match, locArrayIndex);
-	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locNeutralShower->dTOF_FCAL_x_min, locArrayIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locNeutralShower->dTOF_FCAL_y_min, locArrayIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locNeutralShower->dSC_BCAL_phi_min, locArrayIndex);
-	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locNeutralShower->dSC_FCAL_phi_min, locArrayIndex);
-	
+	if (STORE_VETO_INFO) {
+	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locNeutralShower->dSC_BCAL_match, locArrayIndex);
+	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locNeutralShower->dSC_FCAL_match, locArrayIndex);
+	  locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
+	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_x_min"), locNeutralShower->dTOF_FCAL_x_min, locArrayIndex);
+	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_y_min"), locNeutralShower->dTOF_FCAL_y_min, locArrayIndex);
+	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_phi_min"), locNeutralShower->dSC_BCAL_phi_min, locArrayIndex);
+	  locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_phi_min"), locNeutralShower->dSC_FCAL_phi_min, locArrayIndex);
+	}
+
 	//SHOWER ENERGY
 	DetectorSystem_t locDetector = locNeutralShower->dDetectorSystem;
 	double locBCALEnergy = (locDetector == SYS_BCAL) ? locNeutralShower->dEnergy : 0.0;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -763,6 +763,10 @@ void DEventWriterROOT::Create_Branches_NeutralHypotheses(DTreeBranchRegister& lo
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+	locBranchRegister.Register_FundamentalArray<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locArraySizeString, dInitNumNeutralArraySize);
+
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCAL"), locArraySizeString, dInitNumNeutralArraySize);
 	locBranchRegister.Register_FundamentalArray<Float_t>(Build_BranchName(locParticleBranchName, "Energy_BCALPreshower"), locArraySizeString, dInitNumNeutralArraySize);
 	if(BCAL_VERBOSE_OUTPUT) {
@@ -1943,6 +1947,9 @@ void DEventWriterROOT::Fill_NeutralHypo(DTreeFillData* locTreeFillData, unsigned
 	locTreeFillData->Fill_Array<Float_t>(Build_BranchName(locParticleBranchName, "ShowerQuality"), locNeutralShower->dQuality, locArrayIndex);
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOFVeto"), locNeutralShower->dTOFVeto, locArrayIndex);
 	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSCVeto"), locNeutralShower->dSCVeto, locArrayIndex);
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_BCAL_match"), locNeutralShower->dSC_BCAL_match, locArrayIndex);
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerSC_FCAL_match"), locNeutralShower->dSC_FCAL_match, locArrayIndex);
+	locTreeFillData->Fill_Array<Int_t>(Build_BranchName(locParticleBranchName, "ShowerTOF_FCAL_match"), locNeutralShower->dTOF_FCAL_match, locArrayIndex);
 
 	//SHOWER ENERGY
 	DetectorSystem_t locDetector = locNeutralShower->dDetectorSystem;

--- a/src/libraries/FCAL/DFCALShower_factory.cc
+++ b/src/libraries/FCAL/DFCALShower_factory.cc
@@ -369,7 +369,7 @@ jerror_t DFCALShower_factory::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
 	// with each track
 	
 	DVector3 fcalFacePos = ( shower->getPosition() - vertex );
-	if (SHOWER_POSITION_LOG) fcalFacePos = ( shower->getPosition_log() - vertex );
+	//if (SHOWER_POSITION_LOG) fcalFacePos = ( shower->getPosition_log() - vertex );
 	fcalFacePos.SetMag( fcalFacePos.Mag() * projPos.Z() / fcalFacePos.Z() );
  
 	double distance = ( fcalFacePos - projPos ).Mag();
@@ -405,14 +405,14 @@ jerror_t DFCALShower_factory::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
       double sumV = 0;
       // if there is no nearest track, the defaults for xTr and yTr will result
       // in using the beam axis as the directional axis
-      if (!SHOWER_POSITION_LOG)
-	getUVFromHits( sumU, sumV, fcalHits,
-		       DVector3( shower->getPosition().X(), shower->getPosition().Y(), 0 ),
-		       DVector3( xTr, yTr, 0 ) );
-      else
-	getUVFromHits( sumU, sumV, fcalHits,
-		       DVector3( shower->getPosition_log().X(), shower->getPosition_log().Y(), 0 ),
-		       DVector3( xTr, yTr, 0 ) );
+      //if (!SHOWER_POSITION_LOG)
+      getUVFromHits( sumU, sumV, fcalHits,
+		     DVector3( shower->getPosition().X(), shower->getPosition().Y(), 0 ),
+		     DVector3( xTr, yTr, 0 ) );
+      //else
+      //getUVFromHits( sumU, sumV, fcalHits,
+      //	       DVector3( shower->getPosition_log().X(), shower->getPosition_log().Y(), 0 ),
+      //	       DVector3( xTr, yTr, 0 ) );
 
       shower->setSumU( sumU );
       shower->setSumV( sumV );
@@ -581,11 +581,11 @@ DFCALShower_factory::FillCovarianceMatrix(DFCALShower *shower){
   float shower_x = shower->getPosition().X();
   float shower_y = shower->getPosition().Y();
   float shower_z = shower->getPosition().Z();
-  if (SHOWER_POSITION_LOG) {
-    shower_x = shower->getPosition_log().X();
-    shower_y = shower->getPosition_log().Y();
-    shower_z = shower->getPosition_log().Z();
-  }
+  //if (SHOWER_POSITION_LOG) {
+  //shower_x = shower->getPosition_log().X();
+  //shower_y = shower->getPosition_log().Y();
+  //shower_z = shower->getPosition_log().Z();
+  //}
   float shower_r = sqrt(shower_x*shower_x + shower_y*shower_y);
   float shower_theta = atan2(shower_r,shower_z);
   float thlookup = shower_theta/3.14159265*180;

--- a/src/libraries/PID/DNeutralShower.h
+++ b/src/libraries/PID/DNeutralShower.h
@@ -38,16 +38,14 @@ class DNeutralShower : public jana::JObject
   // in the FCAL.  Quality = 1 for all BCAL showers.
 
   double dQuality;
-  int dTOFVeto;
+  
   int dTOF_FCAL_match;
   int dSC_FCAL_match;
   int dSC_BCAL_match;
-  int dSCVeto;
-
-  vector <float> dTOF_FCAL_x;
-  vector <float> dTOF_FCAL_y;
-  vector <float> dSC_BCAL_phi;
-  vector <float> dSC_FCAL_phi;
+  float dTOF_FCAL_x_min;
+  float dTOF_FCAL_y_min;
+  float dSC_BCAL_phi_min;
+  float dSC_FCAL_phi_min;
   
   const JObject* dBCALFCALShower; //is either DBCALShower or DFCALShower: dynamic_cast as appropriate (based on dDetectorSystem)
 

--- a/src/libraries/PID/DNeutralShower.h
+++ b/src/libraries/PID/DNeutralShower.h
@@ -46,7 +46,9 @@ class DNeutralShower : public jana::JObject
 
   vector <float> dTOF_FCAL_x;
   vector <float> dTOF_FCAL_y;
-
+  vector <float> dSC_BCAL_phi;
+  vector <float> dSC_FCAL_phi;
+  
   const JObject* dBCALFCALShower; //is either DBCALShower or DFCALShower: dynamic_cast as appropriate (based on dDetectorSystem)
 
   void toStrings(vector<pair<string,string> > &items) const{

--- a/src/libraries/PID/DNeutralShower.h
+++ b/src/libraries/PID/DNeutralShower.h
@@ -39,6 +39,9 @@ class DNeutralShower : public jana::JObject
 
   double dQuality;
   int dTOFVeto;
+  int dTOF_FCAL_match;
+  int dSC_FCAL_match;
+  int dSC_BCAL_match;
   int dSCVeto;
 
   const JObject* dBCALFCALShower; //is either DBCALShower or DFCALShower: dynamic_cast as appropriate (based on dDetectorSystem)

--- a/src/libraries/PID/DNeutralShower.h
+++ b/src/libraries/PID/DNeutralShower.h
@@ -44,6 +44,9 @@ class DNeutralShower : public jana::JObject
   int dSC_BCAL_match;
   int dSCVeto;
 
+  vector <float> dTOF_FCAL_x;
+  vector <float> dTOF_FCAL_y;
+
   const JObject* dBCALFCALShower; //is either DBCALShower or DFCALShower: dynamic_cast as appropriate (based on dDetectorSystem)
 
   void toStrings(vector<pair<string,string> > &items) const{

--- a/src/libraries/PID/DNeutralShower.h
+++ b/src/libraries/PID/DNeutralShower.h
@@ -38,6 +38,8 @@ class DNeutralShower : public jana::JObject
   // in the FCAL.  Quality = 1 for all BCAL showers.
 
   double dQuality;
+  int dTOFVeto;
+  int dSCVeto;
 
   const JObject* dBCALFCALShower; //is either DBCALShower or DFCALShower: dynamic_cast as appropriate (based on dDetectorSystem)
 

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -312,9 +312,9 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
     double dx = fcalpos.X() - xt;
     double dy = fcalpos.Y() - yt;
     if (fabs(dx) < dx_min)
-      dx_min = dx;
+      dx_min = fabs(dx);
     if (fabs(dy) < dy_min)
-      dy_min = dy;
+      dy_min = fabs(dy);
     if (fabs(dt) < TOF_RF_CUT) {
       global_tof_match ++;
     }
@@ -332,7 +332,7 @@ int DNeutralShower_factory::check_SC_match(double phi, double rfTime, vector< co
     const DSCHit *schits = locSCHits[i];
     double t = schits->t;
     double e = schits->dE;
-    double s = schits->sector-1;
+    double s = schits->sector - 1;
     double diff_t = t - rfTime;
     double phi_sc = sc_pos[s][0].Phi();
     double dphi = phi - phi_sc;

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -53,6 +53,11 @@ DNeutralShower_factory::DNeutralShower_factory()
   TOF_FCAL_PHI_CUT = 10;
   gPARMS->SetDefaultParameter("NeutralShower:TOF_FCAL_PHI_CUT", TOF_FCAL_PHI_CUT);
 
+  TOF_FCAL_x_match_CUT = 10;
+  TOF_FCAL_y_match_CUT = 10;
+  gPARMS->SetDefaultParameter("NeutralShower:TOF_FCAL_x_match_CUT", TOF_FCAL_x_match_CUT);
+  gPARMS->SetDefaultParameter("NeutralShower:TOF_FCAL_y_match_CUT", TOF_FCAL_y_match_CUT);
+
   SC_FCAL_PHI_CUT = 10;
   gPARMS->SetDefaultParameter("NeutralShower:SC_FCAL_PHI_CUT", SC_FCAL_PHI_CUT);
 
@@ -89,7 +94,9 @@ jerror_t DNeutralShower_factory::brun(jana::JEventLoop *locEventLoop, int32_t ru
   jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
   m_beamSpotX = beam_spot.at("x");
   m_beamSpotY = beam_spot.at("y");
-	
+  
+  RunNumber = runnumber;
+
   return NOERROR;
 }
 
@@ -243,9 +250,11 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
       double r = position.Mag();
       t -= (r / TMath::C() * 1e7);
       double phi_fcal = position.Phi();
-      double theta_fcal = position.Theta();
+      //double theta_fcal = position.Theta();
       
       bool Charge_Hit_in_FCAL = false;
+      
+      /*
       for (vector<const DTOFPoint*>::const_iterator tof = locTOFPoints.begin(); tof != locTOFPoints.end(); tof++) {
 	double xt = (*tof)->pos.X() - vertex.X();
 	double yt = (*tof)->pos.Y() - vertex.Y();
@@ -262,8 +271,11 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
 	  Charge_Hit_in_FCAL = true;
 	}
       }
+      */
       
-      if (Charge_Hit_in_FCAL)
+      int tof_match = check_TOF_match(position, rfTime, vertex, locTOFPoints);
+      
+      if (tof_match)
 	locNeutralShower->dTOF_FCAL_match = 1;
       else
 	locNeutralShower->dTOF_FCAL_match = 0;
@@ -371,3 +383,105 @@ double DNeutralShower_factory::getFCALQuality( const DFCALShower* fcalShower, do
   return dFCALClassifier->GetMvaValue( mvaInputs );
 }
 
+double DNeutralShower_factory::bar2x(int bar) {
+  
+  double x = -1000;
+  
+  if (RunNumber < 70000) {
+    
+    int ic = 2 * bar - 45; 
+    
+    double pos;
+    if (ic == 1  || ic == -1) 
+      pos = 3.0 * (double) ic;
+    else if (ic == 3 || ic ==  5) 
+      pos = 1.5 * (double) (ic + 2);
+    else if (ic == -3 || ic == -5) 
+      pos = 1.5 * (double) (ic - 2);
+    else if (ic >  5) 
+      pos = 3. * (ic - 2);
+    else 
+      pos = 3.* (ic + 2);
+    
+    x = 1.1 * pos;
+    
+  } if (RunNumber > 70000) {
+    
+    double inner_region_offset = 24.0;
+    
+    // outer region modules:
+    if (bar <= 17) { // assumes bar=1 is the most negative position
+      int ic = 17 - bar;
+      x = inner_region_offset + 6.0 * (0.5 + (double) ic);
+      x *= -1.0;
+    } if (bar >= 30) {
+      int ic = bar - 30;
+      x = inner_region_offset + 6.0 * (0.5 + (double) ic);
+    }
+    
+    //inner regions (just hard code each for now):
+    if (bar == 18) x = -21.75;
+    else if (bar == 19) x = -17.25;
+    else if (bar == 20) x = -13.50;
+    else if (bar == 21) x = -10.50;
+    else if (bar == 22) x = -6.75;
+    else if (bar == 23) x = -2.25;
+    else if (bar == 24) x = 2.25;
+    else if (bar == 25) x = 6.75;
+    else if (bar == 26) x = 10.50;
+    else if (bar == 27) x = 13.50;
+    else if (bar == 28) x = 17.25;
+    else if (bar == 29) x = 21.75;
+  }
+  
+  return x;
+}
+
+int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector< const DTOFPoint* > locTOFPoints) 
+{
+	
+  int global_tof_match = 0;
+  
+  for (vector< const DTOFPoint* >::const_iterator tof = locTOFPoints.begin(); tof != locTOFPoints.end(); tof++) {
+		
+    double xt = (*tof)->pos.X() - vertex.X();
+    double yt = (*tof)->pos.Y() - vertex.Y();
+    double zt = (*tof)->pos.Z() - vertex.Z();
+    double rt = sqrt(xt*xt + yt*yt + zt*zt);
+    
+    double tt = (*tof)->t - (rt / TMath::C() * 1e7);
+    double dt = tt - rfTime;
+    
+    xt *= fcalpos.Z() / zt;
+    yt *= fcalpos.Z() / zt;
+    
+    int hbar  = (*tof)->dHorizontalBar;
+    int hstat = (*tof)->dHorizontalBarStatus;
+    int vbar  = (*tof)->dVerticalBar;
+    int vstat = (*tof)->dVerticalBarStatus;
+    
+    double dx, dy;
+    
+    if (hstat==3 && vstat==3) { // both planes have hits in both ends
+      dx = fcalpos.X() - xt;
+      dy = fcalpos.Y() - yt;
+    } else if (hstat==3) { // only good position information in horizontal plane
+      dx = fcalpos.X() - xt;
+      dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+    } else if (vstat==3) {
+      dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
+      dy = fcalpos.Y() - yt;
+    } else {
+      dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
+      dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+    }
+    
+    if (fabs(dx) < TOF_FCAL_x_match_CUT && fabs(dy) < TOF_FCAL_y_match_CUT) {
+      if (fabs(dt) < TOF_RF_CUT) 
+	global_tof_match ++;
+    }
+    
+  }
+
+  return global_tof_match;
+}

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -311,11 +311,11 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
     yt *= fcalpos.Z() / zt;
     double dx = fcalpos.X() - xt;
     double dy = fcalpos.Y() - yt;
-    if (fabs(dx) < dx_min)
-      dx_min = fabs(dx);
-    if (fabs(dy) < dy_min)
-      dy_min = fabs(dy);
     if (fabs(dt) < TOF_RF_CUT) {
+      if (fabs(dx) < dx_min)
+	dx_min = fabs(dx);
+      if (fabs(dy) < dy_min)
+	dy_min = fabs(dy);
       global_tof_match ++;
     }
   }

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -121,7 +121,7 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
     double yt = (*tof)->pos.Y() - vertex.Y();
     double zt = (*tof)->pos.Z() - vertex.Z();
     double rt = sqrt(xt*xt + yt*yt + zt*zt);
-    double tt = (*tof)->t - (rt / TMath::C());
+    double tt = (*tof)->t - (rt / TMath::C() * 1e7);
     double dt = tt - rfTime;
     if (fabs(dt) < TOF_RF_CUT)
       n_locTOFPoints ++;

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -272,11 +272,15 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
 	}
       }
       */
+      vector <float> match_x; match_x.clear();
+      vector <float> match_y; match_y.clear();
+      int tof_match = check_TOF_match(position, rfTime, vertex, locTOFPoints, match_x, match_y);
       
-      int tof_match = check_TOF_match(position, rfTime, vertex, locTOFPoints);
-      
+      locNeutralShower->dTOF_FCAL_x = match_x;
+      locNeutralShower->dTOF_FCAL_y = match_y;
+
       if (tof_match)
-	locNeutralShower->dTOF_FCAL_match = 1;
+	locNeutralShower->dTOF_FCAL_match = match_x.size();
       else
 	locNeutralShower->dTOF_FCAL_match = 0;
       
@@ -383,7 +387,7 @@ double DNeutralShower_factory::getFCALQuality( const DFCALShower* fcalShower, do
   return dFCALClassifier->GetMvaValue( mvaInputs );
 }
 
-int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector< const DTOFPoint* > locTOFPoints) 
+int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector< const DTOFPoint* > locTOFPoints, vector <float> &match_x, vector <float> &match_y) 
 {
 	
   int global_tof_match = 0;
@@ -402,8 +406,11 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
     double dy = fcalpos.Y() - yt;
     
     if (fabs(dx) < TOF_FCAL_x_match_CUT && fabs(dy) < TOF_FCAL_y_match_CUT) {
-      if (fabs(dt) < TOF_RF_CUT) 
+      if (fabs(dt) < TOF_RF_CUT) {
+	match_x.push_back(dx);
+	match_y.push_back(dy);
 	global_tof_match ++;
+      }
     }
   }
 

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -35,6 +35,9 @@ DNeutralShower_factory::DNeutralShower_factory()
   dFCALClassifier = new DNeutralShower_FCALQualityMLP( vars );
   
   dResourcePool_TMatrixFSym = std::make_shared<DResourcePool<TMatrixFSym>>(); 
+
+  STORE_VETO_INFO = false;
+  gPARMS->SetDefaultParameter("NeutralShower:STORE_VETO_INFO", STORE_VETO_INFO);
   
   TOF_RF_CUT = 6.5;
   gPARMS->SetDefaultParameter("NeutralShower:TOF_RF_CUT", TOF_RF_CUT);
@@ -109,18 +112,19 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
   assert( eventRFBunches.size() == 1 );
   double rfTime = eventRFBunches[0]->dTime; // this is the RF time at the center of the target
 
-  // Loop over all DBCALShowers, create DNeutralShower if didn't match to any tracks
-  // The chance of an actual neutral shower matching to a bogus track is very small
-
   //-----   TOF veto    -----//
   DVector3 vertex(m_beamSpotX, m_beamSpotY, dTargetCenter.Z());
   vector <const DTOFPoint*> locTOFPoints;
-  locEventLoop->Get(locTOFPoints);
+  if (STORE_VETO_INFO) 
+    locEventLoop->Get(locTOFPoints);
   
   //-----   SC veto -----//
   vector<const DSCHit*> locSCHits;
-  locEventLoop->Get(locSCHits);
+  if (STORE_VETO_INFO) 
+    locEventLoop->Get(locSCHits);
   
+  // Loop over all DBCALShowers, create DNeutralShower if didn't match to any tracks
+  // The chance of an actual neutral shower matching to a bogus track is very small
   JObject::oid_t locShowerID = 0;
   for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
     {
@@ -137,17 +141,20 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
       // in the BCAL set the quality variable 1 to avoid eliminating
       // NeutralShowers in future splitoff rejection algorithms
       locNeutralShower->dQuality = 1;
-
-      double x = locBCALShowers[loc_i]->x - vertex.X();
-      double y = locBCALShowers[loc_i]->y - vertex.Y();
-      double z = locBCALShowers[loc_i]->z - vertex.Z();
-      DVector3 position(x, y, z);
-      double phi_bcal = position.Phi();
-      double delta_phi_min = 1000.;
-      int sc_match = check_SC_match(phi_bcal, rfTime, locSCHits, delta_phi_min);
-      locNeutralShower->dSC_BCAL_match = sc_match;
-      locNeutralShower->dSC_BCAL_phi_min = (float) delta_phi_min;
       
+      // Check if indeed shower is not related to a non-reconstructed track in SC
+      if (STORE_VETO_INFO) {
+	double x = locBCALShowers[loc_i]->x - vertex.X();
+	double y = locBCALShowers[loc_i]->y - vertex.Y();
+	double z = locBCALShowers[loc_i]->z - vertex.Z();
+	DVector3 position(x, y, z);
+	double phi_bcal = position.Phi();
+	double delta_phi_min = 1000.;
+	int sc_match = check_SC_match(phi_bcal, rfTime, locSCHits, delta_phi_min);
+	locNeutralShower->dSC_BCAL_match = sc_match;
+	locNeutralShower->dSC_BCAL_phi_min = (float) delta_phi_min;
+      }
+
       locNeutralShower->dEnergy = locBCALShowers[loc_i]->E;
       locNeutralShower->dSpacetimeVertex.SetXYZT(locBCALShowers[loc_i]->x, locBCALShowers[loc_i]->y, locBCALShowers[loc_i]->z, locBCALShowers[loc_i]->t);
       auto locCovMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
@@ -179,19 +186,22 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
       locNeutralShower->dSpacetimeVertex.SetT(locFCALShowers[loc_i]->getTime());
       
       locNeutralShower->dQuality = getFCALQuality( locFCALShowers[loc_i], rfTime );
-
-      DVector3 position = locFCALShowers[loc_i]->getPosition_log() - vertex;
-      double phi_fcal = position.Phi();
-      double delta_x_min = 1000.;
-      double delta_y_min = 1000.;
-      double delta_phi_min = 1000.;
-      int sc_match = check_SC_match(phi_fcal, rfTime, locSCHits, delta_phi_min);
-      int tof_match = check_TOF_match(position, rfTime, vertex, locTOFPoints, delta_x_min, delta_y_min);
-      locNeutralShower->dTOF_FCAL_match = tof_match;
-      locNeutralShower->dTOF_FCAL_x_min = (float) delta_x_min;
-      locNeutralShower->dTOF_FCAL_y_min = (float) delta_y_min;
-      locNeutralShower->dSC_FCAL_match = sc_match;
-      locNeutralShower->dSC_FCAL_phi_min = (float) delta_phi_min;
+      
+      // Check if indeed shower is not related to a non-reconstructed track in SC and/or TOF
+      if (STORE_VETO_INFO) {
+	DVector3 position = locFCALShowers[loc_i]->getPosition_log() - vertex;
+	double phi_fcal = position.Phi();
+	double delta_x_min = 1000.;
+	double delta_y_min = 1000.;
+	double delta_phi_min = 1000.;
+	int sc_match = check_SC_match(phi_fcal, rfTime, locSCHits, delta_phi_min);
+	int tof_match = check_TOF_match(position, rfTime, vertex, locTOFPoints, delta_x_min, delta_y_min);
+	locNeutralShower->dTOF_FCAL_match = tof_match;
+	locNeutralShower->dTOF_FCAL_x_min = (float) delta_x_min;
+	locNeutralShower->dTOF_FCAL_y_min = (float) delta_y_min;
+	locNeutralShower->dSC_FCAL_match = sc_match;
+	locNeutralShower->dSC_FCAL_phi_min = (float) delta_phi_min;
+      }
       
       auto locCovMatrix = dResourcePool_TMatrixFSym->Get_SharedResource();
       locCovMatrix->ResizeTo(5, 5);

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -107,6 +107,9 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
 {
   const DDetectorMatches* locDetectorMatches = NULL;
   locEventLoop->GetSingle(locDetectorMatches);
+  
+  
+  locEventLoop->GetSingle(dTOFGeometry);
 
   vector<const DBCALShower*> locBCALShowers;
   locEventLoop->Get(locBCALShowers);
@@ -382,7 +385,7 @@ double DNeutralShower_factory::getFCALQuality( const DFCALShower* fcalShower, do
   
   return dFCALClassifier->GetMvaValue( mvaInputs );
 }
-
+/*
 double DNeutralShower_factory::bar2x(int bar) {
   
   double x = -1000;
@@ -436,7 +439,7 @@ double DNeutralShower_factory::bar2x(int bar) {
   
   return x;
 }
-
+*/
 int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector< const DTOFPoint* > locTOFPoints) 
 {
 	
@@ -460,6 +463,9 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
     int vbar  = (*tof)->dVerticalBar;
     int vstat = (*tof)->dVerticalBarStatus;
     
+    double bh = dTOFGeometry->bar2y(hbar);
+    double bv = dTOFGeometry->bar2y(vbar);
+    
     double dx, dy;
     
     if (hstat==3 && vstat==3) { // both planes have hits in both ends
@@ -467,13 +473,17 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
       dy = fcalpos.Y() - yt;
     } else if (hstat==3) { // only good position information in horizontal plane
       dx = fcalpos.X() - xt;
-      dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+      //dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+      dy = fcalpos.Y() - (bh - vertex.Y()) * (fcalpos.Z() / zt);
     } else if (vstat==3) {
-      dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
+      //dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
+      dx = fcalpos.X() - (bv - vertex.X()) * (fcalpos.Z() / zt);
       dy = fcalpos.Y() - yt;
     } else {
-      dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
-      dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+      //dx = fcalpos.X() - (bar2x(vbar) - vertex.X()) * (fcalpos.Z() / zt);
+      //dy = fcalpos.Y() - (bar2x(hbar) - vertex.Y()) * (fcalpos.Z() / zt);
+      dx = fcalpos.X() - (bv - vertex.X()) * (fcalpos.Z() / zt);
+      dy = fcalpos.Y() - (bh - vertex.Y()) * (fcalpos.Z() / zt);
     }
     
     if (fabs(dx) < TOF_FCAL_x_match_CUT && fabs(dy) < TOF_FCAL_y_match_CUT) {

--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -116,34 +116,11 @@ jerror_t DNeutralShower_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t e
   DVector3 vertex(m_beamSpotX, m_beamSpotY, dTargetCenter.Z());
   vector <const DTOFPoint*> locTOFPoints;
   locEventLoop->Get(locTOFPoints);
-  int n_locTOFPoints = 0;
-  for (vector<const DTOFPoint*>::const_iterator tof = locTOFPoints.begin(); tof != locTOFPoints.end(); tof++) {
-    double xt = (*tof)->pos.X() - vertex.X();
-    double yt = (*tof)->pos.Y() - vertex.Y();
-    double zt = (*tof)->pos.Z() - vertex.Z();
-    double rt = sqrt(xt*xt + yt*yt + zt*zt);
-    double tt = (*tof)->t - (rt / TMath::C() * 1e7);
-    double dt = tt - rfTime;
-    if (fabs(dt) < TOF_RF_CUT)
-      n_locTOFPoints ++;
-  }
   
   //-----   SC veto -----//
   vector<const DSCHit*> locSCHits;
   locEventLoop->Get(locSCHits);
-  int n_locSCHits = 0;
-  for (unsigned int i = 0; i < locSCHits.size(); i ++) {
-    const DSCHit *schits = locSCHits[i];
-    double t = schits->t;
-    double e = schits->dE;
-    double diff_t = t - rfTime;
-    if (SC_RF_CUT_MIN < diff_t && diff_t < SC_RF_CUT_MAX) {
-      if ((e * 1e3) > SC_Energy_CUT)
-	n_locSCHits ++;
-    }
-  }
-
-
+  
   JObject::oid_t locShowerID = 0;
   for(size_t loc_i = 0; loc_i < locBCALShowers.size(); ++loc_i)
     {

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -61,7 +61,7 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_BCAL_PHI_CUT;
   double TOF_FCAL_x_match_CUT;
   double TOF_FCAL_y_match_CUT;
-  int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points);
+  int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points, vector <float> &match_x, vector <float> &match_y);
   
 };
 

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -55,12 +55,11 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;
   double SC_Energy_CUT;
-  double SC_FCAL_PHI_CUT;
-  double SC_BCAL_PHI_CUT;
-  double TOF_FCAL_x_match_CUT;
-  double TOF_FCAL_y_match_CUT;
-  int check_SC_match(double phi, double rfTime, double SC_PHI_CUT, vector< const DSCHit* > locSCHits, vector <float> &match_phi);
-  int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points, vector <float> &match_x, vector <float> &match_y);
+  int check_SC_match(double phi, double rfTime, vector< const DSCHit* > locSCHits, double &dphi_min);
+  int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points, double &dx_min, double &dy_min);
+  
+  vector<vector<DVector3> >sc_pos;
+  vector<vector<DVector3> >sc_norm;
   
 };
 

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -15,6 +15,8 @@
 #include <PID/DNeutralShower.h>
 #include <PID/DChargedTrack.h>
 #include <PID/DChargedTrackHypothesis.h>
+#include <TOF/DTOFPoint.h>
+#include <START_COUNTER/DSCHit.h>
 #include <FCAL/DFCALShower.h>
 #include <BCAL/DBCALShower.h>
 #include <CCAL/DCCALShower.h>
@@ -41,11 +43,17 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
 
   shared_ptr<DResourcePool<TMatrixFSym>> dResourcePool_TMatrixFSym;
   DVector3 dTargetCenter;
+  double m_beamSpotX;
+  double m_beamSpotY;  
 
   const char* inputVars[8] = { "nHits", "e9e25Sh", "e1e9Sh", "sumUSh", "sumVSh", "asymUVSh", "speedSh", "dtTrSh" };
   DNeutralShower_FCALQualityMLP* dFCALClassifier;
 
   double getFCALQuality( const DFCALShower* fcalShower, double rfTime ) const;
+  double TOF_RF_CUT;
+  double SC_RF_CUT_MIN;
+  double SC_RF_CUT_MAX;
+  double SC_Energy_CUT;
 };
 
 #endif // _DNeutralShower_factory_

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -16,7 +16,6 @@
 #include <PID/DChargedTrack.h>
 #include <PID/DChargedTrackHypothesis.h>
 #include <TOF/DTOFPoint.h>
-#include <TOF/DTOFGeometry_factory.h>
 #include <START_COUNTER/DSCHit.h>
 #include <FCAL/DFCALShower.h>
 #include <BCAL/DBCALShower.h>
@@ -56,14 +55,12 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;
   double SC_Energy_CUT;
-  double TOF_FCAL_THETA_CUT;
-  double TOF_FCAL_PHI_CUT;
+  //double TOF_FCAL_THETA_CUT;
+  //double TOF_FCAL_PHI_CUT;
   double SC_FCAL_PHI_CUT;
   double SC_BCAL_PHI_CUT;
   double TOF_FCAL_x_match_CUT;
   double TOF_FCAL_y_match_CUT;
-  //double bar2x(int bar);
-  const DTOFGeometry* dTOFGeometry;
   int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points);
   
 };

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -55,12 +55,11 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;
   double SC_Energy_CUT;
-  //double TOF_FCAL_THETA_CUT;
-  //double TOF_FCAL_PHI_CUT;
   double SC_FCAL_PHI_CUT;
   double SC_BCAL_PHI_CUT;
   double TOF_FCAL_x_match_CUT;
   double TOF_FCAL_y_match_CUT;
+  int check_SC_match(double phi, double rfTime, double SC_PHI_CUT, vector< const DSCHit* > locSCHits, vector <float> &match_phi);
   int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points, vector <float> &match_x, vector <float> &match_y);
   
 };

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -54,6 +54,10 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;
   double SC_Energy_CUT;
+  double TOF_FCAL_THETA_CUT;
+  double TOF_FCAL_PHI_CUT;
+  double SC_FCAL_PHI_CUT;
+  double SC_BCAL_PHI_CUT;
 };
 
 #endif // _DNeutralShower_factory_

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -45,7 +45,8 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   DVector3 dTargetCenter;
   double m_beamSpotX;
   double m_beamSpotY;  
-
+  int RunNumber;
+  
   const char* inputVars[8] = { "nHits", "e9e25Sh", "e1e9Sh", "sumUSh", "sumVSh", "asymUVSh", "speedSh", "dtTrSh" };
   DNeutralShower_FCALQualityMLP* dFCALClassifier;
 
@@ -58,6 +59,11 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double TOF_FCAL_PHI_CUT;
   double SC_FCAL_PHI_CUT;
   double SC_BCAL_PHI_CUT;
+  double TOF_FCAL_x_match_CUT;
+  double TOF_FCAL_y_match_CUT;
+  double bar2x(int bar);
+  int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points);
+  
 };
 
 #endif // _DNeutralShower_factory_

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -51,6 +51,7 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   DNeutralShower_FCALQualityMLP* dFCALClassifier;
 
   double getFCALQuality( const DFCALShower* fcalShower, double rfTime ) const;
+  bool STORE_VETO_INFO;
   double TOF_RF_CUT;
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -16,6 +16,7 @@
 #include <PID/DChargedTrack.h>
 #include <PID/DChargedTrackHypothesis.h>
 #include <TOF/DTOFPoint.h>
+#include <TOF/DTOFGeometry_factory.h>
 #include <START_COUNTER/DSCHit.h>
 #include <FCAL/DFCALShower.h>
 #include <BCAL/DBCALShower.h>
@@ -61,7 +62,8 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   double SC_BCAL_PHI_CUT;
   double TOF_FCAL_x_match_CUT;
   double TOF_FCAL_y_match_CUT;
-  double bar2x(int bar);
+  //double bar2x(int bar);
+  const DTOFGeometry* dTOFGeometry;
   int check_TOF_match(DVector3 fcalpos, double rfTime, DVector3 vertex, vector<const DTOFPoint*> tof_points);
   
 };

--- a/src/libraries/PID/DNeutralShower_factory.h
+++ b/src/libraries/PID/DNeutralShower_factory.h
@@ -51,7 +51,6 @@ class DNeutralShower_factory:public jana::JFactory<DNeutralShower>
   DNeutralShower_FCALQualityMLP* dFCALClassifier;
 
   double getFCALQuality( const DFCALShower* fcalShower, double rfTime ) const;
-  bool STORE_VETO_INFO;
   double TOF_RF_CUT;
   double SC_RF_CUT_MIN;
   double SC_RF_CUT_MAX;


### PR DESCRIPTION
Add into the NeutralShower_factor the SC & TOF vetos in order to remove charge hits which are not corresponding to reconstructed tracks