### PR TITLE
changes to optionally allow timing calibrations without the start counter

### DIFF
--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.h
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.h
@@ -77,6 +77,7 @@ class JEventProcessor_HLDetectorTiming:public jana::JEventProcessor{
 		bool NO_FIELD;
 		bool CCAL_CALIB;
 		bool STRAIGHT_TRACK;
+		bool NO_START_COUNTER;
 		
         // The final setup requires some shifts relative to the previous values, need to store them
 


### PR DESCRIPTION
needed for the CPP experiment

enabled by setting HLDETECTORTIMING:NO_START_COUNTER=1