### PR TITLE
Increase default maximum number of evio events processed by hdskims

### DIFF
--- a/src/programs/Utilities/hdskims/hdskims.cc
+++ b/src/programs/Utilities/hdskims/hdskims.cc
@@ -51,7 +51,7 @@ void GetTrigMasks(uint32_t *buff, uint32_t buff_len, uint32_t Mevents, vector <u
 
 vector <string> filenames;
 string   USER_OFILENAME = "";
-uint64_t MAX_EVIO_EVENTS = 50000;
+uint64_t MAX_EVIO_EVENTS = 1000000;
 uint64_t SKIP_EVIO_EVENTS = 0;
 uint64_t Nevents = 0;
 uint64_t Nevents_saved = 0;


### PR DESCRIPTION
The old default was tuned to GlueX production running which caused it to quit early for cosmic runs or anything with a smaller event size. This was only noticed by HOSS having inconsistent numbers for the last event from a file and the first event from the next file for some long cosmic runs.