### PR TITLE
Some more updates related to trigger studies

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -167,6 +167,8 @@ void DEventWriterROOT::Create_DataTree(const DReaction* locReaction, JEventLoop*
 	locBranchRegister.Register_Single<UInt_t>("RunNumber");
 	locBranchRegister.Register_Single<ULong64_t>("EventNumber");
 	locBranchRegister.Register_Single<UInt_t>("L1TriggerBits");
+	locBranchRegister.Register_Single<Double_t>("L1BCALEnergy");
+	locBranchRegister.Register_Single<Double_t>("L1FCALEnergy");
 
 	//create X4_Production
 	locBranchRegister.Register_Single<TLorentzVector>("X4_Production");
@@ -1344,6 +1346,9 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	locTreeFillData->Fill_Single<UInt_t>("RunNumber", locEventLoop->GetJEvent().GetRunNumber());
 	locTreeFillData->Fill_Single<ULong64_t>("EventNumber", locEventLoop->GetJEvent().GetEventNumber());
 	locTreeFillData->Fill_Single<UInt_t>("L1TriggerBits", locTrigger->Get_L1TriggerBits());
+	locTreeFillData->Fill_Single<UInt_t>("L1BCALEnergy", locTrigger->Get_GTP_BCALEnergy());
+	locTreeFillData->Fill_Single<UInt_t>("L1FCALEnergy", locTrigger->Get_GTP_FCALEnergy());
+
 
 	//PRODUCTION X4
 	DLorentzVector locProductionX4 = locVertex->dSpacetimeVertex;

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1346,8 +1346,8 @@ void DEventWriterROOT::Fill_DataTree(JEventLoop* locEventLoop, const DReaction* 
 	locTreeFillData->Fill_Single<UInt_t>("RunNumber", locEventLoop->GetJEvent().GetRunNumber());
 	locTreeFillData->Fill_Single<ULong64_t>("EventNumber", locEventLoop->GetJEvent().GetEventNumber());
 	locTreeFillData->Fill_Single<UInt_t>("L1TriggerBits", locTrigger->Get_L1TriggerBits());
-	locTreeFillData->Fill_Single<UInt_t>("L1BCALEnergy", locTrigger->Get_GTP_BCALEnergy());
-	locTreeFillData->Fill_Single<UInt_t>("L1FCALEnergy", locTrigger->Get_GTP_FCALEnergy());
+	locTreeFillData->Fill_Single<Double_t>("L1BCALEnergy", locTrigger->Get_GTP_BCALEnergy());
+	locTreeFillData->Fill_Single<Double_t>("L1FCALEnergy", locTrigger->Get_GTP_FCALEnergy());
 
 
 	//PRODUCTION X4

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.cc
@@ -4032,7 +4032,19 @@ bool DHistogramAction_TriggerStudies::Perform_Action(JEventLoop* locEventLoop, c
 	locEventLoop->GetSingle(locTrigger);
 	if(locTrigger == nullptr)
 		return true;
+		
+	// allow for this histogram to be called for a particular reaction, and then only plot it for 
+	// events that pass some reasonable kinematic fit cut
+ 	if(dKinFitCLCut >= 0.) {
+		const DKinFitResults* locKinFitResults = locParticleCombo->Get_KinFitResults();
+		if(locKinFitResults == NULL)
+			return true;
+		double locConfidenceLevel = locKinFitResults->Get_ConfidenceLevel();
+		if(locConfidenceLevel < dKinFitCLCut)
+			return true;
+	}
 
+	
 
 	//FILL HISTOGRAMS
 	//Since we are filling histograms local to this action, it will not interfere with other ROOT operations: can use action-wide ROOT lock

--- a/src/libraries/ANALYSIS/DHistogramActions_Independent.h
+++ b/src/libraries/ANALYSIS/DHistogramActions_Independent.h
@@ -993,21 +993,23 @@ class DHistogramAction_TrackMultiplicity : public DAnalysisAction
 class DHistogramAction_TriggerStudies : public DAnalysisAction
 {
 	public:
-		DHistogramAction_TriggerStudies(const DReaction* locReaction, string locActionUniqueString = "") : 
+		DHistogramAction_TriggerStudies(const DReaction* locReaction, string locActionUniqueString = "", double locKinFitCLCut=-1.) : 
 		DAnalysisAction(locReaction, "Hist_TriggerStudies", false, locActionUniqueString),
-		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.) { }
+		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.), dKinFitCLCut(locKinFitCLCut) { }
 
 		DHistogramAction_TriggerStudies(string locActionUniqueString) : 
 		DAnalysisAction(NULL, "Hist_TriggerStudies", false, ""),
-		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.) { }
+		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.), dKinFitCLCut(-1.)  { }
 			
 		DHistogramAction_TriggerStudies(void) : 
 		DAnalysisAction(NULL, "Hist_TriggerStudies", false, ""),
-		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.) { }
+		dBCALBins(240), dFCALBins(240), dMaxBCALEnergy(12.), dMaxFCALEnergy(12.), dKinFitCLCut(-1.)  { }
 
 		int dBCALBins, dFCALBins;
 		double dMaxBCALEnergy;
 		double dMaxFCALEnergy;
+		
+		double dKinFitCLCut;
 
 		void Initialize(JEventLoop* locEventLoop);
 		void Run_Update(JEventLoop* locEventLoop){}

--- a/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
+++ b/src/plugins/Analysis/ReactionFilter/DReaction_factory_ReactionFilter.cc
@@ -226,6 +226,7 @@ jerror_t DReaction_factory_ReactionFilter::evnt(JEventLoop* locEventLoop, uint64
 
 		// KINEMATICS & OTHER INFO
 		locReaction->Add_AnalysisAction(new DHistogramAction_ParticleComboKinematics(locReaction, true));
+		locReaction->Add_AnalysisAction(new DHistogramAction_TriggerStudies(locReaction, "", 0.05));
 
 		_data.push_back(locReaction); //Register the DReaction with the factory
 	}


### PR DESCRIPTION
This PR includes a few useful tools for studying trigger energy sums for different final states

* the FCAL and BCAL energy sums are now written out as part of the standard PART ROOT trees
* the ReactionFilter plugin now makes trigger energy sum histograms for each reaction, and only for combos which pass some cut on the kinematic fit quality (currently CL > 5%)

Note that the code that runs the energy sum estimation for raw data was only fixed recently, so we would need to use these tools on either MC samples or with a new monitoring launch.