### PR TITLE
New command line option to skip wrongly formated F250 signals.

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -61,6 +61,7 @@ DEVIOWorkerThread::DEVIOWorkerThread(
 	buff                = new uint32_t[buff_len];
 
 	PARSE_F250          = true;
+	SKIP_F250_FORMAT_ERROR = false;
 	PARSE_F125          = true;
 	PARSE_F1TDC         = true;
 	PARSE_CAEN1290TDC   = true;
@@ -1394,7 +1395,7 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 {
 	if(!PARSE_F250){ iptr = &iptr[(*iptr) + 1]; return; }
 
-	int continue_on_format_error = false;
+	int continue_on_format_error = SKIP_F250_FORMAT_ERROR;
 
 	auto pe_iter = current_parsed_events.begin();
 	DParsedEvent *pe = NULL;
@@ -1513,7 +1514,7 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					
 						if( (*iptr>>30) != 0x01) {
 							jerr << "Bad f250 Pulse Data for rocid="<<rocid<<" slot="<<slot<<" channel="<<channel<<endl;
-							DumpBinary(istart_pulse_data, iend, ((uint64_t)&iptr[3]-(uint64_t)istart_pulse_data)/4, iptr);
+							if(VERBOSE>7) DumpBinary(istart_pulse_data, iend, ((uint64_t)&iptr[3]-(uint64_t)istart_pulse_data)/4, iptr);
 							if (continue_on_format_error) {
 								iptr = iend;
 								return;
@@ -1532,7 +1533,7 @@ void DEVIOWorkerThread::Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 
 						iptr++;
 						if( (*iptr>>30) != 0x00){
-							DumpBinary(istart_pulse_data, iend, 128, iptr);
+							if(VERBOSE>7) DumpBinary(istart_pulse_data, iend, 128, iptr);
 							if (continue_on_format_error) {
 								iptr = iend;
 								return;

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -81,6 +81,7 @@ class DEVIOWorkerThread{
 		streampos pos;
 
 		bool  PARSE_F250;
+		bool  SKIP_F250_FORMAT_ERROR;
 		bool  PARSE_F125;
 		bool  PARSE_F1TDC;
 		bool  PARSE_CAEN1290TDC;
@@ -95,7 +96,7 @@ class DEVIOWorkerThread{
 
 		bool  LINK_TRIGGERTIME;
 		bool  LINK_CONFIG;
-		
+
 		void Run(void);
 		void Finish(bool wait_to_complete=true);
 		void Prune(void);

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -83,6 +83,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 	LINK_CONFIG = true;
 	PARSE = true;
 	PARSE_F250 = true;
+	SKIP_F250_FORMAT_ERROR = false;
 	PARSE_F125 = true;
 	PARSE_F1TDC = true;
 	PARSE_CAEN1290TDC = true;
@@ -129,6 +130,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 
 	gPARMS->SetDefaultParameter("EVIO:PARSE", PARSE, "Set this to 0 to disable parsing of event buffers and generation of any objects (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_F250", PARSE_F250, "Set this to 0 to disable parsing of data from F250 ADC modules (for benchmarking/debugging)");
+	gPARMS->SetDefaultParameter("EVIO:SKIP_F250_FORMAT_ERROR", SKIP_F250_FORMAT_ERROR, "Set this to 1 to skip F250 format errors (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_F125", PARSE_F125, "Set this to 0 to disable parsing of data from F125 ADC modules (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_F1TDC", PARSE_F1TDC, "Set this to 0 to disable parsing of data from F1TDC modules (for benchmarking/debugging)");
 	gPARMS->SetDefaultParameter("EVIO:PARSE_CAEN1290TDC", PARSE_CAEN1290TDC, "Set this to 0 to disable parsing of data from CAEN 1290 TDC modules (for benchmarking/debugging)");
@@ -218,6 +220,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(const char* source_name):JEventSource(s
 		w->MAX_EVENT_RECYCLES  = MAX_EVENT_RECYCLES;
 		w->MAX_OBJECT_RECYCLES = MAX_OBJECT_RECYCLES;
 		w->PARSE_F250          = PARSE_F250;
+		w->SKIP_F250_FORMAT_ERROR = SKIP_F250_FORMAT_ERROR;
 		w->PARSE_F125          = PARSE_F125;
 		w->PARSE_F1TDC         = PARSE_F1TDC;
 		w->PARSE_CAEN1290TDC   = PARSE_CAEN1290TDC;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -191,6 +191,7 @@ class JEventSource_EVIOpp: public jana::JEventSource{
 
 		bool     PARSE;
 		bool     PARSE_F250;
+		bool     SKIP_F250_FORMAT_ERROR;
 		bool     PARSE_F125;
 		bool     PARSE_F1TDC;
 		bool     PARSE_CAEN1290TDC;


### PR DESCRIPTION
Avoids a problem which appeared during the runs 121153-121157. Binary dump only with verbosity > 7.