### PR TITLE
Explicitly check to see if we're at the end of the file, and return the proper status

### DIFF
--- a/src/libraries/DAQ/HDEVIO.cc
+++ b/src/libraries/DAQ/HDEVIO.cc
@@ -528,6 +528,12 @@ bool HDEVIO::readNoFileBuff(uint32_t *user_buff, uint32_t user_buff_len, bool al
 			return false;			
 		}
 
+		if( words_left_in_file == 0 ) {
+		        err_mess << "Error reading EVIO block header (at EOF - truncated?)";
+		        err_code = HDEVIO_FILE_TRUNCATED;
+			return false;
+		}
+
 		// read EVIO block header
 		BLOCKHEADER_t bh;
 		ifs.seekg( NB_next_pos, ios_base::beg);


### PR DESCRIPTION
This is needed since some EVIO skim files seem to generated without the proper ending block, and for some reason the current calls to async_filebuf sometimes hang when they get called at the end of the file like this.  

This check seems to get around the problem.  We need to check why the ending block isn't being written out though....