### PR TITLE
Small mods to BCAL calib plugin

### DIFF
--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -137,7 +137,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
                     sprintf(histname,"logpeakratiovsZ_%02i%i%i",module+1,layer+1,sector+1);
                     sprintf(modtitle,"Channel (M%i,L%i,S%i)",module+1,layer+1,sector+1);
                     sprintf(histtitle,"%s;Z Position (cm);log of pulse height ratio US/DS",modtitle);
-                    logpeakratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,125,-5,5);
+                    logpeakratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,100,-5,5);
                 }
             }
         }
@@ -149,7 +149,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
 				sprintf(histname,"logintratiovsZ_%02i%i%i",module+1,layer+1,sector+1);
 				sprintf(modtitle,"Channel (M%i,L%i,S%i)",module+1,layer+1,sector+1);
 				sprintf(histtitle,"%s;Z Position (cm);log of integral ratio US/DS",modtitle);
-				logintratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,125,-5,5);
+				logintratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,100,-5,5);
 			}
 		}
 	}

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -137,7 +137,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
                     sprintf(histname,"logpeakratiovsZ_%02i%i%i",module+1,layer+1,sector+1);
                     sprintf(modtitle,"Channel (M%i,L%i,S%i)",module+1,layer+1,sector+1);
                     sprintf(histtitle,"%s;Z Position (cm);log of pulse height ratio US/DS",modtitle);
-                    logpeakratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,220,-220.0,220.0,400,-4,4);
+                    logpeakratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,125,-5,5);
                 }
             }
         }
@@ -149,7 +149,7 @@ jerror_t JEventProcessor_BCAL_attenlength_gainratio::init(void)
 				sprintf(histname,"logintratiovsZ_%02i%i%i",module+1,layer+1,sector+1);
 				sprintf(modtitle,"Channel (M%i,L%i,S%i)",module+1,layer+1,sector+1);
 				sprintf(histtitle,"%s;Z Position (cm);log of integral ratio US/DS",modtitle);
-				logintratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,220,-220.0,220.0,400,-4,4);
+				logintratiovsZ[module][layer][sector] = new TH2I(histname,histtitle,110,-220.0,220.0,125,-5,5);
 			}
 		}
 	}


### PR DESCRIPTION
Raw gain ratio plots: 
     increase y-axis range by 20% to include some big outliers for recently failed SiPMs; 
     decrease total number of bins on most histograms by factor 8 to save resources.
