### PR TITLE
refine the difference flagging in the output tree to reduce unnecessary entries

### DIFF
--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -203,6 +203,7 @@ jerror_t JEventProcessor_cdc_scan::init(void)
 jerror_t JEventProcessor_cdc_scan::brun(JEventLoop *eventLoop, int32_t runnumber)
 {
 	// This is called whenever the run number changes
+  
 	return NOERROR;
 }
 
@@ -410,7 +411,10 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           m_pktime=0;
 
           d_time = time - m_time;
-          d_q = q - m_q;
+	  // Firmware q is either 1 or 0.  m_q is the q_code, 0 to 9, where 0 indicates a good time measurement
+	  // Only flag a difference between these if one is 0 and the other isn't.
+	  uint m_q_binary = (m_q == 0) ? 0 : 1 ;
+          d_q = q - m_q_binary;
           d_overflows = overflows - m_overflows;
           d_pedestal = pedestal - m_pedestal;
           d_integral = integral - m_integral;
@@ -482,7 +486,10 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           m_pktime = fp->peak_time_emulated;	
 
           d_time = time - m_time;
-          d_q = q - m_q;
+	  // Firmware q is either 1 or 0.  m_q is the q_code, 0 to 9, where 0 indicates a good time measurement
+	  // Only flag a difference between these if one is 0 and the other isn't.
+	  uint m_q_binary = (m_q == 0) ? 0 : 1 ;
+          d_q = q - m_q_binary;
           d_overflows = overflows - m_overflows;
           d_pedestal = pedestal - m_pedestal;
           d_integral = integral - m_integral;
@@ -490,7 +497,8 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
           d_pktime = pktime - m_pktime;
 
 	  diffs=0;
-          if (d_time || d_q || d_overflows || d_pedestal || d_integral || d_amp || d_pktime) diffs = 1;
+	  // FDC mode 8 does not report the integral, so don't flag those differences in the diffs branch
+          if (d_time || d_q || d_overflows || d_pedestal || d_amp || d_pktime) diffs = 1;
 	}
 	
         p->Fill();


### PR DESCRIPTION
When deciding whether to set the branch 'diffs' content to 1: 
make emulated q binary before comparison with firmware q, 
ignore d_integral from the FDC, as the firmware integral is not read out.

This cleans up the output tree quite a bit. 