### PR TITLE
change code to use only TOF hits with good QF to make sure

### DIFF
--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
@@ -233,6 +233,12 @@ jerror_t JEventProcessor_TOF_calib::evnt(JEventLoop *loop, uint64_t eventnumber)
   memset(th,0,locTOFGeometry->Get_NPlanes()*locTOFGeometry->Get_NBars()*locTOFGeometry->Get_NEnds()*4);
   for (unsigned int k=0; k<ADCHits.size(); k++){
     const DTOFDigiHit *hit = ADCHits[k];
+
+    // only use DigiHits from fADC250 if QF for pedestal is ok
+    if (hit->QF & 0x40){  // pedestal determination failed! do not use this hit!
+      continue;
+    }
+
     int plane = hit->plane;
     int end = hit->end;
 


### PR DESCRIPTION
that the pedestal determination was ok.

This pull request is a small change in the TOF_calib plugin that skimms the tof data using digi hits for
calibration further up. The code has been changed to discard any TOF hit where the QF for the pedestal
determination is set. this means the pedestal determination failed and a "constant" value is subtracted
which comes from CCDB. This value may not be the best. So the prudent course of action is to not use
these hits.