### PR TITLE
new method for walk correction of tagger microscope timing is introduced

### DIFF
--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
@@ -40,6 +40,7 @@ class DTAGMHit_factory_Calib: public jana::JFactory<DTAGMHit> {
       double t_tdc_base;
 
       // calibration constants stored in row, column format
+      int WalkCorMethod;
       double fadc_gains[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
       double fadc_pedestals[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
       double fadc_time_offsets[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];


### PR DESCRIPTION
and was tested on run 101575
the code is modified to use the old established method by default and only uses the new method if explicitly requested.
Note the new method will use the same walk correction table as the old method therefore if the new method is requiest one has to "overwrite" the walk correction parameters in the walk correction table. this may not be desired by others!