### PR TITLE
add flag to turn on/off inclusion of fake vertex point to indicate th…

### DIFF
--- a/src/libraries/TRACKING/DTrackCandidate_factory.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory.cc
@@ -205,6 +205,9 @@ jerror_t DTrackCandidate_factory::brun(JEventLoop* eventLoop,int32_t runnumber){
   DEBUG_LEVEL=0;
   gPARMS->SetDefaultParameter("TRKFIND:DEBUG_LEVEL", DEBUG_LEVEL);
 
+  ADD_VERTEX_POINT=true;
+  gPARMS->SetDefaultParameter("TRKFIND:ADD_VERTEX_POINT", ADD_VERTEX_POINT);
+   
   return NOERROR;
 }
 
@@ -1649,7 +1652,9 @@ bool DTrackCandidate_factory::MatchMethod4(const DTrackCandidate *srccan,
 	  // Create a new DHelicalFit object for fitting combined data
 	  DHelicalFit fit; 
 	  // Fake point at origin
-	  fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.,true); 
+	  if (ADD_VERTEX_POINT){
+	    fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.,true);
+	  }
 	  // Add hits to the fit object and also to the track candidate
 	  // itself as associated objects
 	  for (unsigned int m=0;m<src_segments.size();m++){
@@ -2254,7 +2259,9 @@ bool DTrackCandidate_factory::MatchMethod8(const DTrackCandidate *cdccan,
 	  }
 	  
 	  // Fake point at origin
-	  fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.,true);
+	  if (ADD_VERTEX_POINT){
+	    fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.,true);
+	  }
 	  // Fit the points to a circle
 	  if (fit.FitCircleRiemann(segments[0]->rc)==NOERROR){
 	    // Use the fdc track candidate to get tanl

--- a/src/libraries/TRACKING/DTrackCandidate_factory.h
+++ b/src/libraries/TRACKING/DTrackCandidate_factory.h
@@ -146,7 +146,7 @@ class DTrackCandidate_factory:public JFactory<DTrackCandidate>{
   vector<DTrackCandidate *>trackcandidates;
 
   int DEBUG_LEVEL,MIN_NUM_HITS;
-  bool DEBUG_HISTS;
+  bool DEBUG_HISTS,ADD_VERTEX_POINT;
   TH2F *match_dist,*match_dist_vs_p;
 //  TH2F *match_center_dist2;
 

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
@@ -52,7 +52,9 @@ jerror_t DTrackCandidate_factory_FDCCathodes::brun(JEventLoop* eventLoop,
 
   FDC_HOUGH_THRESHOLD=10.;
   gPARMS->SetDefaultParameter("TRKFIND:FDC_HOUGH_THRESHOLD",FDC_HOUGH_THRESHOLD);
-
+  ADD_VERTEX_POINT=true;
+  gPARMS->SetDefaultParameter("TRKFIND:ADD_VERTEX_POINT", ADD_VERTEX_POINT);
+ 
   if(DEBUG_HISTS) {
     dapp->Lock();
     match_dist_fdc=(TH2F*)gROOT->FindObject("match_dist_fdc");
@@ -225,7 +227,9 @@ jerror_t DTrackCandidate_factory_FDCCathodes::evnt(JEventLoop *loop, uint64_t ev
     // Create the fit object and add the hits
     DHelicalFit fit; 
     // Fake point at origin
-    fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+    if (ADD_VERTEX_POINT){
+      fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+    }
     double max_r=0.;
     rc=0.,xc=0.,yc=0.,tanl=0.; //initialize helix variables
     q=mytracks[i][0]->q;
@@ -267,7 +271,9 @@ jerror_t DTrackCandidate_factory_FDCCathodes::evnt(JEventLoop *loop, uint64_t ev
 
       // Prune the fake hit at the origin in case we need to use an alternate
       // fit
-      fit.PruneHit(0);
+      if (ADD_VERTEX_POINT){
+	fit.PruneHit(0);
+      }
       if (p>10.){//... try alternate circle fit
 	fit.FitCircle();
 	rc=fit.r0;
@@ -699,7 +705,9 @@ bool DTrackCandidate_factory_FDCCathodes::LinkStraySegment(const DFDCSegment *se
 	// Create fit object and add hits
 	DHelicalFit fit;  
 	// Fake point at origin
-	fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+	if (ADD_VERTEX_POINT){
+	  fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+	}
 	double max_r=0.;
 	for (unsigned int m=0;m<segments.size();m++){ 
 	  for (unsigned int k=0;k<segments[m]->hits.size();k++){
@@ -728,7 +736,9 @@ bool DTrackCandidate_factory_FDCCathodes::LinkStraySegment(const DFDCSegment *se
 	  
 	  // Prune the fake hit at the origin in case we need to use an 
 	  // alternate fit
-	  fit.PruneHit(0);
+	  if (ADD_VERTEX_POINT){
+	    fit.PruneHit(0);
+	  }
 	  if (p>10.){//... try alternate circle fit 
 	    fit.FitCircle();
 	    rc=fit.r0;

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.h
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.h
@@ -79,7 +79,7 @@ class DTrackCandidate_factory_FDCCathodes:public JFactory<DTrackCandidate>{
 			 vector<vector<int> >&is_paired);
 
 
-  bool DEBUG_HISTS,USE_FDC;
+  bool DEBUG_HISTS,USE_FDC,ADD_VERTEX_POINT;
 
   TH2F *match_dist_fdc,*match_center_dist2;
  


### PR DESCRIPTION
…at the track is likely to be coming from the target region.  The default for this new flag  (TRKFIND:ADD_VERTEX_POINT) is true, so this should not change the performance for regular GlueX running.  For CPP it appears that setting this variable to false helps with the track finding.