### PR TITLE
PS and TAGH timing calibration

### DIFF
--- a/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
+++ b/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
@@ -3,14 +3,19 @@
 //    File: JEventProcessor_TAGH_timewalk.cc
 // Created: Fri Nov 13 10:13:02 EST 2015
 // Creator: nsparks (on Linux cua2.jlab.org 3.10.0-229.20.1.el7.x86_64 x86_64)
-//
+// A.S. 1/13/2022 add reference time determined by the PSC
 
 #include "JEventProcessor_TAGH_timewalk.h"
 using namespace jana;
 using namespace std;
 
 #include <TAGGER/DTAGHHit.h>
+#include <TAGGER/DTAGHGeometry.h>
+
 #include <RF/DRFTime.h>
+
+#include <PAIR_SPECTROMETER/DPSPair.h>
+#include <PAIR_SPECTROMETER/DPSCPair.h>
 
 // Routine used to create our JEventProcessor
 #include <JANA/JApplication.h>
@@ -24,6 +29,11 @@ static TH2I *hTAGH_tdcadcTimeDiffVsSlotID;
 static TH2I *hTAGHRF_tdcTimeDiffVsSlotID;
 static TH2I *hTAGHRF_tdcTimeDiffVsPulseHeight[1+Nslots];
 static TH2I *hTAGHRF_correctedTdcTimeDiffVsPulseHeight[1+Nslots];
+static TH2I *htagh_rf_psc;
+
+// Define RFTime_factory
+// DRFTime_factory* dRFTimeFactory;
+
 
 extern "C"{
     void InitPlugin(JApplication *app){
@@ -65,6 +75,10 @@ jerror_t JEventProcessor_TAGH_timewalk::init(void)
     TDirectory *taghDir = gDirectory->mkdir("TAGH_timewalk");
     taghDir->cd();
     gDirectory->mkdir("Offsets")->cd();
+
+
+    htagh_rf_psc = new TH2I("tagh_time_rf", "tagh_time_rf",  300, -0.5, 299.5,1600,-50.,50.);
+
     hTAGH_tdcadcTimeDiffVsSlotID = new TH2I("TAGH_tdcadcTimeDiffVsSlotID","TAGH TDC-ADC time difference vs. counter ID;counter ID;time(TDC) - time(ADC) [ns]",Nslots,0.5,0.5+Nslots,NTb,Tl,Th);
     hTAGHRF_tdcTimeDiffVsSlotID = new TH2I("TAGHRF_tdcTimeDiffVsSlotID","TAGH-RF TDC time difference vs. counter ID;counter ID;time(TDC) - time(RF) [ns]",Nslots,0.5,0.5+Nslots,NTb,Tl,Th);
     taghDir->cd();
@@ -110,29 +124,88 @@ jerror_t JEventProcessor_TAGH_timewalk::evnt(JEventLoop *loop, uint64_t eventnum
     // loop->Get(...) to get reconstructed objects (and thereby activating the
     // reconstruction algorithm) should be done outside of any mutex lock
     // since multiple threads may call this method at the same time.
+
+  vector<const DTAGHGeometry*> taghGeomVect;
+
+  loop->Get( taghGeomVect );  
+  if (taghGeomVect.size() < 1){
+    cout << "  taghGeomVect not found " << endl;
+    return OBJECT_NOT_AVAILABLE;  
+  }
+    
+  const DTAGHGeometry&  taghGeom =  *(taghGeomVect[0]);
+    
+
     vector<const DTAGHHit*> taghhits;
     loop->Get(taghhits, "Calib");
+    
+    vector<const DPSCPair*>   psc_pairs;
+    loop->Get(psc_pairs); 
+    
+    vector<const DPSPair*>   ps_pairs;
+    loop->Get(ps_pairs); 
+
+//    RFs for PS and PSC
+//  Use two separate RFs
+
     const DRFTime* rfTime = nullptr;
     vector <const DRFTime*> rfTimes;
+
+    const DRFTime* rfTimePSC = nullptr;
+    vector <const DRFTime*> rfTimesPSC;
+
+
+    loop->Get(rfTimesPSC,"PSC");
+
+    if (rfTimesPSC.size() > 0)
+      rfTimePSC = rfTimesPSC[0];
+    else
+      return NOERROR;
+
+
     loop->Get(rfTimes,"TAGH");
+
     if (rfTimes.size() > 0)
         rfTime = rfTimes[0];
     else
         return NOERROR;
+
+    
+
+
+    double t_rf_psc     =  0.;
+    int    psc_found    =  0.;
+
+    if((ps_pairs.size() > 0) && (psc_pairs.size() > 0)){
+
+      double psc_time  = (psc_pairs[0]->ee.first->t  +  psc_pairs[0]->ee.second->t)/2.;
+      t_rf_psc = dRFTimeFactory->Step_TimeToNearInputTime(rfTimePSC->dTime, psc_time);      
+
+      psc_found = 1;
+    }
+
+
+
+
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
     japp->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     double t_RF = rfTime->dTime;
+
     for (unsigned int i = 0; i < taghhits.size(); i++) {
+
         const DTAGHHit *hit = taghhits[i];
+
         if (!hit->has_TDC || !hit->has_fADC) continue;
+
         int id = hit->counter_id;
         double t = hit->t;
         double t_tdc = hit->time_tdc;
         double t_adc = hit->time_fadc;
         double pulse_height = hit->pulse_peak;
+
         hTAGH_tdcadcTimeDiffVsSlotID->Fill(id,t_tdc-t_adc);
         hTAGHRF_tdcTimeDiffVsSlotID->Fill(id,t_tdc-t_RF);
 
@@ -142,6 +215,21 @@ jerror_t JEventProcessor_TAGH_timewalk::evnt(JEventLoop *loop, uint64_t eventnum
         hTAGHRF_tdcTimeDiffVsPulseHeight[0]->Fill(pulse_height,t_tdc-t_RF);
         hTAGHRF_tdcTimeDiffVsPulseHeight[id]->Fill(pulse_height,t_tdc-t_RF);
         hTAGHRF_correctedTdcTimeDiffVsPulseHeight[id]->Fill(pulse_height,t-t_RF);
+
+	if(psc_found){
+
+	  double Elow  = taghGeom.getElow(id);
+	  double Ehigh = taghGeom.getEhigh(id);
+	  double tagh_energy = (Elow + Ehigh)/2;
+
+	  double pair_energy = ps_pairs[0]->ee.first->E + ps_pairs[0]->ee.second->E;
+
+	  if(fabs(pair_energy - tagh_energy) < 0.2)
+
+	  htagh_rf_psc->Fill(id, hit->t - t_rf_psc);
+
+	}
+
     }
 
     japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/README_TIME_SHIFT
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/README_TIME_SHIFT
@@ -1,0 +1,15 @@
+The script is used to calibrate ADC and TDC times for 
+TAGH channels, for which the wrong RF bunch was selected.
+The PSC time is used as an external reference for these
+channels.
+
+bash run_time_shift.sh  run_number root_file
+
+bash run_time_shift.sh 90221 run_90221_test.root 
+
+New calibration constants will be stored in the OUTPUT_SHIFT/run_number 
+directory 
+
+To publish fadc_time_offsets and tdc_time_offsets
+
+`bash publish_time_shift.sh 90221 90221 90221`

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/publish_time_shift.sh
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/publish_time_shift.sh
@@ -1,0 +1,7 @@
+RunNo=$1
+RunNo_min=$2
+RunNo_max=$3
+Dir=OUTPUT_TIME_SHIFT/${RunNo}
+
+ccdb add /PHOTON_BEAM/hodoscope/fadc_time_offsets -v default -r ${RunNo_min}-${RunNo_max} ${Dir}/adc_time_offsets_calib.txt '#Correct time shift'
+ccdb add /PHOTON_BEAM/hodoscope/tdc_time_offsets  -v default -r ${RunNo_min}-${RunNo_max} ${Dir}/tdc_time_offsets_calib.txt '#Correct time shift'

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/run_time_shift.sh
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/run_time_shift.sh
@@ -1,0 +1,14 @@
+RunNo=$1
+OutputDir=OUTPUT_TIME_SHIFT/${RunNo}
+InputFile=$2
+cp -p ${InputFile} hd_root.root
+
+ccdb dump /PHOTON_BEAM/hodoscope/fadc_time_offsets:${RunNo} >  adc_time_offsets.txt
+ccdb dump /PHOTON_BEAM/hodoscope/tdc_time_offsets:${RunNo}  >  tdc_time_offsets.txt
+
+root -b -q 'slice_tagh.C()'
+
+rm -f hd_root.root
+mkdir -p ${OutputDir}
+
+mv *.txt ${OutputDir}/.; 

--- a/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/slice_tagh.C
+++ b/src/plugins/Calibration/TAGH_timewalk/scripts/time_shift/slice_tagh.C
@@ -1,0 +1,264 @@
+void slice_tagh(){
+
+
+  int plot_fit = 0;
+
+  // Number of counters inside the PS energy range
+
+  int max_count = 200;
+
+  // ID = 2 is the first counter
+
+  char calib_file_adc[120];
+  char calib_file_tdc[120];
+
+
+  sprintf(calib_file_adc,"adc_time_offsets.txt");
+  sprintf(calib_file_tdc,"tdc_time_offsets.txt");
+
+
+  FILE *file1 = fopen(calib_file_adc,"r");
+  FILE *file2 = fopen(calib_file_tdc,"r");
+
+
+  TFile *file = new TFile ("hd_root.root","R");
+
+  gStyle->SetOptFit(1);
+
+
+  double calib_time  =  0.;
+
+  double  time_tagh[300];
+  float   adc_time_db_tagh[300];
+  float   tdc_time_db_tagh[300];
+
+  double  cnt_numb[300];
+
+  Double_t  ex[300];
+
+
+  memset(ex,0,sizeof(ex));
+
+  memset(time_tagh,0.,sizeof(time_tagh));
+
+  memset(adc_time_db_tagh,0,sizeof(adc_time_db_tagh));
+  memset(tdc_time_db_tagh,0,sizeof(tdc_time_db_tagh));
+
+  memset(cnt_numb,0,sizeof(cnt_numb));
+
+
+  Int_t ii = 0;
+
+  char str1[] = "#";
+
+  int ch;
+  
+  int cnt_tmp;
+
+
+  while (!feof(file1)){
+  
+    if ((ch = getc(file1)) != EOF){
+  
+       if (ch == '#')
+         while (getc(file1) != '\n');     
+        else
+       	  ungetc(ch,file1);
+    }
+  
+  
+    int a = fscanf(file1,"%d  %f \n",&cnt_tmp, &adc_time_db_tagh[ii]);
+
+    cout << "ii = " << ii <<  " CNT  = " << cnt_tmp  << "  DB time =  " << adc_time_db_tagh[ii]  << endl;
+
+   
+    ii++;
+
+  }
+ 
+
+  ii = 0;
+
+  while (!feof(file2)){
+  
+    if ((ch = getc(file2)) != EOF){
+  
+       if (ch == '#')
+         while (getc(file2) != '\n');     
+        else
+       	  ungetc(ch,file2);
+    }
+  
+  
+    int a = fscanf(file2,"%d  %f \n",&cnt_tmp, &tdc_time_db_tagh[ii]);
+
+    cout << "ii = " << ii <<  " CNT  = " << cnt_tmp  << "  DB time  TDC =  " << tdc_time_db_tagh[ii]  << endl;
+
+   
+    ii++;
+
+  }
+
+
+  TH2F *htagh_hit_time   =  (TH2F*)file->Get("TAGH_timewalk/Offsets/tagh_time_rf");
+
+
+  TH1 *htagh[max_count + 2];
+
+
+  TCanvas *c1 = new TCanvas("c1","c1", 200, 10, 800, 300);
+
+
+  for(int ii = 1; ii < max_count + 2; ii++){
+    
+    char title[30];
+    sprintf(title,"htagh%d",ii);
+    htagh[ii]    = htagh_hit_time->ProjectionY(title,ii,ii);
+
+    cnt_numb[ii] = ii;
+
+  }
+
+
+
+  TF1 *f0 = new TF1("f0","gaus",-200.,200.);
+  
+
+  for(int ii = 2; ii < max_count + 2; ii++){
+
+    Int_t nbins   = htagh[ii]->GetNbinsX();
+
+    Int_t entries = htagh[ii]->GetEntries();
+
+    cout << " ID = " << ii - 1 << "  " << entries << endl;
+
+    if(entries > 0){
+
+      // I. Search for peak
+      Int_t max_bin = 0;
+      Int_t max_amp = 0;
+
+      for(int jj = 1; jj < nbins - 1 ; jj++){
+	Int_t cont = htagh[ii]->GetBinContent(jj);
+	if(cont > max_amp){
+	  max_amp = cont;
+	  max_bin = jj;
+	}
+      }
+
+      double xbin = htagh[ii]->GetXaxis()->GetBinCenter(max_bin);
+
+      double xmin = xbin - 1.;
+      double xmax = xbin + 1.;
+     
+
+      f0->SetParameters(entries,xbin,1.2);
+
+      htagh[ii]->Fit("f0","","",xmin,xmax);
+
+      double mean = f0->GetParameter(1);	
+
+
+
+      time_tagh[ii] = mean;
+
+
+      //      cout << "Mean = " << mean << " Entries =  " << entries << 
+      //	" X max = " << xbin <<  endl;
+
+
+      if(plot_fit){
+
+	htagh[ii]->Draw();
+
+	c1->Update();	
+
+	//	getchar();
+
+      }
+      
+    }  // Entries > 0
+    else {
+
+      cout << " NO ENTRIES" << endl;
+      //      getchar();
+    }
+
+  }    // Loop over counters
+  
+  
+  
+
+  
+  TGraphErrors *gr1  = new TGraphErrors(max_count + 2,cnt_numb,time_tagh,ex,ex);
+  
+  gr1->SetMarkerStyle(20);
+  gr1->SetMarkerSize(0.6);
+  gr1->SetMarkerColor(4);
+  
+  gr1->SetTitle("PS Hit Time, Arm A");
+  gr1->GetXaxis()->SetTitle("PS counter");
+  gr1->GetYaxis()->SetTitle("Time (ns)");
+  
+  gr1->SetTitle("");
+  
+  gr1->Draw("AP");
+  
+
+
+  char name[200];
+  char name1[200];
+  
+  sprintf(name,"adc_time_offsets_calib.txt");
+  sprintf(name1,"tdc_time_offsets_calib.txt");
+
+
+  FILE *data_file1 = fopen(name,"w");
+  FILE *data_file2 = fopen(name1,"w");
+
+  // Write PS times and new values of the adc_time_offsets table to files
+  
+  cout << endl << endl;
+  
+  int bad_ch = 0;
+  
+  for(int ii = 0; ii <  274; ii++){
+    
+    int counter = ii + 1;
+    
+    if(counter < max_count){  // Update counters
+      
+      double new_db_time_adc = adc_time_db_tagh[ii] - (calib_time - time_tagh[ii + 2]);
+      double new_db_time_tdc = tdc_time_db_tagh[ii] - (calib_time - time_tagh[ii + 2]);
+      
+      double dt_tagh = calib_time - time_tagh[ii + 2];
+      
+      
+      if(fabs(dt_tagh) > 2){
+	cout << "TAGH:    " <<  counter << "   " <<   dt_tagh <<   "  Old DB   " <<  adc_time_db_tagh[ii] << 
+	  "   New DB  " <<  new_db_time_adc  << endl;
+	bad_ch++;
+      }
+      
+    
+      if(fabs(new_db_time_adc) > 1000.) new_db_time_adc = 0.;
+      if(fabs(new_db_time_tdc) > 1000.) new_db_time_tdc = 0.;
+            
+      fprintf(data_file1, "%d    %12.5f   \n", counter, new_db_time_adc); 
+      fprintf(data_file2, "%d    %12.5f   \n", counter, new_db_time_tdc);    
+
+    } else {
+
+      fprintf(data_file1, "%d    %12.5f   \n", counter, adc_time_db_tagh[ii]); 
+      fprintf(data_file2, "%d    %12.5f   \n", counter, tdc_time_db_tagh[ii]);  
+    }
+    
+  }
+
+  cout << endl << "Total number of bad channels = " << bad_ch << endl; 
+
+  fclose(data_file1);
+  fclose(data_file2);
+ 
+}
+  


### PR DESCRIPTION
Use the ADC time to find the closest RF time in PS_timing (fix bug in 
the PS_timing) 

Added PSC reference time to calibrate TAGH  ADC and TDC times 
for channels  with wrongly assigned RF (in TAGH_timewalk).  By default the
RF is assigned by TAGH ADC. A histogram is added, with the reference time 
(RF) defined by the PSC. Add calibration script  `run_time_shift.sh` to correct 
TAGH channels with wrong time (fadc_time_offsets and tdc_time_offsets)
