### PR TITLE
Fixes to TOF veto in DNeutralShower_factory.cc

### DIFF
--- a/src/libraries/PID/DNeutralShower_factory.cc
+++ b/src/libraries/PID/DNeutralShower_factory.cc
@@ -289,10 +289,10 @@ int DNeutralShower_factory::check_TOF_match(DVector3 fcalpos, double rfTime, DVe
     double dx = fcalpos.X() - xt;
     double dy = fcalpos.Y() - yt;
     if (fabs(dt) < TOF_RF_CUT) {
-      if (fabs(dx) < dx_min)
+      if (dx*dx + dy*dy < dx_min*dx_min + dy_min*dy_min) {
 	dx_min = fabs(dx);
-      if (fabs(dy) < dy_min)
 	dy_min = fabs(dy);
+      }
       global_tof_match ++;
     }
   }


### PR DESCRIPTION
Fixed TOF veto in Neutral Shower factory to take the nearest single shower for both dx and dy, rather than separate components.

Previously would take smallest delta_x and delta_y separately, not necessarily from the same hit.