### PR TITLE
hdview2 Skip events and CTOF

### DIFF
--- a/src/programs/Analysis/hdview2/MyProcessor.cc
+++ b/src/programs/Analysis/hdview2/MyProcessor.cc
@@ -204,18 +204,28 @@ jerror_t MyProcessor::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
 	// whether to draw the event.
 	if( ! REQUIRED_CLASSES_FOR_DRAWING.empty() ){
 		if( Nevents_since_last_draw==0 ) {
-			cout << "Seeking event with object of at least one of: ";
+			string login_str = (REQUIRED_CLASSES_LOGIC == REQUIRED_CLASSES_LOGIC_AND) ? "all":"at least one";
+			cout << "Seeking event with " << login_str << " of: ";
 			for( auto s : REQUIRED_CLASSES_FOR_DRAWING ) cout << s << " ";
 			cout << endl;
 		}
 	}
-	bool draw_event = REQUIRED_CLASSES_FOR_DRAWING.empty();
+
+	uint32_t num_required_classes_present = 0;
 	for( auto c : REQUIRED_CLASSES_FOR_DRAWING ){
 		auto fac = loop->GetFactory( c );
-		if( fac->GetNrows() != 0 ){
-			draw_event = true;
-			break;
+		if( !fac ){
+			jerr << "No factory found for type: " << c << " !" << endl;
+			jerr << "Double check that there is not a typo in the name and run again." << endl;
+			exit(-1);
 		}
+		if( fac->GetNrows() != 0 ){
+			num_required_classes_present++;
+		}
+	}
+	bool draw_event = num_required_classes_present > 0; // Default to OR logic
+	if(REQUIRED_CLASSES_LOGIC == REQUIRED_CLASSES_LOGIC_AND){ // Overwrite draw_ewvent if using AND logic
+		draw_event = (num_required_classes_present>=REQUIRED_CLASSES_FOR_DRAWING.size());
 	}
 	
 	if( draw_event ){

--- a/src/programs/Analysis/hdview2/MyProcessor.cc
+++ b/src/programs/Analysis/hdview2/MyProcessor.cc
@@ -227,6 +227,7 @@ jerror_t MyProcessor::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
 	if(REQUIRED_CLASSES_LOGIC == REQUIRED_CLASSES_LOGIC_AND){ // Overwrite draw_ewvent if using AND logic
 		draw_event = (num_required_classes_present>=REQUIRED_CLASSES_FOR_DRAWING.size());
 	}
+	if( REQUIRED_CLASSES_FOR_DRAWING.empty() ) draw_event = true; // If nothing specified, then draw every event
 	
 	if( draw_event ){
 	

--- a/src/programs/Analysis/hdview2/MyProcessor.cc
+++ b/src/programs/Analysis/hdview2/MyProcessor.cc
@@ -63,6 +63,7 @@ using namespace std;
 #include "TRIGGER/DL1Trigger.h"
 
 extern hdv_mainframe *hdvmf;
+extern int GO; // defined in hdview2.cc
 
 // These are declared in hdv_mainframe.cc, but as static so we need to do it here as well (yechh!)
 static float FCAL_Zmin = 622.8;
@@ -194,28 +195,84 @@ jerror_t MyProcessor::evnt(JEventLoop *eventLoop, uint64_t eventnumber)
 	loop = eventLoop;
 	last_jevent.FreeEvent();
 	last_jevent = loop->GetJEvent();
+	static uint64_t Nevents_since_last_draw = 0;
+	static bool save_continuous = (GO == 1);
+	static long save_sleep_time = hdvmf->GetSleepTime();
 	
-	// get the trigger bits
-	char trigstring[10];
-	const DL1Trigger *trig = NULL;
-	try {
-		loop->GetSingle(trig);
-	} catch (...) {}
-	if (trig) {
-		sprintf(trigstring,"0x%04x",trig->trig_mask); 
-	} else {
-		sprintf(trigstring,"no bits");
+	// The user may specify to only draw events that have at least
+	// one object of list of classes. Check for this so we know
+	// whether to draw the event.
+	if( ! REQUIRED_CLASSES_FOR_DRAWING.empty() ){
+		if( Nevents_since_last_draw==0 ) {
+			cout << "Seeking event with object of at least one of: ";
+			for( auto s : REQUIRED_CLASSES_FOR_DRAWING ) cout << s << " ";
+			cout << endl;
+		}
 	}
-	hdvmf->SetTrig(trigstring);
-
-	string source = "<no source>";
-	if(last_jevent.GetJEventSource())source = last_jevent.GetJEventSource()->GetSourceName();
+	bool draw_event = REQUIRED_CLASSES_FOR_DRAWING.empty();
+	for( auto c : REQUIRED_CLASSES_FOR_DRAWING ){
+		auto fac = loop->GetFactory( c );
+		if( fac->GetNrows() != 0 ){
+			draw_event = true;
+			break;
+		}
+	}
 	
-	cout<<"----------- New Event "<<eventnumber<<"  (run " << last_jevent.GetRunNumber()<<") -------------"<<endl;
-	hdvmf->SetEvent(eventnumber);
-	hdvmf->SetRun(last_jevent.GetRunNumber());
-	hdvmf->SetSource(source.c_str());
-	hdvmf->DoMyRedraw();	
+	if( draw_event ){
+	
+		// Restore control values set if we skipped drawing the previous event
+		if( Nevents_since_last_draw > 0 ){
+			cout << endl;
+			Nevents_since_last_draw = 0;
+			hdvmf->SetCheckButton("continuous", save_continuous);
+			hdvmf->SetSleepTime(save_sleep_time);
+			
+			// At this point, the "clicked()" signal may have been sent to 
+			// the other auxillary windows (e.g. trk_mainframe), but enough 
+			// of a delay occurred that they will have already redrawn and 
+			// need to be redrawn again for this current event. The main
+			// window should be OK, since DoMyRedraw is getting called below.
+			hdvmf->RedrawAuxillaryWindows();
+		}
+	
+		// get the trigger bits
+		char trigstring[10];
+		const DL1Trigger *trig = NULL;
+		try {
+			loop->GetSingle(trig);
+		} catch (...) {}
+		if (trig) {
+			sprintf(trigstring,"0x%04x",trig->trig_mask); 
+		} else {
+			sprintf(trigstring,"no bits");
+		}
+		hdvmf->SetTrig(trigstring);
+
+		string source = "<no source>";
+		if(last_jevent.GetJEventSource())source = last_jevent.GetJEventSource()->GetSourceName();
+
+		cout<<"----------- New Event "<<eventnumber<<"  (run " << last_jevent.GetRunNumber()<<") -------------"<<endl;
+		hdvmf->SetEvent(eventnumber);
+		hdvmf->SetRun(last_jevent.GetRunNumber());
+		hdvmf->SetSource(source.c_str());
+		hdvmf->DoMyRedraw();	
+	}else{
+	
+		// If this is the first event in a sequence we are skipping the draw
+		// then set the "continuous" checkbox on so the outer loop will continue
+		// to call us. Save the state of the checkbox so we can restore it once an
+		// event we do draw is encountered.
+		if( Nevents_since_last_draw == 0 ){
+			save_continuous = hdvmf->GetCheckButton("continuous");
+			if( ! save_continuous ) hdvmf->SetCheckButton("continuous", true);
+			save_sleep_time = hdvmf->GetSleepTime();
+			hdvmf->SetSleepTime(0);
+		}
+
+		Nevents_since_last_draw++;
+		cout << "Skipping events without specified objects " << Nevents_since_last_draw << "  \r";
+		if( Nevents_since_last_draw%1 == 0 ) cout.flush();
+	}
 
 	japp->SetSequentialEventComplete();
 	

--- a/src/programs/Analysis/hdview2/MyProcessor.h
+++ b/src/programs/Analysis/hdview2/MyProcessor.h
@@ -23,6 +23,7 @@
 #include <DCoordinateSystem.h>
 #include <TRACKING/DReferenceTrajectory.h>
 #include "DReferenceTrajectoryHDV.h"
+#include <FMWPC/DFMWPCDigiHit.h>
 #include <FMWPC/DFMWPCHit.h>
 #include <FMWPC/DFMWPCCluster.h>
 #include <FMWPC/DFMWPCMatchedTrack.h>

--- a/src/programs/Analysis/hdview2/fmwpc_mainframe.cc
+++ b/src/programs/Analysis/hdview2/fmwpc_mainframe.cc
@@ -804,6 +804,26 @@ void fmwpc_mainframe::DrawDetectors(TCanvas *c, vector<TObject*> &graphics, std:
         }
     }
 
+    // Draw CTOFPoints
+    if( checkbuttons["Draw CTOFPoints"]->GetState() == kButtonDown) {
+        for (auto point: ctofpoints) {
+
+
+            double s = (view == "top") ? point->pos.X():point->pos.Y();
+            double z = point->pos.Z();
+            
+            // Some empirical color scaling
+				// Top PMT will be a shade of blue while bottom will be shade of red
+            Float_t amp = 0.4 + (double)point->dE/0.002;
+            if( amp<0.4) amp = 0.4;
+            if( amp>1.0) amp = 1.0;
+            auto color = TColor::GetColor((Float_t) 1.0, 1.0-amp, 1.0); // Default to magenta-ish
+				auto m = new TMarker( z, s, 22 );
+				m->SetMarkerColor( color );
+            graphics.push_back(m);
+        }
+    }
+
     // Draw Tracks
     if( checkbuttons["Draw Tracks"]->GetState() == kButtonDown) {
         for (auto tbt: tbts) {

--- a/src/programs/Analysis/hdview2/fmwpc_mainframe.cc
+++ b/src/programs/Analysis/hdview2/fmwpc_mainframe.cc
@@ -20,6 +20,10 @@ using namespace std;
 #include <FCAL/DFCALHit.h>
 #include <TRACKING/DTrackFitterKalmanSIMD.h>
 #include <TRACKING/DTrackTimeBased.h>
+#include <FMWPC/DCTOFDigiHit.h>
+#include <FMWPC/DCTOFTDCDigiHit.h>
+#include <FMWPC/DCTOFHit.h>
+#include <FMWPC/DCTOFPoint.h>
 
 #include <TGButtonGroup.h>
 #include <TGTextEntry.h>
@@ -44,6 +48,10 @@ extern float FMWPC_Zlen;
 extern float FMWPC_Dead_diameter;
 extern float FMWPC_WIRE_SPACING;
 extern vector<double> FMWPC_Zpos;
+extern float CTOF_width;  // 20
+extern float CTOF_length; // 120
+extern float CTOF_depth;  // 1.27
+extern vector<DVector3> CTOF_pos;  // from DGeometry::GetCTOFPositions()
 
 
 // We declare this as a global since putting it in the class would
@@ -155,11 +163,17 @@ fmwpc_mainframe::fmwpc_mainframe(hdv_mainframe *hdvmf, const TGWindow *p, UInt_t
         TGGroupFrame *drawenableframe = new TGGroupFrame(topframe, "Draw Options", kVerticalFrame);
         topframe->AddFrame(drawenableframe, lhints);
         checkbuttons["Draw FMWPC"         ] = new TGCheckButton(drawenableframe, "Draw FMWPC");
+        checkbuttons["Draw CTOF"          ] = new TGCheckButton(drawenableframe, "Draw CTOF");
         checkbuttons["Draw Tracks"        ] = new TGCheckButton(drawenableframe, "Draw Tracks");
         checkbuttons["Draw Track Hit Projections"] = new TGCheckButton(drawenableframe, "Draw Track Hit Projections");
         checkbuttons["Draw FMWPCHits"     ] = new TGCheckButton(drawenableframe, "Draw DFMWPCHits");
+        checkbuttons["Draw FMWPCDigiHits" ] = new TGCheckButton(drawenableframe, "Draw DFMWPCDigiHits");
         checkbuttons["Draw FMWPCClusters" ] = new TGCheckButton(drawenableframe, "Draw DFMWPCClusters");
         checkbuttons["Draw FCALHits"      ] = new TGCheckButton(drawenableframe, "Draw DFCALHits");
+        checkbuttons["Draw CTOFDigiHits"  ] = new TGCheckButton(drawenableframe, "Draw CTOFDigiHits");
+        checkbuttons["Draw CTOFTDCDigiHits"] = new TGCheckButton(drawenableframe, "Draw CTOFTDCDigiHits");
+        checkbuttons["Draw CTOFHits"      ] = new TGCheckButton(drawenableframe, "Draw CTOFHits");
+        checkbuttons["Draw CTOFPoints"    ] = new TGCheckButton(drawenableframe, "Draw CTOFPoints");
         checkbuttons["Draw Vertex Momentum Values"] = new TGCheckButton(drawenableframe, "Draw Vertex Momentum Values");
         checkbuttons["Draw Projection Momentum Values"] = new TGCheckButton(drawenableframe, "Draw Projection Momentum Values");
         for( auto cb : checkbuttons ){
@@ -190,7 +204,7 @@ fmwpc_mainframe::fmwpc_mainframe(hdv_mainframe *hdvmf, const TGWindow *p, UInt_t
 		slo = -95.0;
 		shi =  95.0;
 		zlo = 575.0;
-		zhi = 970.0;
+		zhi = 985.0;
         topcanvas->GetCanvas()->cd();
         topcanvas->GetCanvas()->Range(zlo, slo, zhi, shi);
         sidecanvas->GetCanvas()->cd();
@@ -445,32 +459,73 @@ void fmwpc_mainframe::DrawDetectors(TCanvas *c, vector<TObject*> &graphics, std:
         }
 
         // Draw Absorbers
-        for (uint32_t i = 0; i < FMWPC_Zpos.size() - 2; i++) {
-            Float_t z_upstream = FMWPC_Zpos[i];   // center of upstream chamber
-            Float_t z_dnstream = FMWPC_Zpos[i + 1]; // center of downstream chamber
-            Float_t zmin = z_upstream + FMWPC_Zlen / 2.0 + 1.0;
-            Float_t zmax = z_dnstream - FMWPC_Zlen / 2.0 - 1.0;
-            Float_t smin = -FMWPC_width / 2.0 - 2.0;
-            Float_t smax = +FMWPC_width / 2.0 + 2.0;
+		  if( FMWPC_Zpos.size() < 2 ){
+			jout << "FMWPC_Zpos.size()=" << FMWPC_Zpos.size() <<" which is <2. Unable to draw FMWPC." << std::endl;
+			jout << "Please make sure the CPP geometry is being used. e,g." << std::endl;
+			jout << "  setenv JANA_CALIB_CONTEXT \"variation=mc_cpp\"" << std::endl;
+		  }else{
+      	  for (uint32_t i = 0; i < FMWPC_Zpos.size() - 2; i++) {
+            	Float_t z_upstream = FMWPC_Zpos[i];   // center of upstream chamber
+            	Float_t z_dnstream = FMWPC_Zpos[i + 1]; // center of downstream chamber
+            	Float_t zmin = z_upstream + FMWPC_Zlen / 2.0 + 1.0;
+            	Float_t zmax = z_dnstream - FMWPC_Zlen / 2.0 - 1.0;
+            	Float_t smin = -FMWPC_width / 2.0 - 2.0;
+            	Float_t smax = +FMWPC_width / 2.0 + 2.0;
+            	auto box = new TBox(zmin, smin, zmax, smax);
+            	box->SetFillStyle(3001);
+            	box->SetFillColor(42);
+            	graphics.push_back(box);
+      	  }
+		  }
+    }
+
+    // Draw CTOF
+    if( checkbuttons["Draw CTOF"]->GetState() == kButtonDown) {
+        for (auto pos: CTOF_pos) {
+        
+            Float_t zmin = pos.Z() - CTOF_depth/2.0;
+            Float_t zmax = zmin + CTOF_depth;
+            Float_t smin;
+            Float_t smax;
+            if( view=="top" ){
+                smin = pos.X() - CTOF_width/2.0;
+                smax = smin + CTOF_width;
+            }else{
+                smin = pos.Y() - CTOF_length/2.0;
+                smax = smin + CTOF_length;
+            }
             auto box = new TBox(zmin, smin, zmax, smax);
+            box->SetLineWidth(1);
+            box->SetLineColor(kBlack);
             box->SetFillStyle(3001);
-            box->SetFillColor(42);
+            box->SetFillColor(TColor::GetColor((Float_t) 0.9, 0.9, 0.9));
             graphics.push_back(box);
+            graphics_draw_options[box] = "L"; // Draw outline AND fill style
         }
     }
 
     // Get all JANA objects
     vector<const DTrackTimeBased*> tbts;
     vector<const DFCALHit*> fcalhits;
+    vector<const DFMWPCDigiHit*> fmwpcdigihits;
     vector<const DFMWPCHit*> fmwpchits;
     vector<const DFMWPCCluster*> fmwpcclusters;
     vector<const DFMWPCMatchedTrack*> fmwpcmatchedtracks;
+    vector<const DCTOFDigiHit*> ctofdigihits;
+    vector<const DCTOFTDCDigiHit*> ctoftdcdigihits;
+    vector<const DCTOFHit*> ctofhits;
+    vector<const DCTOFPoint*> ctofpoints;
     if( eventloop != NULL ) {
         eventloop->Get(tbts);
         eventloop->Get(fcalhits);
+        eventloop->Get(fmwpcdigihits);
         eventloop->Get(fmwpchits);
         eventloop->Get(fmwpcclusters);
         eventloop->Get(fmwpcmatchedtracks);
+        eventloop->Get(ctofdigihits);
+        eventloop->Get(ctoftdcdigihits);
+        eventloop->Get(ctofhits);
+        eventloop->Get(ctofpoints);
     }
 
     // Draw FCALHits
@@ -547,6 +602,23 @@ void fmwpc_mainframe::DrawDetectors(TCanvas *c, vector<TObject*> &graphics, std:
         }
     }
 
+    // Draw FMWPCDigiHits
+    if( checkbuttons["Draw FMWPCDigiHits"]->GetState() == kButtonDown) {
+        for (auto hit: fmwpcdigihits) {
+
+            // layers 1,3,5=vertical   layers 2,4,6=horizontal
+            if ((view == "top" ) && ((hit->layer % 2) == 0)) continue; // skip horizontal wires if drawing vertical wires
+            if ((view == "side") && ((hit->layer % 2) == 1)) continue; // skip vertical wires if drawing horizontal wires
+
+            double s = (hit->wire * FMWPC_WIRE_SPACING) - 71.5;
+            double z = (uint32_t)(hit->layer) <= FMWPC_Zpos.size() ? FMWPC_Zpos[hit->layer - 1] : 0.0;
+            auto m = new TMarker(z, s, 22);
+            m->SetMarkerColor(kRed+4);
+            m->SetMarkerSize(1.0);
+            graphics.push_back(m);
+        }
+    }
+
     // Draw FMWPCHits
     if( checkbuttons["Draw FMWPCHits"]->GetState() == kButtonDown) {
         for (auto hit: fmwpchits) {
@@ -560,6 +632,174 @@ void fmwpc_mainframe::DrawDetectors(TCanvas *c, vector<TObject*> &graphics, std:
             auto m = new TMarker(z, s, 8);
             m->SetMarkerColor(kRed);
             m->SetMarkerSize(1.0);
+            graphics.push_back(m);
+        }
+    }
+
+    // Draw CTOFDigiHits
+    if( checkbuttons["Draw CTOFDigiHits"]->GetState() == kButtonDown) {
+        for (auto hit: ctofdigihits) {
+
+            if( (hit->bar<1) || (hit->bar>(int)CTOF_pos.size()) ){
+                _DBG_<<"CTOF bar out of range (" << hit->bar << " not in range 1-" << CTOF_pos.size() << ")" << endl;
+                continue;
+            }
+
+            auto pos = CTOF_pos[ hit->bar -1 ];
+            double s = (view == "top") ? pos.X():pos.Y();
+            double z = pos.Z();
+            
+            // For top view, draw circle, bot side view draw box
+            TObject *m = nullptr;
+            auto pedestal = (double)hit->pedestal*(double)hit->nsamples_integral/(double)hit->nsamples_pedestal;
+            
+            // Some empirical color scaling based on cosmic run 100288
+				// Top PMT will be a shade of blue while bottom will be shade of red
+            Float_t amp = 0.2 + ((double)hit->pulse_integral - pedestal)/2500.0;
+            if( amp<0.2) amp = 0.2;
+            if( amp>1.0) amp = 1.0;
+            auto color = TColor::GetColor((Float_t) 1.0, 1.0-amp, 1.0-amp); // Default to red-ish for top PMT
+				if(hit->end==1) color = TColor::GetColor((Float_t) 1.0-amp, 1.0-amp, 1.0); // blue-ish for bottom PMT
+
+            if( view == "top" ){
+                // For top view, shift the marker upstream/downstream for the top/bottom PMT so both can be seen
+                if( hit->end == 0 ){
+                    // top end
+                    z -= 3.0/2.0 + CTOF_depth;
+                }else{
+                    // bottom end
+                    z += 3.0/2.0 + CTOF_depth;
+                }
+                auto obj = new TEllipse( z, s, 3.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }else{
+                // for side view, shift marker to top or bottom PMT position
+                if( hit->end == 0 ){
+                    // top end
+                    s += CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }else{
+                    // bottom end
+                    s -= CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }
+                auto obj = new TBox( z-3.0, s-10.0, z+3.0, s+10.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }
+            
+            if( m == nullptr ) continue;
+            graphics.push_back(m);
+        }
+    }
+
+    // Draw CTOFTDCDigiHits
+    if( checkbuttons["Draw CTOFTDCDigiHits"]->GetState() == kButtonDown) {
+        for (auto hit: ctoftdcdigihits) {
+
+            if( (hit->bar<1) || (hit->bar>(int)CTOF_pos.size()) ){
+                _DBG_<<"CTOF bar out of range (" << hit->bar << " not in range 1-" << CTOF_pos.size() << ")" << endl;
+                continue;
+            }
+
+            auto pos = CTOF_pos[ hit->bar -1 ];
+            double s = (view == "top") ? pos.X():pos.Y();
+            double z = pos.Z();
+            
+            // For top view, draw circle, bot side view draw box
+            TObject *m = nullptr;
+            
+            // Color top PMT green and bottom yellow
+            auto color = TColor::GetColor((Float_t) 0.0, 1.0, 0.0); // Default to green for top PMT
+				if(hit->end==1) color = TColor::GetColor((Float_t) 1.0, 1.0, 0.2); // yellow for bottom PMT
+
+            if( view == "top" ){
+                // For top view, shift the marker upstream/downstream for the top/bottom PMT so both can be seen
+                if( hit->end == 0 ){
+                    // top end
+                    z -= 2.5/2.0 + CTOF_depth;
+                }else{
+                    // bottom end
+                    z += 2.5/2.0 + CTOF_depth;
+                }
+                auto obj = new TEllipse( z, s, 2.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }else{
+                // for side view, shift marker to top or bottom PMT position
+                if( hit->end == 0 ){
+                    // top end
+                    s += CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }else{
+                    // bottom end
+                    s -= CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }
+                auto obj = new TBox( z-1.5, s-8.0, z+1.5, s+8.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }
+            
+            if( m == nullptr ) continue;
+            graphics.push_back(m);
+        }
+    }
+
+    // Draw CTOFHits
+    if( checkbuttons["Draw CTOFHits"]->GetState() == kButtonDown) {
+        for (auto hit: ctofhits) {
+
+            if( (hit->bar<1) || (hit->bar>(int)CTOF_pos.size()) ){
+                _DBG_<<"CTOF bar out of range (" << hit->bar << " not in range 1-" << CTOF_pos.size() << ")" << endl;
+                continue;
+            }
+
+            auto pos = CTOF_pos[ hit->bar -1 ];
+            double s = (view == "top") ? pos.X():pos.Y();
+            double z = pos.Z();
+            
+            // For top view, draw circle, bot side view draw box
+            TObject *m = nullptr;
+            
+            // Some empirical color scaling
+				// Top PMT will be a shade of blue while bottom will be shade of red
+            Float_t amp = 0.2 + (double)hit->dE/0.100;
+            if( amp<0.2) amp = 0.2;
+            if( amp>1.0) amp = 1.0;
+            auto color = TColor::GetColor((Float_t) 1.0, 1.0-amp, 1.0-amp); // Default to red-ish for top PMT
+				if(hit->end==1) color = TColor::GetColor((Float_t) 1.0-amp, 1.0-amp, 1.0); // blue-ish for bottom PMT
+
+            if( view == "top" ){
+                // For top view, shift the marker upstream/downstream for the top/bottom PMT so both can be seen
+                if( hit->end == 0 ){
+                    // top end
+                    z -= 2.5/2.0 + CTOF_depth;
+                }else{
+                    // bottom end
+                    z += 2.5/2.0 + CTOF_depth;
+                }
+                auto obj = new TEllipse( z, s, 1.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }else{
+                // for side view, shift marker to top or bottom PMT position
+                if( hit->end == 0 ){
+                    // top end
+                    s += CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }else{
+                    // bottom end
+                    s -= CTOF_length/2.0 + 10.0; // 10.0 so tube can be drawn as 20cm long
+                }
+                auto obj = new TBox( z-1.0, s-6.0, z+1.0, s+6.0);
+                obj->SetFillStyle(1001);
+                obj->SetFillColor( color );
+                m = obj;
+            }
+            
+            if( m == nullptr ) continue;
             graphics.push_back(m);
         }
     }

--- a/src/programs/Analysis/hdview2/hdv_mainframe.cc
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.cc
@@ -86,6 +86,10 @@ float FMWPC_Zlen = 5.26;
 float FMWPC_Dead_diameter = 8.0;
 float FMWPC_WIRE_SPACING = 1.016;
 vector<double> FMWPC_Zpos;
+float CTOF_width  =  20.0;  // from CppScint_HDDS.xml
+float CTOF_length = 120.0;  // from CppScint_HDDS.xml
+float CTOF_depth  =  1.27;  // from CppScint_HDDS.xml
+vector<DVector3> CTOF_pos;  // from DGeometry::GetCTOFPositions()
 
 static DFCALGeometry *fcalgeom = NULL;
 static DTOFGeometry *tofgeom = NULL;
@@ -124,6 +128,9 @@ hdv_mainframe::hdv_mainframe(const TGWindow *p, UInt_t w, UInt_t h):TGMainFrame(
   dgeom->GetFMWPCZ_vec(FMWPC_Zpos);
   dgeom->GetFMWPCSize(my_FMWPC_width);
   FMWPC_width = my_FMWPC_width*2.0; // We want full width and method returns half-width
+  
+  // CPP CTOF positions
+  dgeom->GetCTOFPositions(CTOF_pos);
 
   UInt_t MainWidth = w;
   
@@ -2516,6 +2523,17 @@ bool hdv_mainframe::GetCheckButton(string who)
 	if(iter==checkbuttons.end())return false;
 	return iter->second->GetState()==kButtonDown;
 }
+
+//-------------------
+// SetCheckButton
+//-------------------
+void hdv_mainframe::SetCheckButton(string who, bool set_checked)
+{
+	map<string, TGCheckButton*>::iterator iter = checkbuttons.find(who);
+	if(iter==checkbuttons.end())return;
+	iter->second->SetState(set_checked ? kButtonDown:kButtonUp, true); // set value and signal all connected slots
+}
+
 //-------------------
 // AddCheckButtons
 //-------------------
@@ -2652,4 +2670,19 @@ void hdv_mainframe::AddGraphicsEndA(vector<TObject*> &v)
 void hdv_mainframe::AddGraphicsEndB(vector<TObject*> &v)
 {
 	for(unsigned int i=0; i<v.size(); i++)graphics_endB.push_back(v[i]);
+}
+
+//-------------------
+// RedrawAuxillaryWindows
+//-------------------
+void hdv_mainframe::RedrawAuxillaryWindows(void)
+{
+	// This is called to tell the any other windows like the trk_mainframe
+	// or fmwpc_mainframe to redraw the event. It is needed when the user 
+	// specifies to only draw events with certain objects and some events
+	// are skipped. The hdv_mainframe window is automatically redrawn, in
+	// those cases so that is not included here.
+	if( trkmf ) trkmf->DoNewEvent();
+	if( fmwpcmf ) fmwpcmf->DoNewEvent();
+	
 }

--- a/src/programs/Analysis/hdview2/hdv_mainframe.h
+++ b/src/programs/Analysis/hdview2/hdv_mainframe.h
@@ -119,10 +119,13 @@ class hdv_mainframe:public TGMainFrame {
 		void SetRun(Int_t id);
 		void SetTrig(char *trigstring);
 		void SetSource(std::string source);
+		void SetSleepTime(long st) {sleep_time = st;}
 		bool GetDrawCandidates(void){return draw_candidates;}
 		bool GetDrawTracks(void){return draw_tracks;}
 		bool GetDrawThrowns(void){return draw_throwns;}
 		bool GetDrawTrajectories(void){return draw_trajectories;}
+		bool GetContinuous(void){return GetCheckButton("continuous");}
+		long GetSleepTime(void){return sleep_time;}
 		hdv_fulllistframe* GetFullListFrame(void){return fulllistmf;}
 		hdv_debugerframe* GetDebugerFrame(void){return debugermf;}
 		TCanvas* GetBcalDispFrame(void){return bcaldispmf;}
@@ -139,6 +142,7 @@ class hdv_mainframe:public TGMainFrame {
 		void SetFullListFrame(hdv_fulllistframe* d){fulllistmf = d;}
 
 		bool GetCheckButton(std::string who);
+		void SetCheckButton(string who, bool set_checked=true);
 		void AddCheckButtons(std::map<std::string, TGCheckButton*> &checkbuttons);
 		const char* GetFactoryTag(std::string who);
 		void GetReconFactory(std::string &name, std::string &tag);
@@ -153,6 +157,8 @@ class hdv_mainframe:public TGMainFrame {
 		void AddGraphicsEndA(std::vector<TObject*> &v);
 		void AddGraphicsEndB(std::vector<TObject*> &v);
 
+
+		void RedrawAuxillaryWindows(void);
 
 	private:
 	

--- a/src/programs/Analysis/hdview2/hdview2.cc
+++ b/src/programs/Analysis/hdview2/hdview2.cc
@@ -11,6 +11,8 @@ int GO = 0; // 1=continuously display events 0=wait for user
 bool PRINT_FACTORY_LIST = false;
 bool SKIP_EPICS_EVENTS = true;
 std::vector< std::string> REQUIRED_CLASSES_FOR_DRAWING;
+REQUIRED_CLASSES_LOGIC_t REQUIRED_CLASSES_LOGIC=REQUIRED_CLASSES_LOGIC_OR;
+
 
 TCanvas *maincanvas=NULL;
 extern JApplication *japp;
@@ -147,7 +149,17 @@ void ParseCommandLineArguments(int &narg, char *argv[], JApplication *japp)
 				//PrintFactoryList(japp);
 				break;
 			case 'D':
-				REQUIRED_CLASSES_FOR_DRAWING.push_back(&(argv[i][2]));
+			{
+				stringstream s_stream(&(argv[i][2])); //create string stream from the string
+				while(s_stream.good()) {
+					string substr;
+					getline(s_stream, substr, ','); //get first string delimited by comma
+					REQUIRED_CLASSES_FOR_DRAWING.push_back(substr);
+				}				
+				break;
+			}
+			case 'A':
+				REQUIRED_CLASSES_LOGIC=REQUIRED_CLASSES_LOGIC_AND;
 				break;
 		}
 	}
@@ -181,6 +193,7 @@ void Usage(JApplication *japp)
 	cout<<"   -h        Print this message"<<endl;
 	cout<<"   -L        List available factories and exit"<<endl;
 	cout<<"   -Dname    Only draw events with at least one object of the data of type \"name\" (can be used multiple times. OR logic)"<<endl;
+	cout<<"   -A        Use AND logic instead of OR for the classes listed in -D. (i.e. all of tham must be present rather than at least one)" << endl;
 	cout<<endl;
 	cout<<"JANA options:"<<endl;
 	cout<<endl;

--- a/src/programs/Analysis/hdview2/hdview2.cc
+++ b/src/programs/Analysis/hdview2/hdview2.cc
@@ -10,6 +10,7 @@
 int GO = 0; // 1=continuously display events 0=wait for user
 bool PRINT_FACTORY_LIST = false;
 bool SKIP_EPICS_EVENTS = true;
+std::vector< std::string> REQUIRED_CLASSES_FOR_DRAWING;
 
 TCanvas *maincanvas=NULL;
 extern JApplication *japp;
@@ -145,6 +146,9 @@ void ParseCommandLineArguments(int &narg, char *argv[], JApplication *japp)
 				PRINT_FACTORY_LIST = true;
 				//PrintFactoryList(japp);
 				break;
+			case 'D':
+				REQUIRED_CLASSES_FOR_DRAWING.push_back(&(argv[i][2]));
+				break;
 		}
 	}
 	
@@ -175,11 +179,8 @@ void Usage(JApplication *japp)
 	cout<<"Options:"<<endl;
 	cout<<endl;
 	cout<<"   -h        Print this message"<<endl;
-	cout<<"   -Dname    Print the data of type \"name\" (can be used multiple times)"<<endl;
-	cout<<"   -A        Print ALL data types (overrides and -DXXX options)"<<endl;
 	cout<<"   -L        List available factories and exit"<<endl;
-	cout<<"   -p        Don't pause for keystroke between events (def. is to pause)"<<endl;
-	cout<<"   -s        Skip events which don't have any of the specified data types"<<endl;
+	cout<<"   -Dname    Only draw events with at least one object of the data of type \"name\" (can be used multiple times. OR logic)"<<endl;
 	cout<<endl;
 	cout<<"JANA options:"<<endl;
 	cout<<endl;

--- a/src/programs/Analysis/hdview2/hdview2.h
+++ b/src/programs/Analysis/hdview2/hdview2.h
@@ -24,7 +24,13 @@ extern MyProcessor *myproc;
 
 extern int32_t RUNNUMBER;
 
+enum REQUIRED_CLASSES_LOGIC_t{
+	REQUIRED_CLASSES_LOGIC_OR,
+	REQUIRED_CLASSES_LOGIC_AND
+};
 extern std::vector< std::string > REQUIRED_CLASSES_FOR_DRAWING;
+extern REQUIRED_CLASSES_LOGIC_t REQUIRED_CLASSES_LOGIC;
+
 
 
 jerror_t hdv_getevent(void);

--- a/src/programs/Analysis/hdview2/hdview2.h
+++ b/src/programs/Analysis/hdview2/hdview2.h
@@ -5,6 +5,8 @@
 
 #include <iostream>
 #include <iomanip>
+#include <vector>
+#include <string>
 using namespace std;
 
 #include <TApplication.h>
@@ -21,6 +23,9 @@ extern JEventLoop *eventloop;
 extern MyProcessor *myproc;
 
 extern int32_t RUNNUMBER;
+
+extern std::vector< std::string > REQUIRED_CLASSES_FOR_DRAWING;
+
 
 jerror_t hdv_getevent(void);
 jerror_t hdv_drawevent(void);


### PR DESCRIPTION
This implements a new feature to allow hdview2 to automatically skip events not containing some desired objects. IT is terribly fast, but much faster than clicking through manually.

This also includes some visualization of the CTOF for CPP/NPP