### PR TITLE
Fix TOF dE/dx being read from REST files (needed for RunPeriod-2019-11 recon ver01 files)

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1673,9 +1673,19 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
 	       {
 		 locTOFHitMatchParams->dEdx1 = locTofDedxIterator->getDEdx1();
 		 locTOFHitMatchParams->dEdx2 = locTofDedxIterator->getDEdx2();
+
+		 // check if already have average dE/dx
+		 if(locTOFHitMatchParams->dEdx > 0) continue;
+		 
+		 // average dE/dx is missing: take average if hits in both planes, otherwise use single plane value
+		 if(locTOFHitMatchParams->dEdx1>0 && locTOFHitMatchParams->dEdx2>0)
+			 locTOFHitMatchParams->dEdx = (locTOFHitMatchParams->dEdx1 + locTOFHitMatchParams->dEdx2) / 2.0; 
+		 else if(locTOFHitMatchParams->dEdx1>0)
+			 locTOFHitMatchParams->dEdx = locTOFHitMatchParams->dEdx1;
+		 else if(locTOFHitMatchParams->dEdx2>0) 
+			 locTOFHitMatchParams->dEdx = locTOFHitMatchParams->dEdx2;
 	       }
-	   }
-	 
+	   }	 
       }
 
       const hddm_r::BcalDOCAtoTrackList &bcaldocaList = iter->getBcalDOCAtoTracks();

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -1012,7 +1012,7 @@ bool DParticleID::Distance_ToTrack(const DReferenceTrajectory* rt, const DTOFPoi
 	locTOFHitMatchParams->dHitTime = locHitTime;
 	locTOFHitMatchParams->dHitTimeVariance = locHitTimeVariance;
 	locTOFHitMatchParams->dHitEnergy = locHitEnergy;
-	locTOFHitMatchParams->dEdx  = locTOFPoint->dE/dx/2.;
+	locTOFHitMatchParams->dEdx  = locTOFPoint->dE/dx;
 	locTOFHitMatchParams->dEdx1 = locTOFPoint->dE1/dx;
 	locTOFHitMatchParams->dEdx2 = locTOFPoint->dE2/dx;
 	locTOFHitMatchParams->dFlightTime = locFlightTime;


### PR DESCRIPTION
Utilize dE/dx information stored for individual planes to set average dE/dx value in memory (despite it not being written to REST files).  Downstream analysis like monitoring histograms and ReactionFilter will then have the relevant information and it can be used in analysis of produced ROOT trees with the DSelector.