### PR TITLE
Fmwpc hit update

### DIFF
--- a/src/libraries/FMWPC/DFMWPCHit.h
+++ b/src/libraries/FMWPC/DFMWPCHit.h
@@ -19,14 +19,14 @@ class DFMWPCHit:public JObject{
 		int layer;   // 1-8
 		int wire;    // 1-144
 		float q;     // charge deposited
-		float dE;    // energy in GeV
+		float amp;   // peak amplitude
 		float t;     // time in ns
 
 		void toStrings(vector<pair<string, string> >&items) const {
 			AddString(items, "layer", "%d", layer);
 			AddString(items, "wire", "%d", wire);
 			AddString(items, "q",      "%10.2f",  q);
-			AddString(items, "dE(keV)", "%3.1f", dE*1.0E6);
+			AddString(items, "amp",    "%10.2f", amp);
 			AddString(items, "t", "%3.3f", t);
 		}
 

--- a/src/libraries/FMWPC/DFMWPCHit_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.cc
@@ -280,13 +280,12 @@ jerror_t DFMWPCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     // Values for d, itrack, ptype only apply to MC data
     // note that wire counting starts at 1
     hit->q = q;
-    // hit->amp = amp;
+    hit->amp = amp;
     hit->t = t;
     // hit->d = 0.0;
     // hit->QF = digihit->QF;
     // hit->itrack = -1;
     // hit->ptype = 0;
-    hit->dE = 0;
 
     hit->AddAssociatedObject(digihit);
 

--- a/src/libraries/FMWPC/DFMWPCTruthHit.h
+++ b/src/libraries/FMWPC/DFMWPCTruthHit.h
@@ -17,14 +17,15 @@ class DFMWPCTruthHit:public JObject{
 		int layer;   // 1-8
 		int wire;    // 1-144
 		float dE;    // GeV
-		float dx;    // cm
+		float q; // fC
+		float d;    // cm
 		float t;     // ns
 
 		void toStrings(vector<pair<string, string> >&items) const {
 			AddString(items, "layer", "%d", layer);
 			AddString(items, "wire", "%d", wire);
 			AddString(items, "dE(keV)", "%3.1f", dE*1.0E6);
-			AddString(items, "dx", "%3.2f", dx);
+			AddString(items, "d", "%3.2f", d);
 			AddString(items, "t", "%3.3f", t);
 		}
 

--- a/src/libraries/FMWPC/DFMWPCTruthHit.h
+++ b/src/libraries/FMWPC/DFMWPCTruthHit.h
@@ -17,7 +17,7 @@ class DFMWPCTruthHit:public JObject{
 		int layer;   // 1-8
 		int wire;    // 1-144
 		float dE;    // GeV
-		float q; // fC
+		float q; // pC
 		float d;    // cm
 		float t;     // ns
 
@@ -25,6 +25,7 @@ class DFMWPCTruthHit:public JObject{
 			AddString(items, "layer", "%d", layer);
 			AddString(items, "wire", "%d", wire);
 			AddString(items, "dE(keV)", "%3.1f", dE*1.0E6);
+			AddString(items, "q", "%3.2f", q);
 			AddString(items, "d", "%3.2f", d);
 			AddString(items, "t", "%3.3f", t);
 		}

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -2732,8 +2732,9 @@ jerror_t DEventSourceHDDM::Extract_DFMWPCTruthHit(hddm_s::HDDM *record,  JFactor
       DFMWPCTruthHit *hit = new DFMWPCTruthHit;
       hit->layer = iter->getLayer();
       hit->wire  = iter->getWire();
+      hit->q     = iter->getQ();
       hit->dE    = iter->getDE();
-      hit->dx    = iter->getDx();
+      hit->d    = iter->getD();
       hit->t     = iter->getT();
       data.push_back(hit);
    }
@@ -2808,7 +2809,8 @@ jerror_t DEventSourceHDDM::Extract_DFMWPCHit(hddm_s::HDDM *record,  JFactory<DFM
       DFMWPCHit *hit = new DFMWPCHit;
       hit->layer = iter->getLayer();
       hit->wire  = iter->getWire();
-      hit->dE    = iter->getDE();
+      hit->q     = iter->getQ();
+      hit->amp   = iter->getAmp(); 
       hit->t     = iter->getT();
       data.push_back(hit);
    }

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -215,8 +215,8 @@
       </RFtime>
       <forwardMWPC minOccurs="0">
         <fmwpcChamber layer="int" maxOccurs="unbounded" minOccurs="0" wire="int">
-          <fmwpcTruthHit dE="float" dx="float" maxOccurs="unbounded" t="float"/>
-          <fmwpcHit dE="float" maxOccurs="unbounded" t="float"/>
+          <fmwpcTruthHit q="float" dE="float" d="float" maxOccurs="unbounded" t="float"/>
+          <fmwpcHit q="float" amp="float" maxOccurs="unbounded" t="float"/>
         </fmwpcChamber>
         <fmwpcTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
           <trackID minOccurs="0" itrack="int"/>

--- a/src/plugins/Analysis/fcal_charged/JEventProcessor_fcal_charged.cc
+++ b/src/plugins/Analysis/fcal_charged/JEventProcessor_fcal_charged.cc
@@ -188,7 +188,7 @@ jerror_t JEventProcessor_fcal_charged::evnt(JEventLoop *locEventLoop, uint64_t e
     const DFMWPCHit *hit1 = fmwpcHits[k];
     Int_t layer = hit1->layer;
     Int_t wire = hit1->wire;
-    Double_t dEwire = hit1->dE;
+    Double_t q = hit1->q;
     Double_t twire = hit1->t;
     Double_t x = 0;
     Double_t y = 0;
@@ -200,7 +200,7 @@ jerror_t JEventProcessor_fcal_charged::evnt(JEventLoop *locEventLoop, uint64_t e
       // chamber is horizontal -> wire gives y position
       y = wire*1.016 - xmid;
     }
-    cout << "FMWPC Hits Event=" << eventnumber << " k=" << k << " layer=" << layer <<  " wire=" << wire << " dE=" << dEwire << " x=" << x << " y=" << y << " time=" << twire << endl;
+    cout << "FMWPC Hits Event=" << eventnumber << " k=" << k << " layer=" << layer <<  " wire=" << wire << " q=" << q << " x=" << x << " y=" << y << " time=" << twire << endl;
   }
 
 

--- a/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.cc
+++ b/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.cc
@@ -57,8 +57,8 @@ jerror_t JEventProcessor_cppFMWPC::init(void)
     FMWPCwiresT[k] = new TH2D(hnam, htit,  145, 0., 145., 100, 0., 500.);
 
     sprintf(hnam,"FMWPCwiresE%d",k);
-    sprintf(htit,"Chamber %d FMWPC hit dE vs. wire number",k);
-    FMWPCwiresE[k] = new TH2D(hnam, htit,  145, 0., 145., 500, 0., 100.);
+    sprintf(htit,"Chamber %d FMWPC hit q vs. wire number",k);
+    FMWPCwiresQ[k] = new TH2D(hnam, htit,  145, 0., 145., 500, 0., 100.);
   }
 
 
@@ -122,7 +122,7 @@ jerror_t JEventProcessor_cppFMWPC::evnt(JEventLoop *loop, uint64_t eventnumber)
     const DFMWPCHit *hit1 = fmwpcHits[k];
     //std::cout<<hit->layer<<" / "<<hit->wire<<" / "<<hit->t<<std::endl;
     FMWPCwiresT[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->t);
-    FMWPCwiresE[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->dE);
+    FMWPCwiresQ[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->q);
   }
 
 

--- a/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.h
+++ b/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.h
@@ -25,7 +25,7 @@ class JEventProcessor_cppFMWPC:public jana::JEventProcessor{
 
   int nFMWPCchambers;
   TH2D *FMWPCwiresT[8];
-  TH2D *FMWPCwiresE[8];
+  TH2D *FMWPCwiresQ[8];
   
   TH2D *FDCwiresT[24];
 

--- a/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.cc
+++ b/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.cc
@@ -60,8 +60,8 @@ jerror_t JEventProcessor_cppFMWPC_ana::init(void)
     FMWPCwiresT[k] = new TH2D(hnam, htit,  145, 0., 145., 100, 0., 500.);
 
     sprintf(hnam,"FMWPCwiresE%d",k+1);
-    sprintf(htit,"Chamber %d FMWPC hit dE vs. wire number",k+1);
-    FMWPCwiresE[k] = new TH2D(hnam, htit,  145, 0., 145., 500, 0., 100.);
+    sprintf(htit,"Chamber %d FMWPC hit q vs. wire number",k+1);
+    FMWPCwiresQ[k] = new TH2D(hnam, htit,  145, 0., 145., 500, 0., 100.);
 
     sprintf(hnam,"h2_pmuon_vs_mult%d",k+1);
     sprintf(htit,"Plane %d;Multipliticity;Pmuon",k+1);
@@ -161,7 +161,7 @@ jerror_t JEventProcessor_cppFMWPC_ana::evnt(JEventLoop *loop, uint64_t eventnumb
     const DFMWPCHit *hit1 = fmwpcHits[k];
     //std::cout<<hit->layer<<" / "<<hit->wire<<" / "<<hit->t<<std::endl;
     FMWPCwiresT[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->t);
-    FMWPCwiresE[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->dE);
+    FMWPCwiresQ[hit1->layer-1]->Fill((double)hit1->wire, (double)hit1->q);
 
     mwpc_mult[hit1->layer-1] += 1;
     // cout << " k=" << k << " hit1->layer-1=" << hit1->layer-1 << " mwpc_mult[k]=" << mwpc_mult[hit1->layer-1] << endl;

--- a/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.cc
+++ b/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.cc
@@ -59,7 +59,7 @@ jerror_t JEventProcessor_cppFMWPC_ana::init(void)
     sprintf(htit,"Chamber %d FMWPC hit time vs. wire number",k+1);
     FMWPCwiresT[k] = new TH2D(hnam, htit,  145, 0., 145., 100, 0., 500.);
 
-    sprintf(hnam,"FMWPCwiresE%d",k+1);
+    sprintf(hnam,"FMWPCwiresQ%d",k+1);
     sprintf(htit,"Chamber %d FMWPC hit q vs. wire number",k+1);
     FMWPCwiresQ[k] = new TH2D(hnam, htit,  145, 0., 145., 500, 0., 100.);
 

--- a/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.h
+++ b/src/plugins/monitoring/cppFMWPC_ana/JEventProcessor_cppFMWPC_ana.h
@@ -25,7 +25,7 @@ class JEventProcessor_cppFMWPC_ana:public jana::JEventProcessor{
 
   int nFMWPCchambers;
   TH2D *FMWPCwiresT[8];
-  TH2D *FMWPCwiresE[8];
+  TH2D *FMWPCwiresQ[8];
 
   TH2D *h2_pmuon_vs_mult[8];
   


### PR DESCRIPTION
Update FMWPC hit classes to remove dE in favor of q.  Also add amplitude to DFMWPCHit and d (doca to wire) to DFMWPCTruthHit.