### PR TITLE
Nsj extend cdc scan plugin to include emulated data

### DIFF
--- a/src/plugins/Utilities/cdc_emu/JEventProcessor_cdc_emu.h
+++ b/src/plugins/Utilities/cdc_emu/JEventProcessor_cdc_emu.h
@@ -35,7 +35,7 @@ using namespace jana;
 #include "DAQ/Df125CDCPulse.h"
 #include "DAQ/Df125Config.h"
 #include "DAQ/Df125TriggerTime.h"
-
+#include "TRIGGER/DTrigger.h"
 //#include "DAQ/DCODAEventInfo.h"
 
 #include "fa125fns.h"

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -327,7 +327,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
     uint32_t ns;
     p->SetBranchAddress("nsamples",&ns);
 
-    uint16_t adc[NSAMPLES];       //    vector<uint16_t> samples;
+    uint16_t adc[NSAMPLES] = {0};       //    vector<uint16_t> samples;
     p->SetBranchAddress("adc",&adc);
 
     
@@ -395,10 +395,9 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           for (uint j=nsave; j<NSAMPLES; j++) adc[j]=0;   
         }	  
 	
-        if (EMU && wrd) {   // need to make a flag whether to do the emu or not
+        if (EMU && wrd) { 
 	
  	  Df125CDCPulse *emu = new Df125CDCPulse();
-        //Df125FDCPulse *fp = new Df125FDCPulse();      
 
           em->EmulateFirmware(wrd, emu, NULL);
 	

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -417,6 +417,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           d_amp = amp - m_amp;
           d_pktime=0;
 
+	  diffs=0;
           if (d_time || d_q || d_overflows || d_pedestal || d_integral || d_amp) diffs = 1;
 	  
 	}
@@ -488,6 +489,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           d_amp = amp - m_amp;
           d_pktime = pktime - m_pktime;
 
+	  diffs=0;
           if (d_time || d_q || d_overflows || d_pedestal || d_integral || d_amp || d_pktime) diffs = 1;
 	}
 	

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -3,10 +3,23 @@
 //    File: JEventProcessor_cdc_scan.cc
 // Created: Sat Dec  6 21:34:19 EST 2014
 // Creator: njarvis (on Linux maria 2.6.32-431.20.3.el6.x86_64 x86_64)
-//
 
-// Use -PCDC_SCAN:SHORT_MODE=0 to include window raw data, otherwise short mode is assumed
 
+// Use -PEVIO:F125_EMULATION_MODE=2 -PCDC_SCAN:EMU=1 (default 1) to emulate firmware using window raw data
+// Use -PCDC_SCAN:FDC=0 (default 1) to skip the FDC data
+
+// To emulate the firmware using window raw data, use -PEVIO:F125_EMULATION_MODE=2
+// Mode 0 switches the emulation off.  This is the default.
+// Mode 1 replaces firmware values with emulated values always
+// Mode 2 replaces firmware values with emulated values only if the firmware values are absent
+
+// This plugin adds the emulated values to its output tree without replacing the firmware values.
+// These are useful if run with mode=2 as above.
+// Use the emulation switches to apply different configuration settings, eg -PEMULATION125:CDC_PBIT=1
+// This would replace the values supplied in Df125BORConfig
+// eg -PEVIO:F125_EMULATION_MODE=2 -PCDC_SCAN:EMU=1 -PEMULATION125:CDC_H=110 -PEMULATION125:CDC_TH=60 -PEMULATION125:CDC_TL=10
+
+// Naomi Jarvis 12 Nov 2022
 
 #include <stdint.h>
 #include <vector>
@@ -20,20 +33,21 @@ using namespace jana;
 
 
 #include "CDC/DCDCDigiHit.h"
+#include "DAQ/Df125EmulatorAlgorithm_v2.h"
 #include "DAQ/Df125WindowRawData.h"     
 #include "DAQ/Df125CDCPulse.h"
+#include "DAQ/Df125FDCPulse.h"
 #include "DAQ/Df125TriggerTime.h"
 #include "TRIGGER/DTrigger.h"
+
 
 
 #include <TTree.h>
 #include <TBranch.h>
 
 
-
 static TTree *t = NULL;
 static TTree *p = NULL;
-static TTree *w = NULL;
 static TTree *tt = NULL;
 
 
@@ -73,117 +87,95 @@ jerror_t JEventProcessor_cdc_scan::init(void)
 
   const uint32_t NSAMPLES = 200;
 
-  SHORT_MODE = 1;    // suppresses use of window raw data and warnings if not found
+  EMU = 1;    // set to 0 to skip emulation from window raw data
 
   if (gPARMS) {
-    gPARMS->SetDefaultParameter("CDC_SCAN:SHORT_MODE",SHORT_MODE,"Set to 0 to include window raw data");
+    gPARMS->SetDefaultParameter("CDC_SCAN:EMU",EMU,"Set to 0 to skip emulation from window raw data");
   }
 
+  FDC = 1;    // set to 0 to skip FDC data
+
+  if (gPARMS) {
+    gPARMS->SetDefaultParameter("CDC_SCAN:FDC",FDC,"Set to 0 to skip FDC data");
+  }
+
+
+
+
+
+
+  if (!EMU)  cout << "\n cdc_scan: skipping emulation\n\n";
+  if (!FDC)  cout << "\n cdc_scan: skipping FDC data\n\n";  
+
+
   japp->RootWriteLock();
-
-
-
-  if (SHORT_MODE)  cout << "\n cdc_scan: suppressing WRD info\n\n";
-
+  
   t = new TTree("T","Event stats");
 
   ULong64_t t_eventnum;
   t->Branch("eventnum",&t_eventnum,"eventnum/l");
 
-  uint32_t nd;
-  t->Branch("Digihitcount",&nd,"nd/i");
-
-  uint32_t ncp;
+  uint32_t ncp, nfp, nt;
   t->Branch("CDCPulsecount",&ncp,"ncp/i");
-
-  uint32_t nfp;
   t->Branch("FDCPulsecount",&nfp,"nfp/i");
-
-  uint32_t nw;
-  t->Branch("WindowRawDatacount",&nw,"nw/i");
-
-  uint32_t nu;
-  t->Branch("Unpairedobjectcount",&nu,"nu/i");
+  t->Branch("TrigTimecount",&nt,"nt/i");
 
 
+  p = new TTree("P","Pulse data");
 
-  p = new TTree("P","CDC pulse data");
-
-
-  ULong64_t p_eventnum;
+  ULong64_t p_eventnum;  
   p->Branch("eventnum",&p_eventnum,"eventnum/l");
 
-  uint32_t p_rocid;
+  uint32_t p_rocid, p_slot, p_channel, p_itrigger, word1, word2;
   p->Branch("rocid",&p_rocid,"rocid/i");
-
-  uint32_t p_slot;
   p->Branch("slot",&p_slot,"slot/i");
-
-  uint32_t p_channel;
   p->Branch("channel",&p_channel,"channel/i");
-
-  uint32_t p_itrigger;
   p->Branch("itrigger",&p_itrigger,"itrigger/i");
-
-  uint32_t word1;
   p->Branch("word1",&word1,"word1/i");
-
-  uint32_t word2; 
   p->Branch("word2",&word2,"word2/i");
 
-  uint32_t time;   
+  uint32_t time, q, pedestal, amp, integral, overflows, pktime;
   p->Branch("time",&time,"time/i");    
-
-  uint32_t q;
   p->Branch("q",&q,"q/i");    
-
-  uint32_t pedestal;  
   p->Branch("pedestal",&pedestal,"pedestal/i");    
-
-  uint32_t integral;
+  p->Branch("amp",&amp,"amp/i");  
   p->Branch("integral",&integral,"integral/i");    
-
-  uint32_t amp;
-  p->Branch("amp",&amp,"amp/i");    
-
-  uint32_t overflows; 
   p->Branch("overflows",&overflows,"overflows/i");    
-
-  bool emulated; 
-  p->Branch("emulated",&emulated,"emulated/O");    
-
-  bool paired;
-  p->Branch("paired",&paired,"paired/O");
-
-  bool cdc;
+  p->Branch("pktime",&pktime,"pktime/i");
+  
+  bool emulated, cdc;
+  p->Branch("emulated",&emulated,"emulated/O");     // set to 1 if the pulse data object contents are emulated
   p->Branch("cdcdata",&cdc,"cdc/O");
 
-
-
-  w = new TTree("W","CDC window raw data");
-
-  ULong64_t w_eventnum;
-  w->Branch("eventnum",&w_eventnum,"eventnum/l");
-
-  uint32_t w_rocid;
-  w->Branch("rocid",&w_rocid,"rocid/i");
-
-  uint32_t w_slot;
-  w->Branch("slot",&w_slot,"slot/i");
-
-  uint32_t w_channel;
-  w->Branch("channel",&w_channel,"channel/i");
-
-  uint32_t w_itrigger;
-  w->Branch("itrigger",&w_itrigger,"itrigger/i");
-
   uint32_t ns;
-  w->Branch("nsamples",&ns,"nsamples/i");
-
+  p->Branch("nsamples",&ns,"nsamples/i");
+  
   uint16_t adc[NSAMPLES];
-  w->Branch("adc",&adc,Form("adc[%i]/s",NSAMPLES));         
- 
-  w->Branch("paired",&paired,"paired/O");
+  p->Branch("adc",&adc,Form("adc[%i]/s",NSAMPLES));         
+
+  if (EMU) {
+
+    uint32_t m_time, m_q, m_pedestal, m_integral, m_amp, m_overflows, m_pktime;
+    p->Branch("m_time", &m_time, "m_time/i");
+    p->Branch("m_q", &m_q, "m_q/i");
+    p->Branch("m_pedestal", &m_pedestal, "m_pedestal/i");
+    p->Branch("m_integral", &m_integral, "m_integral/i");
+    p->Branch("m_amp", &m_amp, "m_amp/i");
+    p->Branch("m_overflows", &m_overflows, "m_overflows/i");
+    p->Branch("m_pktime", &m_pktime, "m_pktime/i");
+  
+    int d_time, d_q, d_pedestal, d_integral, d_amp, d_overflows, d_pktime;
+    p->Branch("d_time", &d_time, "d_time/I");
+    p->Branch("d_q", &d_q, "d_q/I");
+    p->Branch("d_pedestal", &d_pedestal, "d_pedestal/I");
+    p->Branch("d_integral", &d_integral, "d_integral/I");
+    p->Branch("d_amp", &d_amp, "d_amp/I");
+    p->Branch("d_overflows", &d_overflows, "d_overflows/I");
+    p->Branch("d_pktime", &d_pktime, "d_pktime/I");
+  
+    bool diffs;
+    p->Branch("diffs",&diffs,"diffs/O");
+  }
   
 
   tt = new TTree("TT","Trigger time");
@@ -191,13 +183,9 @@ jerror_t JEventProcessor_cdc_scan::init(void)
   ULong64_t tt_eventnum;
   tt->Branch("eventnum",&tt_eventnum,"eventnum/l");
 
-  uint32_t tt_rocid;
+  uint32_t tt_rocid, tt_slot, tt_itrigger;
   tt->Branch("rocid",&tt_rocid,"rocid/i");
-
-  uint32_t tt_slot;
   tt->Branch("slot",&tt_slot,"slot/i");
-
-  uint32_t tt_itrigger;
   tt->Branch("itrigger",&tt_itrigger,"itrigger/i");
 
   uint64_t tt_time;
@@ -223,24 +211,8 @@ jerror_t JEventProcessor_cdc_scan::brun(JEventLoop *eventLoop, int32_t runnumber
 //------------------
 jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
 {
-	// This is called for every event. Use of common resources like writing
-	// to a file or filling a histogram should be mutex protected. Using
-	// loop->Get(...) to get reconstructed objects (and thereby activating the
-	// reconstruction algorithm) should be done outside of any mutex lock
-	// since multiple threads may call this method at the same time.
-	// Here's an example:
-	//
-	// vector<const MyDataClass*> mydataclasses;
-	// loop->Get(mydataclasses);
-	//
-	// japp->RootWriteLock();
-	//  ... fill histograms or trees ...
-	// japp->RootUnLock();
-
-
 
   // Only look at physics triggers
-
   
   const DTrigger* locTrigger = NULL; 
   loop->GetSingle(locTrigger); 
@@ -249,53 +221,62 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
   if (!locTrigger->Get_IsPhysicsEvent()){ // do not look at PS triggers
     return NOERROR;
   }
+   
+  vector <const Df125CDCPulse*> cdcpulses;
+  loop->Get(cdcpulses);
+  uint32_t nc = (uint32_t)cdcpulses.size();
 
+  
+  vector <const Df125FDCPulse*> fdcpulses;
+  loop->Get(fdcpulses);
+  uint32_t nf = (uint32_t)fdcpulses.size();
 
-  //   cout << "Event " << eventnumber << endl;
-
-
-  // get raw data for cdc
-  vector<const DCDCDigiHit*> digihits;
-  loop->Get(digihits);
-
-  vector<const Df125WindowRawData*> wrdvector;
-  loop->Get(wrdvector);
 
   vector<const Df125TriggerTime*> ttvector;
   loop->Get(ttvector);
-
-  uint32_t nd = (uint32_t)digihits.size();
-  uint32_t nw = (uint32_t)wrdvector.size();
   uint32_t ntt = (uint32_t)ttvector.size();
 
+  
+  if (nc+nf==0) return NOERROR;  // no DC hits
+
+
+  ULong64_t eventnum = (ULong64_t)eventnumber;
+
+  
+  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+
+  t->SetBranchAddress("eventnum",&eventnum);
+  t->SetBranchAddress("CDCPulsecount",&nc);
+  t->SetBranchAddress("FDCPulsecount",&nf);
+  t->SetBranchAddress("TrigTimecount",&ntt);
+    
+  t->Fill();  
+
+  japp->RootUnLock();
+  
+ 
+  
+ 
   
   if (ntt > 0) { //   Df125TriggerTime 
 
     japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
+    tt->SetBranchAddress("eventnum",&eventnum);
 
-    ULong64_t tt_eventnum;
-    tt->SetBranchAddress("eventnum",&tt_eventnum);
-
-    uint32_t tt_rocid;
+    uint32_t tt_rocid, tt_slot, tt_itrigger;
     tt->SetBranchAddress("rocid",&tt_rocid);
-
-    uint32_t tt_slot;
     tt->SetBranchAddress("slot",&tt_slot);
-
-    uint32_t tt_itrigger;
     tt->SetBranchAddress("itrigger",&tt_itrigger);
 
     ULong64_t tt_time;
     tt->SetBranchAddress("time",&tt_time);
 
-    tt_eventnum = eventnumber;
-
     for (uint32_t i=0; i<ntt; i++) {
 
       const Df125TriggerTime *thistt = ttvector[i];
 
-      if (thistt->rocid < 25 || thistt->rocid > 28) continue;   // skip FDC
+      if (!FDC && (thistt->rocid < 25 || thistt->rocid > 28)) continue;   // skip FDC
 
       //      cout << thistt->rocid << " " << thistt->slot << " " << thistt->itrigger << " " << thistt->time << endl;
 
@@ -306,209 +287,90 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       tt->Fill();
     }
+
     japp->RootUnLock();
 
   }
 
+  
+  
+  const uint32_t NSAMPLES = 200;   // 100 for FDC
 
-  uint32_t nhits = nd;  
-  if (nw>nd) nhits = nw;
-
-  //  if (!nhits) printf("No hits in event %li\n",eventnumber);
-
-  if (nhits) {
+  if (nc || (nf&&FDC)) {  // branches are almost the same for CDC & FDC - only amp differs
 
     japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
-    const uint32_t NSAMPLES = 200;
-    const uint32_t NSAMPLESFDC = 100;
-
-
-    t->SetBranchAddress("Digihitcount",&nd);
-    t->SetBranchAddress("WindowRawDatacount",&nw);
+    
+    p->SetBranchAddress("eventnum",&eventnum);
 
 
-    ULong64_t t_eventnum;
-    t->SetBranchAddress("eventnum",&t_eventnum);
-
-    uint32_t ncp;
-    t->SetBranchAddress("CDCPulsecount",&ncp);
-
-    uint32_t nfp;
-    t->SetBranchAddress("FDCPulsecount",&nfp);
-
-    uint32_t nu;
-    t->SetBranchAddress("Unpairedobjectcount",&nu);
-
-
-
-    ULong64_t p_eventnum;
-    p->SetBranchAddress("eventnum",&p_eventnum);
-
-    uint32_t p_rocid;
+    uint32_t p_rocid, p_slot, p_channel, p_itrigger, word1, word2; 
     p->SetBranchAddress("rocid",&p_rocid);
-
-    uint32_t p_slot;
     p->SetBranchAddress("slot",&p_slot);
-
-    uint32_t p_channel;
     p->SetBranchAddress("channel",&p_channel);
-
-    uint32_t p_itrigger;
     p->SetBranchAddress("itrigger",&p_itrigger);
-
-    uint32_t word1;
     p->SetBranchAddress("word1",&word1);
-
-    uint32_t word2; 
     p->SetBranchAddress("word2",&word2);
 
-    uint32_t time;   
+    uint32_t time, q, pedestal, amp, integral, overflows, pktime;
     p->SetBranchAddress("time",&time);
-
-    uint32_t q;
     p->SetBranchAddress("q",&q);
-
-    uint32_t pedestal;  
     p->SetBranchAddress("pedestal",&pedestal);
-
-    uint32_t integral;
-    p->SetBranchAddress("integral",&integral);
-
-    uint32_t amp;
     p->SetBranchAddress("amp",&amp);
-
-    uint32_t overflows; 
+    p->SetBranchAddress("integral",&integral);
     p->SetBranchAddress("overflows",&overflows);
+    p->SetBranchAddress("pktime",&pktime);    
 
-    bool emulated; 
+    bool emulated, cdc; 
     p->SetBranchAddress("emulated",&emulated);
-
-    bool paired;
-    p->SetBranchAddress("paired",&paired);
-
-    bool cdc;
     p->SetBranchAddress("cdcdata",&cdc);
 
-
-
-
-    ULong64_t w_eventnum;
-    w->SetBranchAddress("eventnum",&w_eventnum);
-
-    uint32_t w_rocid;
-    w->SetBranchAddress("rocid",&w_rocid);
-
-    uint32_t w_slot;
-    w->SetBranchAddress("slot",&w_slot);
-
-    uint32_t w_channel;
-    w->SetBranchAddress("channel",&w_channel);
-
-    uint32_t w_itrigger;
-    w->SetBranchAddress("itrigger",&w_itrigger);
-
     uint32_t ns;
-    w->SetBranchAddress("nsamples",&ns);
+    p->SetBranchAddress("nsamples",&ns);
 
     uint16_t adc[NSAMPLES];       //    vector<uint16_t> samples;
-    w->SetBranchAddress("adc",&adc);
- 
-    w->SetBranchAddress("paired",&paired);
+    p->SetBranchAddress("adc",&adc);
 
+    
+    uint32_t m_time=0, m_q=0, m_pedestal=0, m_integral=0, m_amp=0, m_overflows=0, m_pktime=0;
+    int d_time=0, d_q=0, d_pedestal=0, d_integral=0, d_amp=0, d_overflows=0, d_pktime=0;
+    bool diffs=0;
+    
+    if (EMU) {    
+      p->SetBranchAddress("m_time",&m_time);
+      p->SetBranchAddress("m_q",&m_q);
+      p->SetBranchAddress("m_overflows",&m_overflows);
+      p->SetBranchAddress("m_pedestal",&m_pedestal);
+      p->SetBranchAddress("m_integral",&m_integral);
+      p->SetBranchAddress("m_amp",&m_amp);
+      p->SetBranchAddress("m_pktime",&m_pktime);
 
+      p->SetBranchAddress("d_time", &d_time);
+      p->SetBranchAddress("d_q", &d_q);
+      p->SetBranchAddress("d_pedestal", &d_pedestal);
+      p->SetBranchAddress("d_integral", &d_integral);
+      p->SetBranchAddress("d_amp", &d_amp);
+      p->SetBranchAddress("d_overflows", &d_overflows);
+      p->SetBranchAddress("d_pktime", &d_pktime);
+    
+      p->SetBranchAddress("diffs",&diffs);  
+    }
 
-    uint32_t i,j;
+    Df125EmulatorAlgorithm_v2 *em = new Df125EmulatorAlgorithm_v2();    
+    
+    if (nc) {
+       
+      cdc = 1;
+      ns = 0;   // could be different for cdc & fdc
+      
+      for (uint32_t i=0; i<nc; i++) {
 
-
-    ncp = 0;
-    nfp = 0;
-    nu = 0;
-
-
-    t_eventnum = eventnumber;
-
-    //    printf("%i hits \n",(int)nhits); //temp
-
-
-    // look through digihits, find CP and look for associated WRD----------------------
-
-    for (i=0; i<nd; i++) {
-
-      p_eventnum = 0;
-      w_eventnum = 0;
-
-
-      p_rocid = 0; 
-      p_slot = 0; 
-      p_channel = 0;
-      p_itrigger = 0;
-
-      time = 0;
-      q = 0;
-      overflows = 0;  
-      pedestal = 0;
-      amp = 0;
-      integral = 0; 
-
-      word1 = 0;
-      word2 = 0;
-
-      emulated = 0;
-      paired = 0;
-
-
-      w_rocid = 0; 
-      w_slot = 0; 
-      w_channel = 0;
-      w_itrigger = 0;
-
+        const Df125CDCPulse *cp = cdcpulses[i];
   
-      for (j=0; j<NSAMPLES; j++) {
-        adc[j] = 0; 
-      }
-  
-
-      const DCDCDigiHit *digihit = NULL;
-      if (i < nd) digihit = digihits[i];  
-
-      const Df125CDCPulse *cp = NULL;
-      if (digihit) digihit->GetSingle(cp);
-
-
-      const Df125WindowRawData *wrd = NULL;
-
-      if (!SHORT_MODE) {
-        if (cp) cp->GetSingle(wrd);
-        //if (wrd) printf("Found cp->GetSingle(wrd)\n");
-        if (cp && !wrd) printf("Did not find cp->GetSingle(wrd)\n");
-      }
-
-      if (cp) ncp++;
-
-
-      if (!cp) printf("\nMissing CDCPulse in event %li \n\n",eventnumber);
-      if (!SHORT_MODE) {
-        if (!wrd) printf("\nMissing WRD in event %li \n\n",eventnumber);
-      }
-
-      if (!digihit) continue;
-
-
-
-      uint32_t nexpect = NSAMPLES;  //set to CDC 
-
-
-      if (cp) {
-
-        cdc = 1;
-
-        p_eventnum = eventnumber;
         p_rocid = cp->rocid;
         p_slot = cp->slot;
         p_channel = cp->channel;
         p_itrigger = cp->itrigger;
-
+  
         word1 = cp->word1;
         word2 = cp->word2;
         time = cp->le_time;
@@ -517,137 +379,128 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
         q = cp->time_quality_bit;
         overflows = cp->overflow_count;
         amp = cp->first_max_amp;
-
+        pktime = 0;
+	
         emulated = cp->emulated;
-      }
 
+        const Df125WindowRawData *wrd;
+        cp->GetSingle(wrd);
 
-      if (wrd) {
+        if (wrd) {
+          ns = (uint32_t)wrd->samples.size();
 
-        w_eventnum = eventnumber;
-        w_rocid = wrd->rocid;
-        w_slot = wrd->slot;
-        w_channel = wrd->channel;
-        w_itrigger = wrd->itrigger;
-
-        ns = (uint32_t)wrd->samples.size();
-  
-        for (j=0; j<ns; j++) {
-          adc[j] = wrd->samples[j];
-        }
-
-        if (w_rocid<24 || w_rocid>28) nexpect = NSAMPLESFDC;
-        if (!w_rocid) nexpect = 0;
-
-        if (ns != nexpect) {
-          printf("\nFound %u WRD samples for event %llu roc %u slot %u channel %u \n\n",ns,w_eventnum,w_rocid,w_slot,w_channel);
-        }
-
-
-        if (w_eventnum == p_eventnum) {
-
-          paired = 1;
-
-          if (p_rocid != w_rocid) paired = 0;
-          if (p_slot != w_slot) paired = 0;
-          if (p_channel != w_channel) paired = 0;
-          if (p_itrigger != w_itrigger) paired = 0;
-
-        } 
-
-        if (!paired) nu++;
+          uint32_t nsave = (ns<=NSAMPLES) ? ns : NSAMPLES ;  // save the first NSAMPLES values of the array
       
-      } //wrd
+          for (uint j=0; j<nsave; j++) adc[j] = wrd->samples[j];
+          for (uint j=nsave; j<NSAMPLES; j++) adc[j]=0;   
+        }	  
+	
+        if (EMU && wrd) {   // need to make a flag whether to do the emu or not
+	
+ 	  Df125CDCPulse *emu = new Df125CDCPulse();
+        //Df125FDCPulse *fp = new Df125FDCPulse();      
 
-      //if (!paired) printf("  Mismatch for p_eventnum %i CDCPulse roc %i slot %i ch %i trig %i with WRD roc %i slot %i ch %i trig %i\n",p_eventnum,rocid,slot,channel,itrigger,wrd->rocid,wrd->slot,wrd->channel,wrd->itrigger);
+          em->EmulateFirmware(wrd, emu, NULL);
+	
+          m_time = emu->le_time_emulated;
+          m_q = emu->time_quality_bit_emulated;
+          m_overflows = emu->overflow_count_emulated;
+          m_pedestal = emu->pedestal_emulated;
+          m_integral = emu->integral_emulated;
+          m_amp = emu->first_max_amp_emulated;
+          m_pktime=0;
 
-      if (!SHORT_MODE) w->Fill();
-      p->Fill();
+          d_time = time - m_time;
+          d_q = q - m_q;
+          d_overflows = overflows - m_overflows;
+          d_pedestal = pedestal - m_pedestal;
+          d_integral = integral - m_integral;
+          d_amp = amp - m_amp;
+          d_pktime=0;
 
-    }  //nhits
+          if (d_time || d_q || d_overflows || d_pedestal || d_integral || d_amp) diffs = 1;
+	  
+	}
+	
+        p->Fill();
+  
+      }
 
-    //    cout << "Event " << eventnumber;  
-    //    printf(" PulseData: %u CDCPulse: %u FDCPulse: %u WindowData: %u Unpaired data: %u\n",nd,ncp,nfp,nw,nu);
-
-
-
-
-
-    // look through wrd ----------------------------
-
-
-
-    for (i=0; i<nw; i++) {
-
-      const Df125WindowRawData *wrd = wrdvector[i];
-      if (wrd->rocid>28) nfp++; 
-      if (wrd->rocid>28) continue; //skip fdc
-      //printf("wrd->rocid %i\n",wrd->rocid);
-
-      const Df125CDCPulse *cp = NULL;
-      wrd->GetSingle(cp);
-
-      if (cp) continue; //should have found this one already via digihits
-
-      //if (cp) printf("Found wrd->GetSingle(cp)\n");
-      if (!cp) printf("Did not find wrd->GetSingle(cp)\n");
-
-      if (!cp) printf("\nMissing CDCPulse in eventnum %li \n\n",eventnumber);
-      if (!wrd) printf("\nMissing WRD in eventnum %li \n\n",eventnumber);
-
+    }
 
   
-      for (j=0; j<NSAMPLES; j++) {
-        adc[j] = 0; 
+    if (FDC && nf) {
+
+      cdc = 0;      
+      ns = 0;
+      
+      for (uint32_t i=0; i<nf; i++) {
+
+        const Df125FDCPulse *fp = fdcpulses[i];
+  
+        p_rocid = fp->rocid;
+        p_slot = fp->slot;
+        p_channel = fp->channel;
+        p_itrigger = fp->itrigger;
+  
+        word1 = fp->word1;
+        word2 = fp->word2;
+        time = fp->le_time;
+        pedestal = fp->pedestal;
+        integral = fp->integral;
+        q = fp->time_quality_bit;
+        overflows = fp->overflow_count;
+        amp = fp->peak_amp;
+        pktime = fp->peak_time;
+	
+        emulated = fp->emulated;
+
+        const Df125WindowRawData *wrd;
+        fp->GetSingle(wrd);
+
+        if (wrd) {
+          ns = (uint32_t)wrd->samples.size();
+
+          uint32_t nsave = (ns<=NSAMPLES) ? ns : NSAMPLES ;  // save the first NSAMPLES values of the array
+      
+          for (uint j=0; j<nsave; j++) adc[j] = wrd->samples[j];
+          for (uint j=nsave; j<NSAMPLES; j++) adc[j]=0;   
+        }	  
+	
+        if (EMU && wrd) {   // need to make a flag whether to do the emu or not
+	
+ 	  Df125FDCPulse *emu = new Df125FDCPulse();
+
+          em->EmulateFirmware(wrd, NULL, emu);
+
+          m_time = fp->le_time_emulated;
+          m_q = fp->time_quality_bit_emulated;
+          m_overflows = fp->overflow_count_emulated;
+          m_pedestal = fp->pedestal_emulated;
+          m_integral = fp->integral_emulated;
+          m_amp = fp->peak_amp_emulated;
+          m_pktime = fp->peak_time_emulated;	
+
+          d_time = time - m_time;
+          d_q = q - m_q;
+          d_overflows = overflows - m_overflows;
+          d_pedestal = pedestal - m_pedestal;
+          d_integral = integral - m_integral;
+          d_amp = amp - m_amp;
+          d_pktime = pktime - m_pktime;
+
+          if (d_time || d_q || d_overflows || d_pedestal || d_integral || d_amp || d_pktime) diffs = 1;
+	}
+	
+        p->Fill();
+  
       }
   
-      uint32_t nexpect = NSAMPLES;  //set to CDC 
+    }
 
-
-        w_eventnum = eventnumber;
-        w_rocid = wrd->rocid;
-        w_slot = wrd->slot;
-        w_channel = wrd->channel;
-        w_itrigger = wrd->itrigger;
-
-        ns = (uint32_t)wrd->samples.size();
-  
-        for (j=0; j<ns; j++) {
-          adc[j] = wrd->samples[j];
-        }
-
-        if (w_rocid<24 || w_rocid>28) nexpect = NSAMPLESFDC;
-        if (!w_rocid) nexpect = 0;
-
-        if (ns != nexpect) {
-          printf("\nFound %u WRD samples for event %llu roc %u slot %u channel %u \n\n",ns,w_eventnum,w_rocid,w_slot,w_channel);
-        }
-
-
-      w->Fill();
- 
-    }  //nhits
-
-    //    cout << "Event " << eventnumber;  
-    //    printf(" PulseData: %u CDCPulse: %u FDCPulse: %u WindowData: %u Unpaired data: %u\n",nd,ncp,nfp,nw,nu);
-
-
-
-
-
-    if (nd||nw)  t->Fill();
-
-    //    if (nd||nw) printf("filling tree T\n");
-
-
-    japp->RootUnLock();
-
-
-  }  // if (nhits)
-
-
-
-
+    japp->RootUnLock();    
+  }
+    
   return NOERROR;
 
 }

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.h
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.h
@@ -28,7 +28,8 @@ class JEventProcessor_cdc_scan:public jana::JEventProcessor{
 		jerror_t fini(void);						///< Called after last event of last event source has been processed.
 
 
-                int SHORT_MODE; // set to 0 to include window raw data
+                int EMU; // set to 1 to run emulation if window raw data is present
+                int FDC; // set to 0 to skip FDC data
 
 };
 


### PR DESCRIPTION
CDC_scan plugin makes root trees from the fa125 low level data, pulse time, amplitude, etc.
In this PR it was modified to include the FDC data by default, and the option was added 
(-PEVIO:F125_EMULATION_MODE=2 -PCDC_SCAN:EMU=1) to make branches 
containing emulated data, using the emulation functions in the DAQ library.

CDC_emu plugin generates similar output but has its own inc file containing the emulation code and reads in the fa125 config parameters from the roccdc1 etc cnf files. This is less user friendly than the other plugin but does not need BORconfig data.
In this PR it was modified only slightly, to make the name of the configuration files that it reads in more generic.
