### PR TITLE
Reaction efficiency enhancements

### DIFF
--- a/src/libraries/ANALYSIS/DAnalysisUtilities.cc
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.cc
@@ -626,6 +626,35 @@ void DAnalysisUtilities::Get_UnusedNeutralParticles(JEventLoop* locEventLoop, co
 	}
 }
 
+void DAnalysisUtilities::Get_UnusedTOFPoints(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, vector<const DTOFPoint*>& locUnusedTOFPoints) const
+{
+	locUnusedTOFPoints.clear();
+	locEventLoop->Get(locUnusedTOFPoints);
+
+	vector<const DParticleComboStep*> locParticleComboSteps = locParticleCombo->Get_ParticleComboSteps();
+	for(size_t loc_icombo = 0; loc_icombo < locParticleComboSteps.size(); ++loc_icombo) {
+		const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(loc_icombo);
+		for(size_t loc_ipart = 0; loc_ipart < locParticleComboStep->Get_NumFinalParticles(); ++loc_ipart) {
+
+			auto locParticle = locParticleComboStep->Get_FinalParticle_Measured(loc_ipart);
+			if(locParticle == nullptr || locParticle->charge() == 0) continue; 
+
+			const DChargedTrack* locChargedTrack = static_cast<const DChargedTrack*>(locParticleComboStep->Get_FinalParticle_SourceObject(loc_ipart));
+			const DChargedTrackHypothesis* locChargedTrackHypothesis = locChargedTrack->Get_Hypothesis(locParticle->PID());
+	
+			if(locChargedTrackHypothesis->Get_TOFHitMatchParams() == nullptr) continue;
+			const DTOFPoint *locTOFPoint = locChargedTrackHypothesis->Get_TOFHitMatchParams()->dTOFPoint;
+
+			for(auto locIterator = locUnusedTOFPoints.begin(); locIterator != locUnusedTOFPoints.end();) {
+				if(locTOFPoint != *locIterator)
+					++locIterator;
+				else
+					locIterator = locUnusedTOFPoints.erase(locIterator);
+			}
+		}
+	}
+}
+
 void DAnalysisUtilities::Get_ThrownParticleSteps(JEventLoop* locEventLoop, deque<pair<const DMCThrown*, deque<const DMCThrown*> > >& locThrownSteps) const
 {
  	vector<const DMCThrown*> locMCThrowns;

--- a/src/libraries/ANALYSIS/DAnalysisUtilities.h
+++ b/src/libraries/ANALYSIS/DAnalysisUtilities.h
@@ -72,6 +72,7 @@ class DAnalysisUtilities : public JObject
 
 		void Get_UnusedNeutralShowers(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, vector<const DNeutralShower*>& locUnusedNeutralShowers) const;
 		void Get_UnusedNeutralParticles(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, vector<const DNeutralParticle*>& locUnusedNeutralParticles) const;
+		void Get_UnusedTOFPoints(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo, vector<const DTOFPoint*>& locUnusedTOFPoints) const;
 
 		void Get_ThrownParticleSteps(JEventLoop* locEventLoop, deque<pair<const DMCThrown*, deque<const DMCThrown*> > >& locThrownSteps) const;
 		bool Are_ThrownPIDsSameAsDesired(JEventLoop* locEventLoop, const deque<Particle_t>& locDesiredPIDs, Particle_t locMissingPID = Unknown) const;

--- a/src/plugins/Analysis/ReactionEfficiency/DCustomAction_MissingMatch.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DCustomAction_MissingMatch.cc
@@ -1,0 +1,164 @@
+// $Id$
+//
+//    File: DCustomAction_MissingMatch.cc
+// Created: Wed Jun 19 17:20:17 EDT 2019
+// Creator: jrsteven (on Linux ifarm1402.jlab.org 3.10.0-327.el7.x86_64 x86_64)
+//
+
+#include "DCustomAction_MissingMatch.h"
+
+void DCustomAction_MissingMatch::Initialize(JEventLoop* locEventLoop)
+{
+	//Optional: Create histograms and/or modify member variables.
+	//Create any histograms/trees/etc. within a ROOT lock. 
+		//This is so that when running multithreaded, only one thread is writing to the ROOT file at a time. 
+	//NEVER: Get anything from the JEventLoop while in a lock: May deadlock
+
+	//CREATE THE HISTOGRAMS
+	//Since we are creating histograms, the contents of gDirectory will be modified: must use JANA-wide ROOT lock
+	japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	{
+		CreateAndChangeTo_ActionDirectory();
+
+		dHistMissingMatch2DTOF = GetOrCreate_Histogram<TH2F>("HistMissingMatch2DTOF", "HistMissingMatch2DTOF", 100, -10, 10, 100, 0.0, 100.0);
+		dHistMissingMatch2DBCAL = GetOrCreate_Histogram<TH2F>("HistMissingMatch2DBCAL", "HistMissingMatch2DBCAL", 100, -10, 10, 100, 0.0, 100.0);
+
+		dHistMissingMatchDistTOF = GetOrCreate_Histogram<TH1F>("HistMissingMatchDistTOF", "HistMissingMatchDistTOF", 100, 0.0, 100.0);
+		dHistMissingMatchDistBCAL = GetOrCreate_Histogram<TH1F>("HistMissingMatchDistBCAL", "HistMissingMatchDistBCAL", 100, 0.0, 100.0);
+		ChangeTo_BaseDirectory();
+	}
+	japp->RootUnLock(); //RELEASE ROOT LOCK!!
+
+	// repeated in Run_Update() for possible CCDB updates each run(?)
+        const DParticleID* locParticleID = NULL;
+        locEventLoop->GetSingle(locParticleID);
+        dParticleID = locParticleID;
+
+	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	bfield = dapp->GetBfield((locEventLoop->GetJEvent()).GetRunNumber());
+	rt = new DReferenceTrajectory(bfield);
+
+	locEventLoop->GetSingle(dAnalysisUtilities);
+}
+
+bool DCustomAction_MissingMatch::Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo)
+{       
+	// distance of best match to TOF and BCAL
+	double locBestMissingMatchDistTOF = 999;
+	double locBestMissingMatchDistBCAL = 999;
+
+	// get missing particle
+	vector<const DKinematicData*> locMissingParticles = locParticleCombo->Get_MissingParticles(Get_Reaction());
+	if(locMissingParticles.empty()) return false;
+
+	const DKinematicData *locMissing = locMissingParticles[0];
+        DVector3 locMissingPosition = locMissing->position();
+	DVector3 locMissingMomentum = locMissing->momentum();
+	double locInputStartTime = locParticleCombo->Get_EventVertex().T();
+
+	rt->Reset();
+	rt->Swim(locMissingPosition, locMissingMomentum, locMissing->charge());
+
+	/*
+	// try with MC track for PiPlus?
+	vector<const DMCThrown*> locMCThrowns;
+	locEventLoop->Get(locMCThrowns);
+	DVector3 locMCThrownPosition;
+	DVector3 locMCThrownMomentum;
+	double locMCThrownTime;
+	for(size_t loc_i=0; loc_i<locMCThrowns.size(); loc_i++) {
+		if(locMCThrowns[loc_i]->PID() == locMissing->PID()) {
+			locMCThrownPosition = locMCThrowns[loc_i]->position();
+			locMCThrownMomentum = locMCThrowns[loc_i]->momentum();
+			locMCThrownTime = locMCThrowns[loc_i]->time();
+			break;
+		}
+	}
+	
+	locMissingPosition.Print();
+	locMCThrownPosition.Print();
+	locMissingMomentum.Print();
+	locMCThrownMomentum.Print();
+	cout<<locInputStartTime<<" "<<locMCThrownTime<<endl;
+
+	cout<<"MCThrown"<<endl;
+	locMCThrownMomentum.Print();
+
+	rt->Swim(locMCThrownPosition, locMCThrownMomentum, locMissing->charge());
+	*/
+
+	// compute distance from unused BCAL showers
+	vector<const DNeutralShower*> locUnusedNeutralShowers;
+	dAnalysisUtilities->Get_UnusedNeutralShowers(locEventLoop, locParticleCombo, locUnusedNeutralShowers);
+	for(size_t loc_i=0; loc_i<locUnusedNeutralShowers.size(); loc_i++) {
+		if(locUnusedNeutralShowers[loc_i]->dDetectorSystem != SYS_BCAL) continue;
+		
+		const DBCALShower *locBCALShower;
+		locUnusedNeutralShowers[loc_i]->GetSingle(locBCALShower);
+
+		shared_ptr<DBCALShowerMatchParams>locShowerMatchParams;
+		DVector3 locOutputProjPos, locOutputProjMom;
+		if(dParticleID->Distance_ToTrack(rt, locBCALShower, locInputStartTime, locShowerMatchParams, &locOutputProjPos, &locOutputProjMom)) {
+
+			double locDeltaT = locBCALShower->t - locShowerMatchParams->dFlightTime - locInputStartTime;
+			double locMissingMatchDist = locShowerMatchParams->Get_DistanceToTrack();
+			dHistMissingMatch2DBCAL->Fill(locDeltaT, locMissingMatchDist);
+
+			if(fabs(locDeltaT) > 1.0) continue;
+
+			// keep best matched BCAL hit
+			if(locMissingMatchDist < locBestMissingMatchDistBCAL) 
+				locBestMissingMatchDistBCAL = locMissingMatchDist;
+		}
+	}
+
+	// Replace with Get_UnusedTOFPoints function to match custom DEventWriter...
+
+	// compute distance from TOF
+	vector<const DTOFPoint*> locTOFPoints;
+	locEventLoop->Get(locTOFPoints);
+	for(size_t loc_i=0; loc_i<locTOFPoints.size(); loc_i++) {
+		
+		// check if TOF point is used by another measured track
+		bool locIsTOFPointUsed = false;
+		for(size_t loc_j = 0; loc_j < dChargedIndices.size(); ++loc_j) {
+			const DParticleComboStep* locParticleComboStep = locParticleCombo->Get_ParticleComboStep(0);
+			auto locParticle = Get_UseKinFitResultsFlag() ? locParticleComboStep->Get_FinalParticle(dChargedIndices[loc_j]) : locParticleComboStep->Get_FinalParticle_Measured(dChargedIndices[loc_j]);
+			const DChargedTrack* locChargedTrack = static_cast<const DChargedTrack*>(locParticleComboStep->Get_FinalParticle_SourceObject(dChargedIndices[loc_j]));
+			const DChargedTrackHypothesis* locChargedTrackHypothesis = locChargedTrack->Get_Hypothesis(locParticle->PID());
+			
+			if(locChargedTrackHypothesis->Get_TOFHitMatchParams() == nullptr) continue;
+			const DTOFPoint *locUsedTOFPoint = locChargedTrackHypothesis->Get_TOFHitMatchParams()->dTOFPoint;
+			if(locUsedTOFPoint == locTOFPoints[loc_i]) {
+				locIsTOFPointUsed = true;
+				break;
+			}
+		}
+		if(locIsTOFPointUsed) continue;
+
+		shared_ptr<DTOFHitMatchParams>locHitMatchParams;
+		DVector3 locOutputProjPos, locOutputProjMom;
+		
+		if(dParticleID->Distance_ToTrack(rt, locTOFPoints[loc_i], locInputStartTime, locHitMatchParams, &locOutputProjPos, &locOutputProjMom)) {
+
+			double locDeltaT = locHitMatchParams->dHitTime - locHitMatchParams->dFlightTime - locInputStartTime;
+			double locMissingMatchDist = locHitMatchParams->Get_DistanceToTrack();
+			dHistMissingMatch2DTOF->Fill(locDeltaT, locMissingMatchDist);
+
+			if(fabs(locDeltaT) > 0.3) continue;
+
+			// keep best matched TOF hit
+			if(locMissingMatchDist < locBestMissingMatchDistTOF) 
+				locBestMissingMatchDistTOF = locMissingMatchDist;
+		}
+	}
+	
+	Lock_Action(); //ACQUIRE ROOT LOCK!!
+	{
+		dHistMissingMatchDistTOF->Fill(locBestMissingMatchDistTOF);
+		dHistMissingMatchDistBCAL->Fill(locBestMissingMatchDistBCAL);
+	}
+	Unlock_Action(); //RELEASE ROOT LOCK!!
+
+	return true; //return false if you want to use this action to apply a cut (and it fails the cut!)
+}

--- a/src/plugins/Analysis/ReactionEfficiency/DCustomAction_MissingMatch.h
+++ b/src/plugins/Analysis/ReactionEfficiency/DCustomAction_MissingMatch.h
@@ -1,0 +1,64 @@
+// $Id$
+//
+//    File: DCustomAction_MissingMatch.h
+// Created: Wed Jun 19 17:20:17 EDT 2019
+// Creator: jrsteven (on Linux ifarm1402.jlab.org 3.10.0-327.el7.x86_64 x86_64)
+//
+
+#ifndef _DCustomAction_MissingMatch_
+#define _DCustomAction_MissingMatch_
+
+#include <string>
+#include <iostream>
+
+#include "JANA/JEventLoop.h"
+#include "JANA/JApplication.h"
+
+#include "ANALYSIS/DAnalysisAction.h"
+#include "ANALYSIS/DReaction.h"
+#include "ANALYSIS/DParticleCombo.h"
+#include "ANALYSIS/DAnalysisUtilities.h"
+
+using namespace std;
+using namespace jana;
+
+class DCustomAction_MissingMatch : public DAnalysisAction
+{
+	public:
+
+        DCustomAction_MissingMatch(const DReaction* locReaction, bool locUseKinFitResultsFlag, deque<int> locChargedIndices, string locActionUniqueString = "") : 
+	DAnalysisAction(locReaction, "Custom_MissingMatch", locUseKinFitResultsFlag, locActionUniqueString), dChargedIndices(locChargedIndices) {}
+
+		void Initialize(JEventLoop* locEventLoop);
+		void Run_Update(JEventLoop* locEventLoop) {
+			const DParticleID* locParticleID = NULL;
+			locEventLoop->GetSingle(locParticleID);
+			dParticleID = locParticleID;
+
+			DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+			bfield = dapp->GetBfield((locEventLoop->GetJEvent()).GetRunNumber());
+			rt = new DReferenceTrajectory(bfield);
+ 
+			locEventLoop->GetSingle(dAnalysisUtilities); 
+		}
+
+		void Reset_NewEvent(void){}; //RESET HISTOGRAM DUPLICATE-CHECK TRACKING HERE!!
+	private:
+
+		bool Perform_Action(JEventLoop* locEventLoop, const DParticleCombo* locParticleCombo);
+
+                const DParticleID* dParticleID;
+		const DMagneticFieldMap *bfield;
+		DReferenceTrajectory *rt;
+
+		const DAnalysisUtilities* dAnalysisUtilities;
+
+		//Store any histograms as member variables here
+		deque<int> dChargedIndices;
+		
+		TH2F *dHistMissingMatch2DTOF, *dHistMissingMatch2DBCAL;
+		TH1F *dHistMissingMatchDistTOF, *dHistMissingMatchDistBCAL;
+};
+
+#endif // _DCustomAction_MissingMatch_
+

--- a/src/plugins/Analysis/ReactionEfficiency/DEventProcessor_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DEventProcessor_ReactionEfficiency.cc
@@ -6,6 +6,7 @@
 //
 
 #include "DEventProcessor_ReactionEfficiency.h"
+#include "DEventWriterROOT_ReactionEfficiency.h"
 
 // Routine used to create our DEventProcessor
 
@@ -71,8 +72,8 @@ jerror_t DEventProcessor_ReactionEfficiency::evnt(jana::JEventLoop* locEventLoop
 		//If no cuts are performed by the analysis actions added to a DReaction, then this saves all of its particle combinations. 
 		//The event writer gets the DAnalysisResults objects from JANA, performing the analysis. 
 	// string is DReaction factory tag: will fill trees for all DReactions that are defined in the specified factory
-	const DEventWriterROOT* locEventWriterROOT = NULL;
-	locEventLoop->GetSingle(locEventWriterROOT);
+	const DEventWriterROOT_ReactionEfficiency* locEventWriterROOT = NULL;
+	locEventLoop->GetSingle(locEventWriterROOT, "ReactionEfficiency");
 	locEventWriterROOT->Fill_DataTrees(locEventLoop, "ReactionEfficiency");
 
 	return NOERROR;

--- a/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_ReactionEfficiency.cc
@@ -1,0 +1,121 @@
+// $Id$
+//
+//    File: DEventWriterROOT_ReactionEfficiency.cc
+// Created: Sat Jun 10 10:20:19 EDT 2023
+// Creator: jrsteven (on Linux ifarm1901.jlab.org 3.10.0-1160.90.1.el7.x86_64 x86_64)
+//
+
+#include "DEventWriterROOT_ReactionEfficiency.h"
+
+//GLUEX TTREE DOCUMENTATION: https://halldweb.jlab.org/wiki/index.php/Analysis_TTreeFormat
+
+void DEventWriterROOT_ReactionEfficiency::Run_Update_Custom(JEventLoop* locEventLoop)
+{
+	const DParticleID* locParticleID = NULL;
+	locEventLoop->GetSingle(locParticleID);
+	dParticleID = locParticleID;
+	
+	DApplication* dapp=dynamic_cast<DApplication*>(locEventLoop->GetJApplication());
+	bfield = dapp->GetBfield((locEventLoop->GetJEvent()).GetRunNumber());
+	rt = new DReferenceTrajectory(bfield);
+}
+
+void DEventWriterROOT_ReactionEfficiency::Create_CustomBranches_DataTree(DTreeBranchRegister& locBranchRegister, JEventLoop* locEventLoop, const DReaction* locReaction, bool locIsMCDataFlag) const
+{
+	//EXAMPLES: Create a branch to hold an array of fundamental type:
+	//If filling for a specific particle, the branch name should match the particle branch name
+	//locArraySizeString is the name of the branch whose variable that contains the size of the array for that tree entry
+		//To match the default TTree branches, use either: 'NumThrown', 'NumBeam', 'NumChargedHypos', 'NumNeutralHypos', or 'NumCombos', as appropriate
+	unsigned int locInitArraySize = 50; //if too small, will auto-increase as needed, but requires new calls //if too large, uses more memory than needed
+	locBranchRegister.Register_FundamentalArray<Float_t>("BestMissingMatchDistTOF", "NumCombos", locInitArraySize);
+	locBranchRegister.Register_FundamentalArray<Float_t>("BestMissingMatchDistBCAL", "NumCombos", locInitArraySize);
+}
+
+void DEventWriterROOT_ReactionEfficiency::Create_CustomBranches_ThrownTree(DTreeBranchRegister& locBranchRegister, JEventLoop* locEventLoop) const
+{
+	//EXAMPLES: See Create_CustomBranches_DataTree
+}
+
+void DEventWriterROOT_ReactionEfficiency::Fill_CustomBranches_DataTree(DTreeFillData* locTreeFillData, JEventLoop* locEventLoop, const DReaction* locReaction, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
+	const DMCThrownMatching* locMCThrownMatching, const DDetectorMatches* locDetectorMatches,
+	const vector<const DBeamPhoton*>& locBeamPhotons, const vector<const DChargedTrackHypothesis*>& locChargedHypos,
+	const vector<const DNeutralParticleHypothesis*>& locNeutralHypos, const deque<const DParticleCombo*>& locParticleCombos) const
+{
+	//The array indices of the particles/combos in the main TTree branches match the vectors of objects passed into this function
+		//So if you want to add custom data for each (e.g.) charged track, the correspondence to the main arrays is 1 <--> 1
+
+	for(size_t loc_icombo=0; loc_icombo<locParticleCombos.size(); loc_icombo++) {
+		const DParticleCombo* locParticleCombo = locParticleCombos[loc_icombo];
+		
+		// distance of best match to TOF and BCAL
+		double locBestMissingMatchDistTOF = 999;
+		double locBestMissingMatchDistBCAL = 999;
+		
+		// get missing particle
+		vector<const DKinematicData*> locMissingParticles = locParticleCombo->Get_MissingParticles(locReaction);
+		if(locMissingParticles.empty()) return;
+		
+		const DKinematicData *locMissing = locMissingParticles[0];
+		DVector3 locMissingPosition = locMissing->position();
+		DVector3 locMissingMomentum = locMissing->momentum();
+		double locInputStartTime = locParticleCombo->Get_EventVertex().T();
+		
+		rt->Reset();
+		rt->Swim(locMissingPosition, locMissingMomentum, locMissing->charge());
+		
+		// compute distance from unused BCAL showers
+		vector<const DNeutralShower*> locUnusedNeutralShowers;
+		dAnalysisUtilities->Get_UnusedNeutralShowers(locEventLoop, locParticleCombo, locUnusedNeutralShowers);
+		for(size_t loc_i=0; loc_i<locUnusedNeutralShowers.size(); loc_i++) {
+			if(locUnusedNeutralShowers[loc_i]->dDetectorSystem != SYS_BCAL) continue;
+			
+			const DBCALShower *locBCALShower;
+			locUnusedNeutralShowers[loc_i]->GetSingle(locBCALShower);
+			
+			shared_ptr<DBCALShowerMatchParams>locShowerMatchParams;
+			DVector3 locOutputProjPos, locOutputProjMom;
+			if(dParticleID->Distance_ToTrack(rt, locBCALShower, locInputStartTime, locShowerMatchParams, &locOutputProjPos, &locOutputProjMom)) {
+				
+				double locDeltaT = locBCALShower->t - locShowerMatchParams->dFlightTime - locInputStartTime;
+				double locMissingMatchDist = locShowerMatchParams->Get_DistanceToTrack();
+				
+				if(fabs(locDeltaT) > 1.0) continue;
+				
+				// keep best matched BCAL hit
+				if(locMissingMatchDist < locBestMissingMatchDistBCAL) 
+					locBestMissingMatchDistBCAL = locMissingMatchDist;
+			}
+		}
+		
+		vector<const DTOFPoint*> locUnusedTOFPoints;
+		dAnalysisUtilities->Get_UnusedTOFPoints(locEventLoop, locParticleCombo, locUnusedTOFPoints);
+		for(size_t loc_i=0; loc_i<locUnusedTOFPoints.size(); loc_i++) {
+
+			shared_ptr<DTOFHitMatchParams>locHitMatchParams;
+			DVector3 locOutputProjPos, locOutputProjMom;
+		
+			////////////////////////////////////////////////////////////////////////
+			if(dParticleID->Distance_ToTrack(rt, locUnusedTOFPoints[loc_i], locInputStartTime, locHitMatchParams, &locOutputProjPos, &locOutputProjMom)) {
+				
+				double locDeltaT = locHitMatchParams->dHitTime - locHitMatchParams->dFlightTime - locInputStartTime;
+				double locMissingMatchDist = locHitMatchParams->Get_DistanceToTrack();
+				
+				if(fabs(locDeltaT) > 0.3) continue;
+				
+				// keep best matched TOF hit
+				if(locMissingMatchDist < locBestMissingMatchDistTOF) 
+					locBestMissingMatchDistTOF = locMissingMatchDist;
+			}
+		}
+		
+		locTreeFillData->Fill_Array<Float_t>("BestMissingMatchDistTOF", locBestMissingMatchDistTOF, loc_icombo);
+		locTreeFillData->Fill_Array<Float_t>("BestMissingMatchDistBCAL", locBestMissingMatchDistBCAL, loc_icombo);
+	}
+
+}
+
+void DEventWriterROOT_ReactionEfficiency::Fill_CustomBranches_ThrownTree(DTreeFillData* locTreeFillData, JEventLoop* locEventLoop, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns) const
+{
+	//EXAMPLES: See Fill_CustomBranches_DataTree
+}
+

--- a/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_ReactionEfficiency.h
+++ b/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_ReactionEfficiency.h
@@ -1,0 +1,45 @@
+// $Id$
+//
+//    File: DEventWriterROOT_ReactionEfficiency.h
+// Created: Sat Jun 10 10:20:19 EDT 2023
+// Creator: jrsteven (on Linux ifarm1901.jlab.org 3.10.0-1160.90.1.el7.x86_64 x86_64)
+//
+
+#ifndef _DEventWriterROOT_ReactionEfficiency_
+#define _DEventWriterROOT_ReactionEfficiency_
+
+#include <map>
+#include <string>
+
+#include <ANALYSIS/DEventWriterROOT.h>
+
+using namespace std;
+using namespace jana;
+
+class DEventWriterROOT_ReactionEfficiency : public DEventWriterROOT
+{
+	public:
+		virtual ~DEventWriterROOT_ReactionEfficiency(void){};
+		void Run_Update_Custom(JEventLoop* locEventLoop);
+
+	protected:
+
+		//CUSTOM FUNCTIONS: //Inherit from this class and write custom code in these functions
+
+		virtual void Create_CustomBranches_ThrownTree(DTreeBranchRegister& locBranchRegister, JEventLoop* locEventLoop) const;
+		virtual void Fill_CustomBranches_ThrownTree(DTreeFillData* locTreeFillData, JEventLoop* locEventLoop, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns) const;
+
+		virtual void Create_CustomBranches_DataTree(DTreeBranchRegister& locBranchRegister, JEventLoop* locEventLoop, const DReaction* locReaction, bool locIsMCDataFlag) const;
+		virtual void Fill_CustomBranches_DataTree(DTreeFillData* locTreeFillData, JEventLoop* locEventLoop, const DReaction* locReaction, const DMCReaction* locMCReaction, const vector<const DMCThrown*>& locMCThrowns,
+				const DMCThrownMatching* locMCThrownMatching, const DDetectorMatches* locDetectorMatches,
+				const vector<const DBeamPhoton*>& locBeamPhotons, const vector<const DChargedTrackHypothesis*>& locChargedHypos,
+				const vector<const DNeutralParticleHypothesis*>& locNeutralHypos, const deque<const DParticleCombo*>& locParticleCombos) const;		
+
+	private:
+
+		const DParticleID* dParticleID;
+		const DMagneticFieldMap *bfield;
+		DReferenceTrajectory *rt;
+};
+
+#endif //_DEventWriterROOT_ReactionEfficiency_

--- a/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_factory_ReactionEfficiency.h
+++ b/src/plugins/Analysis/ReactionEfficiency/DEventWriterROOT_factory_ReactionEfficiency.h
@@ -1,0 +1,71 @@
+// $Id$
+//
+//    File: DEventWriterROOT_factory_ReactionEfficiency.h
+// Created: Sat Jun 10 10:20:19 EDT 2023
+// Creator: jrsteven (on Linux ifarm1901.jlab.org 3.10.0-1160.90.1.el7.x86_64 x86_64)
+//
+
+#ifndef _DEventWriterROOT_factory_ReactionEfficiency_
+#define _DEventWriterROOT_factory_ReactionEfficiency_
+
+#include <JANA/JFactory.h>
+#include <JANA/JEventLoop.h>
+
+#include "DEventWriterROOT_ReactionEfficiency.h"
+
+class DEventWriterROOT_factory_ReactionEfficiency : public jana::JFactory<DEventWriterROOT>
+{
+	public:
+		DEventWriterROOT_factory_ReactionEfficiency(){use_factory = 1;}; //prevents JANA from searching the input file for these objects
+		~DEventWriterROOT_factory_ReactionEfficiency(){};
+		const char* Tag(void){return "ReactionEfficiency";}
+
+		DEventWriterROOT_ReactionEfficiency *dROOTEventWriter = nullptr;
+
+        private:
+
+                //------------------
+                // brun
+                //------------------
+                jerror_t brun(JEventLoop *loop, int32_t runnumber)
+                {
+                        // (See DTAGHGeometry_factory.h)
+                        SetFactoryFlag(NOT_OBJECT_OWNER);
+                        ClearFactoryFlag(WRITE_TO_OUTPUT);
+
+                        if( dROOTEventWriter == nullptr ) {
+                                dROOTEventWriter = new DEventWriterROOT_ReactionEfficiency();
+                                dROOTEventWriter->Initialize(loop);
+				dROOTEventWriter->Run_Update_Custom(loop);
+                        } else {
+                                dROOTEventWriter->Run_Update(loop);
+				dROOTEventWriter->Run_Update_Custom(loop);
+                        }
+
+                        return NOERROR;
+                }
+
+                //------------------
+                // evnt
+                //------------------
+                 jerror_t evnt(JEventLoop *loop, uint64_t eventnumber)
+                 {
+                        // Reuse existing DBCALGeometry object.
+                        if( dROOTEventWriter ) _data.push_back( dROOTEventWriter );
+
+                        return NOERROR;
+                 }
+
+
+		 //------------------
+                // fini
+                //------------------
+                jerror_t fini(void)
+                {
+                        // Delete object: Must be "this" thread so that interfaces deleted properly
+                        delete dROOTEventWriter;
+                        return NOERROR;
+                }
+};
+
+#endif // _DEventWriterROOT_factory_ReactionEfficiency_

--- a/src/plugins/Analysis/ReactionEfficiency/DFactoryGenerator_ReactionEfficiency.h
+++ b/src/plugins/Analysis/ReactionEfficiency/DFactoryGenerator_ReactionEfficiency.h
@@ -12,6 +12,7 @@
 #include <JANA/JFactoryGenerator.h>
 
 #include "DReaction_factory_ReactionEfficiency.h"
+#include "DEventWriterROOT_factory_ReactionEfficiency.h"
 
 class DFactoryGenerator_ReactionEfficiency : public jana::JFactoryGenerator
 {
@@ -22,6 +23,7 @@ class DFactoryGenerator_ReactionEfficiency : public jana::JFactoryGenerator
 		jerror_t GenerateFactories(jana::JEventLoop* locEventLoop)
 		{
 			locEventLoop->AddFactory(new DReaction_factory_ReactionEfficiency());
+			locEventLoop->AddFactory(new DEventWriterROOT_factory_ReactionEfficiency()); 
 			return NOERROR;
 		}
 };

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
@@ -89,7 +89,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
 
-	_data.push_back(locReaction); //Register the DReaction with the factory
+	//_data.push_back(locReaction); //Register the DReaction with the factory
 
 
 	/**************************************************** pi0pimmisspip__B1_T1_U1_M7_Effic ****************************************************/
@@ -128,7 +128,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
 
-	_data.push_back(locReaction); //Register the DReaction with the factory
+	//_data.push_back(locReaction); //Register the DReaction with the factory
 
 	/**************************************************** pi0pipmisspim__B1_T1_U1_Effic ****************************************************/
 

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
@@ -700,7 +700,6 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	
 	// MISSING MASS SQUARED
 	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 100, -1.0, 4.5, "MM2")); 
-	locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.25, 3.75));
 	
 	_data.push_back(locReaction); //Register the DReaction with the factory
 

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
@@ -81,6 +81,11 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
 
+	// CUSTOM ACTION TO MATCH MISSING TRAJECTORY WITH FAST DETECTOR
+	deque<int> locChargedIndices; locChargedIndices.clear();  
+	locChargedIndices.push_back(1); locChargedIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_MissingMatch(locReaction, true, locChargedIndices, "MissingMatch"));
+
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
 
@@ -114,6 +119,85 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+	// CUSTOM ACTION TO MATCH MISSING TRAJECTORY WITH FAST DETECTOR
+	locChargedIndices.clear();  
+	locChargedIndices.push_back(1); locChargedIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_MissingMatch(locReaction, true, locChargedIndices, "MissingMatch"));
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** pi0pipmisspim__B1_T1_U1_Effic ****************************************************/
+
+	locReaction = new DReaction("pi0pipmisspim__B1_T1_U1_Effic");
+	locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiPlus, Proton}, PiMinus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_KinFitType(d_P4AndVertexFit);
+	locReaction->Set_NumPlusMinusRFBunches(1); // B1
+	locReaction->Set_MaxExtraGoodTracks(1); // T1
+	locReaction->Enable_TTreeOutput("tree_pi0pipmisspim__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+	// KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
+	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+	// CUSTOM ACTION TO MATCH MISSING TRAJECTORY WITH FAST DETECTOR
+	locChargedIndices.clear();  
+	locChargedIndices.push_back(1); locChargedIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_MissingMatch(locReaction, true, locChargedIndices, "MissingMatch"));
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** pi0pimmisspip__B1_T1_U1_Effic ****************************************************/
+
+	locReaction = new DReaction("pi0pimmisspip__B1_T1_U1_Effic");
+	locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiMinus, Proton}, PiPlus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_KinFitType(d_P4AndVertexFit);
+	locReaction->Set_NumPlusMinusRFBunches(1); // B1
+	locReaction->Set_MaxExtraGoodTracks(1); // T1
+	locReaction->Enable_TTreeOutput("tree_pi0pimmisspip__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+	// KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
+	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+	// CUSTOM ACTION TO MATCH MISSING TRAJECTORY WITH FAST DETECTOR
+	locChargedIndices.clear();  
+	locChargedIndices.push_back(1); locChargedIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_MissingMatch(locReaction, true, locChargedIndices, "MissingMatch"));
 
 	// HISTOGRAM MASSES //false/true: measured/kinfit data
 	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
@@ -511,9 +595,9 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	_data.push_back(locReaction); //Register the DReaction with the factory
 
 
-	/**************************************************** pi0lambkpmiss__B1_T1_U1_Effic ****************************************************/
+	/**************************************************** pi0lambmisskp__B1_T1_U1_Effic ****************************************************/
 	
-	locReaction = new DReaction("pi0lambkpmiss__B1_T1_U1_Effic");
+	locReaction = new DReaction("pi0lambmisskp__B1_T1_U1_Effic");
 	locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiMinus, Proton}, KPlus);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
@@ -525,7 +609,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	locReaction->Set_KinFitType(d_P4AndVertexFit);
 	locReaction->Set_NumPlusMinusRFBunches(1); // B1
 	locReaction->Set_MaxExtraGoodTracks(1); // T1
-	locReaction->Enable_TTreeOutput("tree_pi0lambkpmiss__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+	locReaction->Enable_TTreeOutput("tree_pi0lambmisskp__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
@@ -544,9 +628,9 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	_data.push_back(locReaction); //Register the DReaction with the factory
 
 	
-	/**************************************************** pi0lambpmiss__B1_T1_U1_Effic ****************************************************/
+	/**************************************************** pi0kplambmissprot__B1_T1_U1_Effic ****************************************************/
 	
-	locReaction = new DReaction("pi0lambpmiss__B1_T1_U1_Effic");
+	locReaction = new DReaction("pi0kplambmissprot__B1_T1_U1_Effic");
 	locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiMinus, KPlus}, Proton);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
@@ -558,7 +642,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	locReaction->Set_KinFitType(d_P4AndVertexFit);
 	locReaction->Set_NumPlusMinusRFBunches(1); // B1
 	locReaction->Set_MaxExtraGoodTracks(1); // T1
-	locReaction->Enable_TTreeOutput("tree_pi0lambpmiss__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+	locReaction->Enable_TTreeOutput("tree_pi0kplambmissprot__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
@@ -571,9 +655,9 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	_data.push_back(locReaction); //Register the DReaction with the factory
 
 
-	/**************************************************** pi0lambpimmiss__B1_T1_U1_Effic ****************************************************/
+	/**************************************************** pi0kplambmisspim__B1_T1_U1_Effic ****************************************************/
 	
-	locReaction = new DReaction("pi0lambpimmiss__B1_T1_U1_Effic");
+	locReaction = new DReaction("pi0kplambmisspim__B1_T1_U1_Effic");
 	locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, KPlus, Proton}, PiMinus);
 	locReaction->Add_ReactionStep(locReactionStep);
 	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
@@ -585,7 +669,7 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 	locReaction->Set_KinFitType(d_P4AndVertexFit);
 	locReaction->Set_NumPlusMinusRFBunches(1); // B1
 	locReaction->Set_MaxExtraGoodTracks(1); // T1
-	locReaction->Enable_TTreeOutput("tree_pi0lambpimmiss__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+	locReaction->Enable_TTreeOutput("tree_pi0kplambmisspim__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
 	
 	// KINEMATIC FIT
 	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
@@ -595,6 +679,108 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
         locRecoilIndices.clear();  locRecoilIndices.push_back(0); locRecoilIndices.push_back(2); // K* = Pi0+KPlus 
 	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.9, 1.3, "LambdaRecoil_KinFit"));
 	
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+
+	/**************************************************** pippippimpimmissprot__B1_T1_U1_Effic ****************************************************/
+	
+	locReaction = new DReaction("pippippimpimmissprot__B1_T1_U1_Effic");
+	locReactionStep = new DReactionStep(Gamma, Proton, {PiPlus, PiPlus, PiMinus, PiMinus}, Proton);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_KinFitType(d_P4AndVertexFit);
+	locReaction->Set_NumPlusMinusRFBunches(1); // B1
+	locReaction->Set_MaxExtraGoodTracks(1); // T1
+	locReaction->Enable_TTreeOutput("tree_pippippimpimmissprot__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+	
+	// KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+	
+	// MISSING MASS SQUARED
+	locReaction->Add_AnalysisAction(new DHistogramAction_MissingMassSquared(locReaction, false, 100, -1.0, 4.5, "MM2")); 
+	locReaction->Add_AnalysisAction(new DCutAction_MissingMassSquared(locReaction, false, -0.25, 3.75));
+	
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+
+	/**************************************************** omegamisspim__B1_T1_U1_Effic ****************************************************/
+
+	locReaction = new DReaction("omegamisspim__B1_T1_U1_Effic");
+	locReactionStep = new DReactionStep(Gamma, Proton, {omega, Pi0, Proton});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReactionStep = new DReactionStep(omega, {Pi0, PiPlus}, PiMinus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_KinFitType(d_P4AndVertexFit);
+	locReaction->Set_NumPlusMinusRFBunches(1); // B1
+	locReaction->Set_MaxExtraGoodTracks(1); // T1
+	locReaction->Enable_TTreeOutput("tree_omegapi0misspim__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+	// KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
+	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.8, 1.6, "b1Recoil"));
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.8, 1.6, "b1Recoil_KinFit"));
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
+	_data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** omegapi0misspip__B1_T1_U1_Effic ****************************************************/
+
+	locReaction = new DReaction("omegapi0misspip__B1_T1_U1_Effic");
+	locReactionStep = new DReactionStep(Gamma, Proton, {omega, Pi0, Proton});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReactionStep = new DReactionStep(omega, {Pi0, PiMinus}, PiPlus);
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+	locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+	locReaction->Add_ReactionStep(locReactionStep);
+	dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+	locReaction->Set_KinFitType(d_P4AndVertexFit);
+	locReaction->Set_NumPlusMinusRFBunches(1); // B1
+	locReaction->Set_MaxExtraGoodTracks(1); // T1
+	locReaction->Enable_TTreeOutput("tree_omegapi0misspip__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+	// KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+	locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
+	locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.8, 1.6, "b1Recoil"));
+	locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.8, 1.6, "b1Recoil_KinFit"));
+
+	// HISTOGRAM MASSES //false/true: measured/kinfit data
+	locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
 	_data.push_back(locReaction); //Register the DReaction with the factory
 
 	return NOERROR;

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.cc
@@ -120,6 +120,121 @@ jerror_t DReaction_factory_ReactionEfficiency::evnt(JEventLoop* locEventLoop, ui
 
 	_data.push_back(locReaction); //Register the DReaction with the factory
 
+
+	/**************************************************** pippimmisspi0__B1_T1_U1_M7_Effic ****************************************************/
+
+        locReaction = new DReaction("pippimmisspi0__B1_T1_U1_M7_Effic");
+        locReactionStep = new DReactionStep(Gamma, Proton, {PiPlus, PiMinus, Proton}, Pi0);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+        locReaction->Set_KinFitType(d_P4AndVertexFit);
+        locReaction->Set_NumPlusMinusRFBunches(1); // B1
+        locReaction->Set_MaxExtraGoodTracks(1); // T1
+        locReaction->Enable_TTreeOutput("tree_pippimmisspi0__B1_T1_U1_M7_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+        // KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+        locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+        // CUSTOM ACTION TO REDUCE OUTPUT SIZE
+        locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+        _data.push_back(locReaction); //Register the DReaction with the factory
+
+
+	/**************************************************** pippimpi0__B1_T1_U1_M7_Effic ****************************************************/
+        // exclusive pi+ pi- pi0 w/ no pi0 mass constraint
+        locReaction = new DReaction("pippimpi0__B1_T1_U1_M7_Effic");
+        locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiPlus, PiMinus, Proton});
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+        locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+        locReactionStep->Set_KinFitConstrainInitMassFlag(false);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+        locReaction->Set_KinFitType(d_P4AndVertexFit);
+        locReaction->Set_NumPlusMinusRFBunches(1); // B1
+        locReaction->Set_MaxExtraGoodTracks(1); // T1
+        locReaction->Enable_TTreeOutput("tree_pippimpi0__B1_T1_U1_M7_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+        // HISTOGRAM MASSES //false/true: measured/kinfit data
+        locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+        // KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+        locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+        // CUSTOM ACTION TO REDUCE OUTPUT SIZE
+        locRecoilIndices.clear();  locRecoilIndices.push_back(3);
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+        // HISTOGRAM MASSES //false/true: measured/kinfit data
+        locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
+        _data.push_back(locReaction); //Register the DReaction with the factory
+	
+	
+	/**************************************************** pippimpi0__B1_T1_U1_Effic ****************************************************/
+        // exclusive pi+ pi- pi0 w/ pi0 mass constraint
+        locReaction = new DReaction("pippimpi0__B1_T1_U1_Effic");
+        locReactionStep = new DReactionStep(Gamma, Proton, {Pi0, PiPlus, PiMinus, Proton});
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+        locReactionStep = new DReactionStep(Pi0, {Gamma, Gamma});
+        locReactionStep->Set_KinFitConstrainInitMassFlag(true);
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+        locReaction->Set_KinFitType(d_P4AndVertexFit);
+        locReaction->Set_NumPlusMinusRFBunches(1); // B1
+        locReaction->Set_MaxExtraGoodTracks(1); // T1
+        locReaction->Enable_TTreeOutput("tree_pippimpi0__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+        // HISTOGRAM MASSES //false/true: measured/kinfit data
+        locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PreKinFit"));
+
+        // KINEMATIC FIT
+	locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+        locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+        // CUSTOM ACTION TO REDUCE OUTPUT SIZE
+        locRecoilIndices.clear();  locRecoilIndices.push_back(3);
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+        // HISTOGRAM MASSES //false/true: measured/kinfit data
+        locReaction->Add_AnalysisAction(new DHistogramAction_InvariantMass(locReaction, Pi0, false, 600, 0.0, 0.3, "Pi0_PostKinFit"));
+
+        _data.push_back(locReaction); //Register the DReaction with the factory
+
+	/**************************************************** pippim__B1_T1_U1_Effic ****************************************************/
+        locReaction = new DReaction("pippim__B1_T1_U1_Effic");
+        locReactionStep = new DReactionStep(Gamma, Proton, {PiPlus, PiMinus, Proton});
+        locReaction->Add_ReactionStep(locReactionStep);
+        dReactionStepPool.push_back(locReactionStep); //register so will be deleted later: prevent memory leak
+
+        locReaction->Set_KinFitType(d_P4AndVertexFit);
+        locReaction->Set_NumPlusMinusRFBunches(1); // B1
+        locReaction->Set_MaxExtraGoodTracks(1); // T1
+        locReaction->Enable_TTreeOutput("tree_pippim__B1_T1_U1_Effic.root", true); // U1 = true -> true/false: do/don't save unused hypotheses
+
+        // KINEMATIC FIT
+        locReaction->Add_AnalysisAction(new DHistogramAction_KinFitResults(locReaction, 0.05)); //5% confidence level cut on pull histograms only
+        locReaction->Add_AnalysisAction(new DCutAction_KinFitFOM(locReaction, locMinKinFitFOM)); //0% confidence level cut //require kinematic fit converges
+
+	// CUSTOM ACTION TO REDUCE OUTPUT SIZE
+        locRecoilIndices.clear();  locRecoilIndices.push_back(2);
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, false, locRecoilIndices, 0.2, 1.2, "OmegaRecoil"));
+        locReaction->Add_AnalysisAction(new DCustomAction_RecoilMass(locReaction, true, locRecoilIndices, 0.2, 1.2, "OmegaRecoil_KinFit"));
+
+        _data.push_back(locReaction); //Register the DReaction with the factory
+
+
 	/**************************************************** kpkmmissprot__B1_T1_U1_Effic ****************************************************/
 	
 	locReaction = new DReaction("kpkmmissprot__B1_T1_U1_Effic");

--- a/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.h
+++ b/src/plugins/Analysis/ReactionEfficiency/DReaction_factory_ReactionEfficiency.h
@@ -17,6 +17,7 @@
 #include <ANALYSIS/DCutActions.h>
 
 #include "DCustomAction_RecoilMass.h"
+#include "DCustomAction_MissingMatch.h"
 
 using namespace std;
 using namespace jana;


### PR DESCRIPTION
Add reactions to ReactionEfficiency for missing pi0 studies, missing proton against 4 charged pions, etc.  Also include distance from trajectory of missing track projection to TOF and BCAL as additional possible filtering on "found" tracks.