### PR TITLE
Fixes memory leak in DCCALShower factory

### DIFF
--- a/src/libraries/CCAL/DCCALShower.h
+++ b/src/libraries/CCAL/DCCALShower.h
@@ -93,6 +93,7 @@ class DCCALShower : public JObject {
 		ClusterType_t ClusterType;
 		PeakType_t PeakType;
       		
+		vector<DCCALHit>hitsInCluster;
 		
 		TMatrixFSym ExyztCovariance;
 		

--- a/src/libraries/CCAL/DCCALShower_factory.cc
+++ b/src/libraries/CCAL/DCCALShower_factory.cc
@@ -398,6 +398,7 @@ jerror_t DCCALShower_factory::evnt(JEventLoop *locEventLoop, uint64_t eventnumbe
 	  
 	  if (VERBOSE>2) {printf("(E,x,y,z,t)    "); shower->ExyztCovariance.Print(); }
 
+	  shower->hitsInCluster.clear();
 	  for( int icell = 0; icell < ccalClusters[k].nhits; icell++ ) {
 	    
 	    int hitID   = clusterStorage[k].id[icell];
@@ -406,15 +407,15 @@ jerror_t DCCALShower_factory::evnt(JEventLoop *locEventLoop, uint64_t eventnumbe
 	    int hitROW  = ccalGeom.row( hitY );
 	    int hitCOL  = ccalGeom.column( hitX );
 	    	    
-	    DCCALHit *clusHit = new DCCALHit;
-	    clusHit->row    = hitROW;
-	    clusHit->column = hitCOL;
-	    clusHit->x      = hitX;
-	    clusHit->y      = hitY;
-	    clusHit->E      = static_cast<float>( 1000.*clusterStorage[k].E[icell] );
-	    clusHit->t      = static_cast<float>( clusterStorage[k].t[icell] );
+	    DCCALHit clusHit;
+	    clusHit.row    = hitROW;
+	    clusHit.column = hitCOL;
+	    clusHit.x      = hitX;
+	    clusHit.y      = hitY;
+	    clusHit.E      = static_cast<float>( 1000.*clusterStorage[k].E[icell] );
+	    clusHit.t      = static_cast<float>( clusterStorage[k].t[icell] );
 	    
-	    shower->AddAssociatedObject( clusHit );
+	    shower->hitsInCluster.push_back( clusHit );
 	    
 	  }
 


### PR DESCRIPTION
Add hits used in a cluster explicitly to the shower object instead of using the AddAssociatedObject mechanism, which was causing a memory leak.