### PR TITLE
Reduce error messages on startup

### DIFF
--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -1769,7 +1769,7 @@ bool DGeometry::GetCCALZ(double &z_ccal) const
 {
    vector<double> ComptonEMcalpos;
    jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
-   bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);\
+   bool good = Get("//section/composition/posXYZ[@volume='ComptonEMcal']/@X_Y_Z", ComptonEMcalpos);
    jgeom->SetVerbose(1);   // reenable error messages
 
    if(!good){
@@ -1791,9 +1791,11 @@ bool DGeometry::GetCCALZ(double &z_ccal) const
 bool DGeometry::GetCTOFZ(double &z) const {
   z=1000; // cm; initialize to a large value
   vector<double> CppScintPos;
+  jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
   bool good = Get("//section/composition/posXYZ[@volume='CppScint']/@X_Y_Z", CppScintPos);
+  jgeom->SetVerbose(1);   // reenable error messages
   if (!good){  
-    _DBG_<<"Unable to retrieve CPP scintillator position."<<endl;
+    //_DBG_<<"Unable to retrieve CPP scintillator position."<<endl;
     return false;
   }
   z=CppScintPos[2];
@@ -1805,7 +1807,9 @@ bool DGeometry::GetCTOFZ(double &z) const {
 //---------------------------------
 bool DGeometry::GetCTOFPositions(vector<DVector3>&posvec) const{
   vector<double>origin;
+  jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
   bool good = Get("//section/composition/posXYZ[@volume='CppScint']/@X_Y_Z",origin);
+  jgeom->SetVerbose(1);   // reenable error messages
   if (!good) return false;
   DVector3 pos(origin[0],origin[1],origin[2]);
   for (unsigned int paddle=1;paddle<5;paddle++){
@@ -1824,7 +1828,9 @@ bool DGeometry::GetCTOFPositions(vector<DVector3>&posvec) const{
 bool DGeometry::GetFMWPCZ_vec(vector<double>&zvec_fmwpc) const
 {
   vector<double> ForwardMWPCpos;
+  jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
   bool good = Get("//section/composition/posXYZ[@volume='ForwardMWPC']/@X_Y_Z", ForwardMWPCpos);
+  jgeom->SetVerbose(1);   // reenable error messages
   if (!good){
     //_DBG_<<"Unable to retrieve ForwardMWPC position."<<endl;
     return false;
@@ -1853,7 +1859,9 @@ bool DGeometry::GetFMWPCZ_vec(vector<double>&zvec_fmwpc) const
 bool DGeometry::GetFMWPCXY_vec(vector<double>&xvec_fmwpc, vector<double>&yvec_fmwpc) const
 {
   vector<double> ForwardMWPCpos;
+  jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
   bool good = Get("//section/composition/posXYZ[@volume='ForwardMWPC']/@X_Y_Z", ForwardMWPCpos);
+  jgeom->SetVerbose(1);   // reenable error messages
   if (!good){
     //_DBG_<<"Unable to retrieve ForwardMWPC position."<<endl;
     return false;
@@ -1906,7 +1914,9 @@ bool DGeometry::GetFMWPCXY_vec(vector<double>&xvec_fmwpc, vector<double>&yvec_fm
 bool DGeometry::GetFMWPCSize(double &xy_fmwpc) const
 {
   vector<double> ForwardMWPCdimensions;
+  jgeom->SetVerbose(0);   // don't print error messages for optional detector elements
   bool good = Get("//section[@name='ForwardMWPC']/box[@name='CPPF']/@X_Y_Z", ForwardMWPCdimensions);
+  jgeom->SetVerbose(1);   // reenable error messages
   if (!good){  
     xy_fmwpc=0.0;
     return false;

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
@@ -72,6 +72,8 @@ jerror_t DL1MCTrigger_factory::init(void)
   SIMU_BASELINE = 1;
   SIMU_GAIN = 0;
   
+  VERBOSE = 0;
+  
 
   simu_baseline_fcal  =  1;
   simu_baseline_bcal  =  1;
@@ -135,6 +137,9 @@ jerror_t DL1MCTrigger_factory::init(void)
 
   gPARMS->SetDefaultParameter("TRIG:SIMU_GAIN", SIMU_GAIN,
 			      "Enable simulation of gain variations");
+			      
+  gPARMS->SetDefaultParameter("TRIG:VERBOSE", VERBOSE,
+			      "Enable more verbose output");
 
 
   BCAL_ADC_PER_MEV_CORRECT  =  22.7273;
@@ -193,10 +198,10 @@ jerror_t DL1MCTrigger_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumb
 
   if(getenv("JANA_CALIB_CONTEXT") != NULL ){ 
     JANA_CALIB_CONTEXT = getenv("JANA_CALIB_CONTEXT");
-    cout << " ---------DL1MCTrigger (Brun): JANA_CALIB_CONTEXT =" << JANA_CALIB_CONTEXT << endl;
+    if(print_messages) cout << " ---------DL1MCTrigger (Brun): JANA_CALIB_CONTEXT =" << JANA_CALIB_CONTEXT << endl;
     if ( (JANA_CALIB_CONTEXT.find("mc_generic") != string::npos)
 	 || (JANA_CALIB_CONTEXT.find("mc_cpp") != string::npos) ){
-      cout << " ---------DL1MCTrigger (Brun): JANA_CALIB_CONTEXT found mc_generic or mc_cpp" << endl;
+      if(print_messages) cout << " ---------DL1MCTrigger (Brun): JANA_CALIB_CONTEXT found mc_generic or mc_cpp" << endl;
       use_rcdb = 0;
       // Don't simulate baseline fluctuations for mc_generic
       simu_baseline_fcal = 0;
@@ -207,7 +212,7 @@ jerror_t DL1MCTrigger_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumb
     }
   }
   else {
-      cout << " ---------**** DL1MCTrigger (Brun): JANA_CALIB_CONTEXT = NULL" << endl;
+      if(print_messages) cout << " ---------**** DL1MCTrigger (Brun): JANA_CALIB_CONTEXT = NULL" << endl;
   }
 
   //  runnumber = 30942;
@@ -946,7 +951,7 @@ int  DL1MCTrigger_factory::Read_RCDB(int32_t runnumber, bool print_messages)
 	    }
 	    
 	    catch(...){
-	      if(print_messages) cout << "Exception: FCAL channel is not in the translation table  " <<  " Crate = " << 10 + crate << "  Slot = " << slot << 
+	      if(VERBOSE && print_messages) cout << "Exception: FCAL channel is not in the translation table  " <<  " Crate = " << 10 + crate << "  Slot = " << slot << 
 		" Channel = " << ch << endl;
 	      continue;
 	    }
@@ -960,7 +965,8 @@ int  DL1MCTrigger_factory::Read_RCDB(int32_t runnumber, bool print_messages)
 	    tmp.row = channel_info.fcal.row;
 	    tmp.col = channel_info.fcal.col;
 	    
-	    cout << " MASKED CHANNEL = " << tmp.row << "   " << tmp.col << endl;
+	    if(VERBOSE)
+	    	cout << " MASKED CHANNEL = " << tmp.row << "   " << tmp.col << endl;
 
 	    fcal_trig_mask.push_back(tmp);
 	  }
@@ -973,7 +979,7 @@ int  DL1MCTrigger_factory::Read_RCDB(int32_t runnumber, bool print_messages)
   }    // Loop over crates       
   
   
-  cout << " NUMBER OF MASKED CHANNELS = " << fcal_trig_mask.size() << endl;
+  if(VERBOSE) cout << " NUMBER OF MASKED CHANNELS = " << fcal_trig_mask.size() << endl;
   
 
   // Load BCAL Trigger Masks

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.h
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.h
@@ -181,6 +181,8 @@ class DL1MCTrigger_factory:public jana::JFactory<DL1MCTrigger>{
 
 		int SIMU_BASELINE;
 		int SIMU_GAIN;
+		
+		int VERBOSE;
 
 
 		double time_shift;

--- a/src/libraries/TRIGGER/DTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DTrigger_factory.cc
@@ -12,7 +12,7 @@ jerror_t DTrigger_factory::init(void)
 	EMULATE_FCAL_LED_TRIGGER = false;
 	EMULATE_BCAL_LED_TRIGGER = false;
 
-    EMULATE_CAL_ENERGY_SUMS = false;
+    EMULATE_CAL_ENERGY_SUMS = true;
 	
 	BCAL_LED_NHITS_THRESHOLD = 200;
 	FCAL_LED_NHITS_THRESHOLD = 200;


### PR DESCRIPTION
Reduce some of the output when the job is starting up to reduce confusion (or at least try to).

Also, reenable a feature for looking at trigger energy sums in data since this seems to be working better now.