### PR TITLE
Fix string buffer overflow rtj

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1478,7 +1478,6 @@ jerror_t DEventSourceREST::Extract_DTrackTimeBased(hddm_r::HDDM *record,
    
    if( PRUNE_DUPLICATE_TRACKS && (data.size() > 1) ) {
    		vector< int > indices_to_erase;
-   		vector<DTrackTimeBased*>::iterator it = data.begin();
    		
    		 for( unsigned int i=0; i<data.size()-1; i++ ) {
   			for( unsigned int j=i+1; j<data.size(); j++ ) {

--- a/src/programs/Utilities/hddm/hddm-c.cpp
+++ b/src/programs/Utilities/hddm/hddm-c.cpp
@@ -1693,6 +1693,7 @@ void CodeBuilder::writeMatcher()
          << "      (token = strtok(line+level+1,\" >\")))"      << std::endl
          << "   {"                                              << std::endl
          << "      strncpy(tag,token,500);"                     << std::endl
+         << "      tag[499] = 0;"                               << std::endl
          << "      return level/2;"                             << std::endl
          << "   }"                                              << std::endl
          << "   return -1;"                                     << std::endl


### PR DESCRIPTION
These fixes are inspired by the compiler warnings in the monthly build email. No actual behavior changes are entailed, just code cleanup. -rtj