### PR TITLE
Add ctof matching

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -33,6 +33,7 @@
 #include <BCAL/DBCALShower_factory_IU.h>
 #include <START_COUNTER/DSCHit.h>
 #include <TOF/DTOFPoint.h>
+#include <FMWPC/DCTOFPoint.h>
 #include <TRIGGER/DTrigger.h>
 #include <DANA/DApplication.h>
 #include <RF/DRFTime.h>
@@ -76,7 +77,9 @@ class DEventSourceREST:public JEventSource
    jerror_t Extract_DSCHit(hddm_r::HDDM *record,
                     JFactory<DSCHit>* factory);
    jerror_t Extract_DTOFPoint(hddm_r::HDDM *record,
-                    JFactory<DTOFPoint>* factory);
+                    JFactory<DTOFPoint>* factory); 
+   jerror_t Extract_DCTOFPoint(hddm_r::HDDM *record,
+                    JFactory<DCTOFPoint>* factory);
    jerror_t Extract_DFCALShower(hddm_r::HDDM *record,
                     JFactory<DFCALShower>* factory);
    jerror_t Extract_DBCALShower(hddm_r::HDDM *record,

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -92,6 +92,9 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	std::vector<const DTOFPoint*> tofpoints;
 	locEventLoop->Get(tofpoints);
 
+	std::vector<const DCTOFPoint*> ctofpoints;
+	locEventLoop->Get(ctofpoints);
+
 	std::vector<const DSCHit*> starthits;
 	locEventLoop->Get(starthits);
 
@@ -343,7 +346,18 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
         ccal().setDime(ccalshowers[i]->dime);                                                                                             
         ccal().setId(ccalshowers[i]->id);                                                                                                
         ccal().setIdmax(ccalshowers[i]->idmax);                                                                                                
-    }                                                                                                                                            
+    }
+
+    // push any DCTOFPoint objects to the output record
+	for (size_t i=0; i < ctofpoints.size(); i++)
+	{
+		hddm_r::CtofPointList ctof = res().addCtofPoints(1);
+		ctof().setX(ctofpoints[i]->pos(0));
+		ctof().setY(ctofpoints[i]->pos(1));
+		ctof().setZ(ctofpoints[i]->pos(2));
+		ctof().setT(ctofpoints[i]->t);
+		ctof().setDE(ctofpoints[i]->dE);
+	}
 
 	// push any DTOFPoint objects to the output record
 	for (size_t i=0; i < tofpoints.size(); i++)
@@ -589,6 +603,27 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				fcalList().setPathlength(locFCALShowerMatchParamsVector[loc_k]->dPathLength);
 				fcalList().setTflight(locFCALShowerMatchParamsVector[loc_k]->dFlightTime);
 				fcalList().setTflightvar(locFCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
+			}
+
+			vector<shared_ptr<const DCTOFHitMatchParams>> locCTOFHitMatchParamsVector;
+			locDetectorMatches[loc_i]->Get_CTOFMatchParams(tracks[loc_j], locCTOFHitMatchParamsVector);
+			for(size_t loc_k = 0; loc_k < locCTOFHitMatchParamsVector.size(); ++loc_k)
+			{
+				hddm_r::CtofMatchParamsList ctofList = matches().addCtofMatchParamses(1);
+				ctofList().setTrack(loc_j);
+
+				size_t locCTOFindex = 0;
+				for(; locCTOFindex < ctofpoints.size(); ++locCTOFindex)
+				{
+					if(ctofpoints[locCTOFindex] == locCTOFHitMatchParamsVector[loc_k]->dCTOFPoint)
+						break;
+				}
+				ctofList().setHit(locCTOFindex);
+				ctofList().setDEdx(locCTOFHitMatchParamsVector[loc_k]->dEdx);
+				ctofList().setTflight(locCTOFHitMatchParamsVector[loc_k]->dFlightTime);
+
+				ctofList().setDeltax(locCTOFHitMatchParamsVector[loc_k]->dDeltaXToHit);
+				ctofList().setDeltay(locCTOFHitMatchParamsVector[loc_k]->dDeltaYToHit);
 			}
 
 			vector<shared_ptr<const DFCALSingleHitMatchParams>> locFCALSingleHitMatchParamsVector;

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -352,6 +352,7 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 	for (size_t i=0; i < ctofpoints.size(); i++)
 	{
 		hddm_r::CtofPointList ctof = res().addCtofPoints(1);
+		ctof().setBar(ctofpoints[i]->bar);
 		ctof().setX(ctofpoints[i]->pos(0));
 		ctof().setY(ctofpoints[i]->pos(1));
 		ctof().setZ(ctofpoints[i]->pos(2));

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -89,8 +89,8 @@
               sector="int" t="float" dE="float"
               tunit="ns" Eunit="GeV"/>
     <ctofPoint maxOccurs="unbounded" minOccurs="0" jtag="string"
-              x="float" y="float" z="float" t="float" dE="float"
-              lunit="cm" tunit="ns" Eunit="GeV">
+	       bar="int" x="float" y="float" z="float" t="float" dE="float"
+               lunit="cm" tunit="ns" Eunit="GeV">
     </ctofPoint>
     <tofPoint maxOccurs="unbounded" minOccurs="0" jtag="string"
               x="float" y="float" z="float" t="float" dE="float" terr="float"

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -88,6 +88,10 @@
     <startHit maxOccurs="unbounded" minOccurs="0" jtag="string"
               sector="int" t="float" dE="float"
               tunit="ns" Eunit="GeV"/>
+    <ctofPoint maxOccurs="unbounded" minOccurs="0" jtag="string"
+              x="float" y="float" z="float" t="float" dE="float"
+              lunit="cm" tunit="ns" Eunit="GeV">
+    </ctofPoint>
     <tofPoint maxOccurs="unbounded" minOccurs="0" jtag="string"
               x="float" y="float" z="float" t="float" dE="float" terr="float"
               lunit="cm" tunit="ns" Eunit="GeV">
@@ -132,6 +136,11 @@
                 track="int" ehit="float" thit="float"
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
                 tunit="ns" lunit="cm"/>
+      <ctofMatchParams maxOccurs="unbounded" minOccurs="0"
+                track="int" hit="int"
+                dEdx="float" thit="float" ehit="float"
+                deltax="float" deltay="float" tflight="float"
+		tunit="ns" lunit="cm" dEdx_unit="GeV/cm"/>
       <tofMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" hit="int"
                 dEdx="float" thit="float" thitvar="float" ehit="float"

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -137,8 +137,7 @@
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
                 tunit="ns" lunit="cm"/>
       <ctofMatchParams maxOccurs="unbounded" minOccurs="0"
-                track="int" hit="int"
-                dEdx="float" thit="float" ehit="float"
+                track="int" hit="int" dEdx="float" 
                 deltax="float" deltay="float" tflight="float"
 		tunit="ns" lunit="cm" dEdx_unit="GeV/cm"/>
       <tofMatchParams maxOccurs="unbounded" minOccurs="0"

--- a/src/libraries/PID/DChargedTrackHypothesis.h
+++ b/src/libraries/PID/DChargedTrackHypothesis.h
@@ -68,8 +68,7 @@ class DChargedTrackHypothesis : public DKinematicData
 		shared_ptr<const DFCALShowerMatchParams> Get_FCALShowerMatchParams(void) const{return dTrackingInfo->dFCALShowerMatchParams;}
 		shared_ptr<const DFCALSingleHitMatchParams> Get_FCALSingleHitMatchParams(void) const{return dTrackingInfo->dFCALSingleHitMatchParams;}
 		shared_ptr<const DDIRCMatchParams> Get_DIRCMatchParams(void) const{return dTrackingInfo->dDIRCMatchParams;}
-		
-		
+		shared_ptr<const DCTOFHitMatchParams> Get_CTOFHitMatchParams(void) const{return dTrackingInfo->dCTOFHitMatchParams;}
 
 		//SETTERS
 
@@ -92,7 +91,8 @@ class DChargedTrackHypothesis : public DKinematicData
 		void Set_BCALShowerMatchParams(shared_ptr<const DBCALShowerMatchParams> locMatchParams){dTrackingInfo->dBCALShowerMatchParams = locMatchParams;}
 		void Set_FCALShowerMatchParams(shared_ptr<const DFCALShowerMatchParams> locMatchParams){dTrackingInfo->dFCALShowerMatchParams = locMatchParams;}
 		void Set_FCALSingleHitMatchParams(shared_ptr<const DFCALSingleHitMatchParams> locMatchParams){dTrackingInfo->dFCALSingleHitMatchParams = locMatchParams;}
-		void Set_DIRCMatchParams(shared_ptr<const DDIRCMatchParams> locMatchParams){dTrackingInfo->dDIRCMatchParams = locMatchParams;}
+		void Set_DIRCMatchParams(shared_ptr<const DDIRCMatchParams> locMatchParams){dTrackingInfo->dDIRCMatchParams = locMatchParams;}	
+		void Set_CTOFHitMatchParams(shared_ptr<const DCTOFHitMatchParams> locMatchParams){dTrackingInfo->dCTOFHitMatchParams = locMatchParams;}
 
 		void toStrings(vector<pair<string,string> > &items) const
 		{
@@ -169,7 +169,8 @@ class DChargedTrackHypothesis : public DKinematicData
 				shared_ptr<const DBCALShowerMatchParams> dBCALShowerMatchParams = nullptr;
 				shared_ptr<const DFCALShowerMatchParams> dFCALShowerMatchParams = nullptr;
 				shared_ptr<const DFCALSingleHitMatchParams> dFCALSingleHitMatchParams = nullptr;
-				shared_ptr<const DDIRCMatchParams> dDIRCMatchParams = nullptr;
+				shared_ptr<const DDIRCMatchParams> dDIRCMatchParams = nullptr;	
+				shared_ptr<const DCTOFHitMatchParams> dCTOFHitMatchParams = nullptr;
 		};
 
 	private:
@@ -404,6 +405,7 @@ inline void DChargedTrackHypothesis::DTrackingInfo::Reset(void)
 	dTrackTimeBased = nullptr;
 	dSCHitMatchParams = nullptr;
 	dTOFHitMatchParams = nullptr;
+	dCTOFHitMatchParams = nullptr;
 	dBCALShowerMatchParams = nullptr;
 	dFCALShowerMatchParams = nullptr;
 	dFCALSingleHitMatchParams = nullptr;

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -269,7 +269,8 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 	shared_ptr<const DTOFHitMatchParams> locTOFHitMatchParams;
 	shared_ptr<const DFCALShowerMatchParams> locFCALShowerMatchParams;
 	shared_ptr<const DFCALSingleHitMatchParams> locFCALSingleHitMatchParams;
-	shared_ptr<const DDIRCMatchParams> locDIRCMatchParams;
+	shared_ptr<const DDIRCMatchParams> locDIRCMatchParams;	
+	shared_ptr<const DCTOFHitMatchParams> locCTOFHitMatchParams;
 	if(dPIDAlgorithm->Get_BestBCALMatchParams(locTrackTimeBased, locDetectorMatches, locBCALShowerMatchParams))
 		locChargedTrackHypothesis->Set_BCALShowerMatchParams(locBCALShowerMatchParams);
 	if(dPIDAlgorithm->Get_BestTOFMatchParams(locTrackTimeBased, locDetectorMatches, locTOFHitMatchParams))
@@ -280,6 +281,8 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 		locChargedTrackHypothesis->Set_FCALSingleHitMatchParams(locFCALSingleHitMatchParams);
 	if(dPIDAlgorithm->Get_DIRCMatchParams(locTrackTimeBased, locDetectorMatches, locDIRCMatchParams))
 		locChargedTrackHypothesis->Set_DIRCMatchParams(locDIRCMatchParams);
+	if(dPIDAlgorithm->Get_BestCTOFMatchParams(locTrackTimeBased, locDetectorMatches, locCTOFHitMatchParams))
+	  locChargedTrackHypothesis->Set_CTOFHitMatchParams(locCTOFHitMatchParams);
 
 	//PID
 	if(locChargedTrackHypothesis->t1_detector() == SYS_BCAL)

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -334,6 +334,8 @@ inline bool DDetectorMatches::Get_IsMatchedToHit(const DTrackingData* locTrack) 
 		return true;
 	if(dTrackSCMatchParams.find(locTrack) != dTrackSCMatchParams.end())
 		return true;
+	if(dTrackCTOFMatchParams.find(locTrack) != dTrackCTOFMatchParams.end())
+		return true;
 	return false;
 }
 
@@ -347,6 +349,8 @@ inline bool DDetectorMatches::Get_IsMatchedToDetector(const DTrackingData* locTr
 		return (dTrackTOFMatchParams.find(locTrack) != dTrackTOFMatchParams.end());
 	else if(locDetectorSystem == SYS_START)
 		return (dTrackSCMatchParams.find(locTrack) != dTrackSCMatchParams.end());
+	else if(locDetectorSystem == SYS_CTOF)
+		return (dTrackCTOFMatchParams.find(locTrack) != dTrackCTOFMatchParams.end());
 	else
 		return false;
 }

--- a/src/libraries/PID/DDetectorMatches_factory.cc
+++ b/src/libraries/PID/DDetectorMatches_factory.cc
@@ -66,6 +66,9 @@ DDetectorMatches* DDetectorMatches_factory::Create_DDetectorMatches(jana::JEvent
 	vector<const DDIRCTruthBarHit*> locDIRCBarHits;
 	locEventLoop->Get(locDIRCBarHits);
 
+	vector<const DCTOFPoint*> locCTOFPoints;
+	locEventLoop->Get(locCTOFPoints);
+
 	DDetectorMatches* locDetectorMatches = new DDetectorMatches();
 
 	//Match tracks to showers/hits
@@ -76,6 +79,7 @@ DDetectorMatches* DDetectorMatches_factory::Create_DDetectorMatches(jana::JEvent
 		MatchToFCAL(locParticleID, locTrackTimeBasedVector[loc_i], locFCALShowers, locDetectorMatches);
 		MatchToSC(locParticleID, locTrackTimeBasedVector[loc_i], locSCHits, locDetectorMatches);
 		MatchToDIRC(locParticleID, locTrackTimeBasedVector[loc_i], locDIRCHits, locDetectorMatches, locDIRCBarHits);
+		MatchToCTOF(locParticleID, locTrackTimeBasedVector[loc_i], locCTOFPoints, locDetectorMatches);
 	}
 
 	//Find nearest tracks to showers
@@ -135,6 +139,20 @@ void DDetectorMatches_factory::MatchToBCAL(const DParticleID* locParticleID, con
 	  if(locParticleID->Cut_MatchDistance(extrapolations, locBCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
 	    locDetectorMatches->Add_Match(locTrackTimeBased, locBCALShowers[loc_i], locShowerMatchParams);
 	}
+}
+
+void DDetectorMatches_factory::MatchToCTOF(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DCTOFPoint*>& locCTOFPoints, DDetectorMatches* locDetectorMatches) const
+{
+  vector<DTrackFitter::Extrapolation_t> extrapolations=locTrackTimeBased->extrapolations.at(SYS_CTOF);
+  if (extrapolations.size()==0) return;
+  
+  double locInputStartTime = locTrackTimeBased->t0();
+  for(size_t loc_i = 0; loc_i < locCTOFPoints.size(); ++loc_i)
+    {
+      shared_ptr<DCTOFHitMatchParams> locCTOFHitMatchParams;
+      if(locParticleID->Cut_MatchDistance(extrapolations, locCTOFPoints[loc_i], locInputStartTime, locCTOFHitMatchParams))
+	locDetectorMatches->Add_Match(locTrackTimeBased, locCTOFPoints[loc_i], locCTOFHitMatchParams);
+    }
 }
 
 void DDetectorMatches_factory::MatchToTOF(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DTOFPoint*>& locTOFPoints, DDetectorMatches* locDetectorMatches) const

--- a/src/libraries/PID/DDetectorMatches_factory.h
+++ b/src/libraries/PID/DDetectorMatches_factory.h
@@ -17,6 +17,7 @@
 #include <TRACKING/DTrackTimeBased.h>
 #include <PID/DParticleID.h>
 #include <TOF/DTOFPoint.h>
+#include <FMWPC/DCTOFPoint.h>
 #include <BCAL/DBCALShower.h>
 #include <FCAL/DFCALShower.h>
 #include <DIRC/DDIRCPmtHit.h>
@@ -46,6 +47,7 @@ class DDetectorMatches_factory : public jana::JFactory<DDetectorMatches>
 		void MatchToFCAL(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DFCALShower*>& locFCALShowers, DDetectorMatches* locDetectorMatches) const;
 		void MatchToSC(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DSCHit*>& locSCHits, DDetectorMatches* locDetectorMatches) const;
 		void MatchToDIRC(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DDIRCPmtHit*>& locDIRCHits, DDetectorMatches* locDetectorMatches, const vector<const DDIRCTruthBarHit*>& locDIRCBarHits) const;
+		void MatchToCTOF(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DCTOFPoint*>& locCTOFPoints, DDetectorMatches* locDetectorMatches) const;
 
 		void MatchToFCAL(const DParticleID* locParticleID,
 				 const DTrackTimeBased *locTrackTimeBased,

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -29,6 +29,7 @@
 #include <FCAL/DFCALCluster.h>
 #include <FCAL/DFCALHit.h>
 #include <FCAL/DFCALGeometry_factory.h>
+#include <FMWPC/DCTOFPoint.h>
 #include <TOF/DTOFPoint.h>
 #include <TOF/DTOFPaddleHit.h>
 #include <TOF/DTOFGeometry_factory.h>
@@ -129,6 +130,7 @@ class DParticleID:public jana::JObject
 					const DVector3 &locProjPos) const;
 		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DFCALShower* locFCALShower, double locInputStartTime, shared_ptr<DFCALShowerMatchParams>& locShowerMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
 		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t>&extrapolations, const DTOFPoint* locTOFPoint, double locInputStartTime,shared_ptr<DTOFHitMatchParams>& locTOFHitMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
+		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t>&extrapolations, const DCTOFPoint* locCTOFPoint, double locInputStartTime,shared_ptr<DCTOFHitMatchParams>& locCTOFHitMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
 		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DSCHit* locSCHit, double locInputStartTime,shared_ptr<DSCHitMatchParams>& locSCHitMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
 		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DBCALShower* locBCALShower, double locInputStartTime,shared_ptr<DBCALShowerMatchParams>& locShowerMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
 		bool Distance_ToTrack(double locStartTime,const DTrackFitter::Extrapolation_t &extrapolation,const DFCALHit *locFCALHit,double &locDOCA,double &locHitTime) const;
@@ -143,7 +145,8 @@ class DParticleID:public jana::JObject
 
 		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DBCALShower* locBCALShower, double locInputStartTime,shared_ptr<DBCALShowerMatchParams>& locShowerMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
 		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DFCALShower* locFCALShower, double locInputStartTime,shared_ptr<DFCALShowerMatchParams>& locShowerMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
-		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DTOFPoint* locTOFPoint, double locInputStartTime,shared_ptr<DTOFHitMatchParams>& locTOFHitMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
+		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DTOFPoint* locTOFPoint, double locInputStartTime,shared_ptr<DTOFHitMatchParams>& locTOFHitMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;	
+		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DCTOFPoint* locCTOFPoint, double locInputStartTime,shared_ptr<DCTOFHitMatchParams>& locCTOFHitMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
 		bool Cut_MatchDistance(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DSCHit* locSCHit, double locInputStartTime,shared_ptr<DSCHitMatchParams>& locSCHitMatchParams, bool locIsTimeBased, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
 		bool Cut_MatchDIRC(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const vector<const DDIRCPmtHit*> locDIRCHits, double locInputStartTime, Particle_t locPID, shared_ptr<DDIRCMatchParams>& locDIRCMatchParams, const vector<const DDIRCTruthBarHit*> locDIRCBarHits, map<shared_ptr<const DDIRCMatchParams>, vector<const DDIRCPmtHit*> >& locDIRCTrackMatchParams, DVector3 *locOutputProjPos=nullptr, DVector3 *locOutputProjMom=nullptr) const;
 
@@ -152,7 +155,8 @@ class DParticleID:public jana::JObject
 		// Wrappers
 		bool Get_BestBCALMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DBCALShowerMatchParams>& locBestMatchParams) const;
 		bool Get_BestSCMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DSCHitMatchParams>& locBestMatchParams) const;
-		bool Get_BestTOFMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DTOFHitMatchParams>& locBestMatchParams) const;
+		bool Get_BestTOFMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DTOFHitMatchParams>& locBestMatchParams) const;	
+		bool Get_BestCTOFMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DCTOFHitMatchParams>& locBestMatchParams) const;
 		bool Get_BestFCALMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DFCALShowerMatchParams>& locBestMatchParams) const;
 		bool Get_BestFCALSingleHitMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DFCALSingleHitMatchParams>& locBestMatchParams) const;
 		bool Get_DIRCMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DDIRCMatchParams>& locBestMatchParams) const;
@@ -161,6 +165,7 @@ class DParticleID:public jana::JObject
 		shared_ptr<const DBCALShowerMatchParams> Get_BestBCALMatchParams(DVector3 locMomentum, vector<shared_ptr<const DBCALShowerMatchParams> >& locShowerMatchParams) const;
 		shared_ptr<const DSCHitMatchParams> Get_BestSCMatchParams(vector<shared_ptr<const DSCHitMatchParams> >& locSCHitMatchParams) const;
 		shared_ptr<const DTOFHitMatchParams> Get_BestTOFMatchParams(vector<shared_ptr<const DTOFHitMatchParams> >& locTOFHitMatchParams) const;
+		shared_ptr<const DCTOFHitMatchParams> Get_BestCTOFMatchParams(vector<shared_ptr<const DCTOFHitMatchParams> >& locCTOFHitMatchParams) const;
 		shared_ptr<const DFCALShowerMatchParams> Get_BestFCALMatchParams(vector<shared_ptr<const DFCALShowerMatchParams> >& locShowerMatchParams) const;
 		shared_ptr<const DFCALSingleHitMatchParams> Get_BestFCALSingleHitMatchParams(vector<shared_ptr<const DFCALSingleHitMatchParams> >& locMatchParams) const;
 
@@ -259,6 +264,7 @@ class DParticleID:public jana::JObject
 		double dA_CDC;
 		double dA_FDC;
 
+		double CTOF_MATCH_X_CUT=20.,CTOF_MATCH_Y_CUT=20.0;
 		double BCAL_Z_CUT,BCAL_PHI_CUT_PAR1,BCAL_PHI_CUT_PAR2, BCAL_PHI_CUT_PAR3;
 		double FCAL_CUT_PAR1,FCAL_CUT_PAR2,FCAL_CUT_PAR3;
 		double TOF_CUT_PAR1, TOF_CUT_PAR2, TOF_CUT_PAR3, TOF_CUT_PAR4;


### PR DESCRIPTION
Add DDetector matching object for CTOF points to reconstruction and to REST output.   Right now there is a +-20 cm matching cut in both x and y, configurable by command-line parameters.