### PR TITLE
Elton beamphoton

### DIFF
--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -72,12 +72,11 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t locE
     vector<const DTAGMHit*> tagm_hits;
     locEventLoop->Get(tagm_hits);
 
-    DBeamPhoton* gamma = nullptr;;
     for (unsigned int ih=0; ih < tagm_hits.size(); ++ih)
     {
         if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
         if (tagm_hits[ih]->row > 0) continue; // Skip individual fiber readouts
-        gamma = Get_Resource();
+        DBeamPhoton* gamma = Get_Resource();
 
         Set_BeamPhoton(gamma, tagm_hits[ih], locEventNumber);
         _data.push_back(gamma);
@@ -90,25 +89,10 @@ jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t locE
     {
         if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
         if (!tagh_hits[ih]->has_TDC) continue;  // Skip fADC-only hits (i.e. hits with no TDC info.)
+        DBeamPhoton* gamma = Get_Resource();
 
-
-        /*DBeamPhoton *gamma = nullptr;
-        for (unsigned int jh=0; jh < _data.size(); ++jh)
-        {
-            if (fabs(_data[jh]->momentum().Mag() - tagh_hits[ih]->E) < DELTA_E_DOUBLES_MAX
-            && fabs(_data[jh]->time() - tagh_hits[ih]->t) < DELTA_T_DOUBLES_MAX)
-            {
-                gamma = _data[jh];
-                if (_data[jh]->momentum().Mag() < tagh_hits[ih]->E)
-                {
-                    gamma->Reset();
-                    Set_BeamPhoton(gamma, tagh_hits[ih], locEventNumber);
-                }
-            }
-	    }*/
-        if (gamma == nullptr) gamma = Get_Resource();
-            Set_BeamPhoton(gamma, tagh_hits[ih], locEventNumber);
-            _data.push_back(gamma);
+	Set_BeamPhoton(gamma, tagh_hits[ih], locEventNumber);
+        _data.push_back(gamma);
 	   
     }
 


### PR DESCRIPTION
I have modified the DBeamPhoton factory to create one DBeamPhoton for each microscope and each hodoscope hit. A dump of the output of some BH events (just signal, no accidentals) shows that the code has the intended result.
<img width="982" alt="DBeamPhoton_double" src="https://user-images.githubusercontent.com/13572800/165340469-6456e158-29ee-4820-83e6-e756f4316e10.png">
<img width="981" alt="DBeamPhoton_single" src="https://user-images.githubusercontent.com/13572800/165340517-e92e35ec-4bf0-4a4c-adee-3972ad9f505a.png">
The output file has 1000 events. I have plotted the times that the microscope only fires (mult=0), the number of times the hodoscope only fires (mult=1) and if both fire, we plot the sum (microscope+hodoscope hits). We find that about 600 events the microscope only fires; the hodoscope never fires by itself, and about 400 times we see that we have a hit in both the microscope and the hodoscope. This is what I expect for 100% microscope efficiency, although we know this is to the case in the actual detector. Do we ignore the microscope efficiency since we are only interested in "tagged" events?