### PR TITLE
Add fmwpc matches

### DIFF
--- a/src/libraries/FMWPC/DCPPEpEm_factory.cc
+++ b/src/libraries/FMWPC/DCPPEpEm_factory.cc
@@ -123,13 +123,13 @@ jerror_t DCPPEpEm_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
   unsigned int ip=(q1>q2)?0:1;
   unsigned int in=(q1>q2)?1:0;
   
-  hyp=tracks[ip]->Get_Hypothesis(PiPlus);
-  if (hyp==NULL) return RESOURCE_UNAVAILABLE;
-  const DTrackTimeBased *piplus=hyp->Get_TrackTimeBased();
+  const DChargedTrackHypothesis *PiPhyp=tracks[ip]->Get_Hypothesis(PiPlus);
+  if (PiPhyp==NULL) return RESOURCE_UNAVAILABLE;
+  const DTrackTimeBased *piplus=PiPhyp->Get_TrackTimeBased();
 
-  hyp=tracks[in]->Get_Hypothesis(PiMinus);
-  if (hyp==NULL) return RESOURCE_UNAVAILABLE;
-  const DTrackTimeBased *piminus=hyp->Get_TrackTimeBased();
+  const DChargedTrackHypothesis *PiMhyp=tracks[in]->Get_Hypothesis(PiMinus);
+  if (PiMhyp==NULL) return RESOURCE_UNAVAILABLE;
+  const DTrackTimeBased *piminus=PiMhyp->Get_TrackTimeBased();
 
   hyp=tracks[ip]->Get_Hypothesis(KPlus);
   if (hyp==NULL) return RESOURCE_UNAVAILABLE;
@@ -285,7 +285,7 @@ jerror_t DCPPEpEm_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
       // n.b. if we need to use a mutex then we should pass a local
       // array for "input" and the lock the mutex just for the copy
       // to the tflite tensor.
-      if( PiMuFillFeatures(loop, piplus, piminus, pimu_input) ){
+      if( PiMuFillFeatures(loop, tracks.size(), PiPhyp, PiMhyp, pimu_input) ){
 
       	// Run inference
       	if( pimu_interpreter->Invoke() == kTfLiteOk){
@@ -418,26 +418,9 @@ bool DCPPEpEm_factory::VetoNeutrals(double t0_rf,const DVector3 &vect,
 // Return true if values are valid, false otherwise.
 // e.g. return false if there is not at least 1 pi+
 // and 1 pi- candidate.
-bool DCPPEpEm_factory::PiMuFillFeatures(jana::JEventLoop *loop, const DTrackTimeBased *piplus, const DTrackTimeBased *piminus, float *features){
-  
-  vector<const DFMWPCMatchedTrack*> matchedtracks;
-  loop->Get( matchedtracks );
-  
-  // Find the DFMWPCMatchedTrack objects corresponding to
-  // the piplus, piminus tracks used in for the kinematic fit
-  // (i.e. the ones passed into this method as arguments)
-  const DFMWPCMatchedTrack *piplus_mt  = nullptr;
-  const DFMWPCMatchedTrack *piminus_mt = nullptr;
-  for( auto mt : matchedtracks ){
-    const DTrackTimeBased *trk;
-    mt->GetSingleT(trk);
-    if( trk == piplus  ) piplus_mt = mt;
-    if( trk == piminus ) piminus_mt = mt;
-  }
-  
-  // Must have a DFMWPCMatchedTrack for both a pi+ and pi-
-  if( (piplus_mt==nullptr) || (piminus_mt==nullptr) ) return false;
-  
+bool DCPPEpEm_factory::PiMuFillFeatures(jana::JEventLoop *loop, unsigned int nChargedTracks,const DChargedTrackHypothesis *PiPhyp, const DChargedTrackHypothesis *PiMhyp, float *features){
+  memset(features,0,47*sizeof(float));
+
   // Features list is the following:
   //  0  nChargedTracks
   //  1  nFCALShowers
@@ -487,53 +470,82 @@ bool DCPPEpEm_factory::PiMuFillFeatures(jana::JEventLoop *loop, const DTrackTime
   // 45  FMWPC_dist_closest_wire6_9
   // 46  FMWPC_Nhits_cluster6_9
   
-  vector<const DChargedTrack*> chargedtracks;
   vector<const DFCALShower*  > fcalshowers;
   vector<const DFCALHit*     > fcalhits;
   vector<const DFMWPCHit*    > fmwpchits;
-  loop->Get( chargedtracks );
+  vector<const DEventHitStatistics*>stats;
+  loop->Get( stats         );
   loop->Get( fcalshowers   );
   loop->Get( fcalhits      );
   loop->Get( fmwpchits     );
 
-  features[ 0] = chargedtracks.size();
+  features[ 0] = nChargedTracks;
   features[ 1] = fcalshowers.size();
-  features[ 2] = fcalhits.size();
+  features[ 2] = (stats.size()>0) ? stats[0]->fcal_blocks : fcalhits.size();
   features[ 3] = fmwpchits.size();
-  features[ 4] = matchedtracks.size();
-  features[ 5] = piplus_mt->FCAL_E_center;
-  features[ 6] = piplus_mt->FCAL_E_3x3;
-  features[ 7] = piplus_mt->FCAL_E_5x5;
-  for(int ilayer=0; ilayer<6; ilayer++){
-    features[ 8+3*ilayer] = piplus_mt->FMWPC_closest_wire[ilayer];
-    features[ 9+3*ilayer] = piplus_mt->FMWPC_dist_closest_wire[ilayer];
-    features[10+3*ilayer] = piplus_mt->FMWPC_Nhits_cluster[ilayer];
+  features[ 4] = 2; // piPlus + piMinus tracks found ??
+
+  // Match to FCAL for pi+ hypothesis
+  shared_ptr<const DFCALShowerMatchParams>fcalparms=PiPhyp->Get_FCALShowerMatchParams();
+  if (fcalparms!=nullptr){
+    features[ 5] = fcalparms->dEcenter;
+    features[ 6] = fcalparms->dE3x3;
+    features[ 7] = fcalparms->dE5x5;
   }
-  features[26] = piminus_mt->FCAL_E_center;
-  features[27] = piminus_mt->FCAL_E_3x3;
-  features[28] = piminus_mt->FCAL_E_5x5;
-  for(int ilayer=0; ilayer<6; ilayer++){
-    features[29+3*ilayer] = piminus_mt->FMWPC_closest_wire[ilayer];
-    features[30+3*ilayer] = piminus_mt->FMWPC_dist_closest_wire[ilayer];
-    features[31+3*ilayer] = piminus_mt->FMWPC_Nhits_cluster[ilayer];
-  }
-  
+  // Match to FMWPCs for pi+ hypothesis
+  shared_ptr<const DFMWPCMatchParams>fmwpcparms=PiPhyp->Get_FMWPCMatchParams();
   // Before training the model, Nikhil's code replaced feature values
   // where the distance to the closest wire was >30 with values used
   // to indicate no wire hit. 
-  for(int ilayer=0; ilayer<6; ilayer++){
-    if( piminus_mt->FMWPC_dist_closest_wire[ilayer] >30.0 ){
-      features[29+3*ilayer] = -1000.0;
-      features[30+3*ilayer] = 1000000;
-      features[31+3*ilayer] = 0;
+  for (int ilayer=0; ilayer<6; ilayer++){
+    features[ 8+3*ilayer] = -1000.0;
+    features[ 9+3*ilayer] = 1000000;
+    features[10+3*ilayer] = 0;
+  }
+  if (fmwpcparms!=nullptr){
+    for (unsigned int i=0;i<fmwpcparms->dLayers.size();i++){
+      if (fmwpcparms->dDists[i]<30){
+	int ilayer=fmwpcparms->dLayers[i]-1;
+	features[ 8+3*ilayer] = fmwpcparms->dClosestWires[i];
+	features[ 9+3*ilayer] = fmwpcparms->dDists[i];
+	features[10+3*ilayer] = fmwpcparms->dNhits[i];
+      }
     }
   }
 
+  // Match to FCAL for pi- hypothesis
+  fcalparms=PiMhyp->Get_FCALShowerMatchParams();
+  if (fcalparms!=nullptr){
+    features[26] = fcalparms->dEcenter;
+    features[27] = fcalparms->dE3x3;
+    features[28] = fcalparms->dE5x5;
+  }
+  // Match to FMWPCs for pi- hypothesis
+  fmwpcparms=PiMhyp->Get_FMWPCMatchParams();
+  // Before training the model, Nikhil's code replaced feature values
+  // where the distance to the closest wire was >30 with values used
+  // to indicate no wire hit. 
+  for (int ilayer=0; ilayer<6; ilayer++){
+    features[29+3*ilayer] = -1000.0;
+    features[30+3*ilayer] = 1000000;
+    features[31+3*ilayer] = 0;
+  }
+  if (fmwpcparms!=nullptr){
+    for (unsigned int i=0;i<fmwpcparms->dLayers.size();i++){
+      if (fmwpcparms->dDists[i]<30){
+	int ilayer=fmwpcparms->dLayers[i]-1;
+	features[29+3*ilayer] = fmwpcparms->dClosestWires[i];
+	features[30+3*ilayer] = fmwpcparms->dDists[i];
+	features[31+3*ilayer] = fmwpcparms->dNhits[i];
+      }
+    }
+  }
+  
   // These are values Nikhil sent that were used for normalizing the
   // features before training the model.  
   static const float feature_min[] = {2.0,0.0,2.0,0.0,2.0,0.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,0.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,-1000.0,0.0,0.0,0.0};
   static const float feature_max[] = {6.0,10.0,20.0,94.0,8.0,3.924656391143799,5.177245497703552,5.349521217867732,144.0,1000000.0,39.0,144.0,1000000.0,17.0,144.0,1000000.0,12.0,144.0,1000000.0,11.0,144.0,1000000.0,8.0,144.0,1000000.0,7.0,4.154212951660156,5.578885164111853,5.9553504548966885,144.0,1000000.0,39.0,144.0,1000000.0,32.0,144.0,1000000.0,14.0,144.0,1000000.0,35.0,144.0,1000000.0,7.0,144.0,1000000.0,11.0,1.0};
-  for(int i=0; i<48; i++){
+  for(int i=0; i<47; i++){
     features[i] = (features[i] - feature_min[i])/(feature_max[i]-feature_min[i]);
   }
 

--- a/src/libraries/FMWPC/DCPPEpEm_factory.cc
+++ b/src/libraries/FMWPC/DCPPEpEm_factory.cc
@@ -483,7 +483,7 @@ bool DCPPEpEm_factory::PiMuFillFeatures(jana::JEventLoop *loop, unsigned int nCh
   features[ 1] = fcalshowers.size();
   features[ 2] = (stats.size()>0) ? stats[0]->fcal_blocks : fcalhits.size();
   features[ 3] = fmwpchits.size();
-  features[ 4] = 2; // piPlus + piMinus tracks found ??
+  features[ 4] = 4; // lepton and pion tracks found 
 
   // Match to FCAL for pi+ hypothesis
   shared_ptr<const DFCALShowerMatchParams>fcalparms=PiPhyp->Get_FCALShowerMatchParams();

--- a/src/libraries/FMWPC/DCPPEpEm_factory.h
+++ b/src/libraries/FMWPC/DCPPEpEm_factory.h
@@ -28,6 +28,7 @@
 #include <ANALYSIS/DKinFitUtils_GlueX.h>
 #include <FMWPC/DFMWPCMatchedTrack.h>
 #include <FMWPC/DFMWPCHit.h>
+#include <HDDM/DEventHitStatistics.h>
 
 
 class ReadMLPMinus;
@@ -56,7 +57,7 @@ void DoKinematicFit(const DBeamPhoton *beamphoton,
 bool VetoNeutrals(double t0_rf,const DVector3 &vect,
 		    vector<const DNeutralParticle*>&neutrals) const;
 
-bool PiMuFillFeatures(jana::JEventLoop *loop, const DTrackTimeBased *piplus, const DTrackTimeBased *piminus, float *features);
+ bool PiMuFillFeatures(jana::JEventLoop *loop, unsigned int nChargedTracks,const DChargedTrackHypothesis *piplus, const DChargedTrackHypothesis *piminus, float *features);
 
 double SPLIT_CUT,FCAL_THRESHOLD,BCAL_THRESHOLD,GAMMA_DT_CUT;
 string PIMU_MODEL_FILE;

--- a/src/libraries/FMWPC/DFMWPCCluster.h
+++ b/src/libraries/FMWPC/DFMWPCCluster.h
@@ -20,18 +20,21 @@ class DFMWPCCluster:public jana::JObject{
 		
 		vector<const DFMWPCHit*> members; ///< DFMWPCHits that make up this cluster
 		int layer; ///< #1-6 FMWPC layer
+		int orientation; ///< Vertical/Horizontal
+		float xoffset,yoffset; ///< x and y offsets of wires
 		float q; ///< total charge in the cluster
 		float u; ///< center of gravity of cluster in wire coordinates
 		int first_wire; ///< first wire in cluster 1-144
 		int last_wire; ///< last wire in cluster 1-144
 		int Nhits; ///< Number of wire hits in cluster
-		DVector3 pos; ///< position (x,y,z) in global coodinates
+		DVector3 pos; ///< position (x,y,z) in global coordinates
 		float t;     // time in ns
 		
 		// This method is used primarily for pretty printing
 		// the second argument to AddString is printf style format
 		void toStrings(vector<pair<string,string> > &items)const{
 			AddString(items, "layer", "%d", layer);
+			AddString(items, "orientation", "%d", orientation);
 			AddString(items, "q", "%10.2f", q);
 			AddString(items, "u", "%3.4f", u);
  			AddString(items, "first_wire", "%3d", first_wire);

--- a/src/libraries/FMWPC/DFMWPCCluster_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCCluster_factory.cc
@@ -184,6 +184,9 @@ void DFMWPCCluster_factory::pique(vector<const DFMWPCHit*>& H)
     // global coordinate system
     // set to -777 for not measured coordinate
     auto orientation = fmwpc_wire_orientation[newCluster->layer-1];
+    newCluster->orientation=orientation;
+    newCluster->xoffset=xvec[newCluster->layer-1];
+    newCluster->yoffset=yvec[newCluster->layer-1];
     double x = (orientation==DGeometry::kFMWPC_WIRE_ORIENTATION_VERTICAL  ) ? xvec[newCluster->layer-1]+(newCluster->u-72.5)*FMWPC_WIRE_SPACING : -777 ;
     double y = (orientation==DGeometry::kFMWPC_WIRE_ORIENTATION_HORIZONTAL) ? yvec[newCluster->layer-1]+(newCluster->u-72.5)*FMWPC_WIRE_SPACING : -777 ;
     double z = zvec[newCluster->layer-1];

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1699,7 +1699,16 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
          locShowerMatchParams->dFlightTimeVariance = fcalIter->getTflightvar();
          locShowerMatchParams->dPathLength = fcalIter->getPathlength();
          locShowerMatchParams->dDOCAToShower = fcalIter->getDoca();
-
+	 locShowerMatchParams->dEcenter=0.;
+	 locShowerMatchParams->dE3x3=0.;
+	 locShowerMatchParams->dE5x5=0.;
+	 const hddm_r::FcalEnergyParamsList &fcalEnergyList = fcalIter->getFcalEnergyParamses();
+	 hddm_r::FcalEnergyParamsList::iterator fcalEnergyIter = fcalEnergyList.begin();
+	 for(; fcalEnergyIter != fcalEnergyList.end(); ++fcalEnergyIter){
+	   locShowerMatchParams->dEcenter=fcalEnergyIter->getEcenter();
+	   locShowerMatchParams->dE3x3=fcalEnergyIter->getE3x3();
+	   locShowerMatchParams->dE5x5=fcalEnergyIter->getE5x5();
+	 }
          locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex], locFCALShowers[locShowerIndex], std::const_pointer_cast<const DFCALShowerMatchParams>(locShowerMatchParams));
       }
 

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1794,7 +1794,26 @@ jerror_t DEventSourceREST::Extract_DDetectorMatches(JEventLoop* locEventLoop, hd
 	       }
 	   }	 
       }
-      
+
+      // Extract track matching data for FMPWCs
+      const hddm_r::FmwpcMatchParamsList &fmwpcList = iter->getFmwpcMatchParamses();
+      hddm_r::FmwpcMatchParamsList::iterator fmwpcIter = fmwpcList.begin();
+      for(; fmwpcIter != fmwpcList.end(); ++fmwpcIter)
+      {
+         size_t locTrackIndex = fmwpcIter->getTrack();
+	 const hddm_r::FmwpcDataList &fmwpcDataList = fmwpcIter->getFmwpcDatas();
+	 hddm_r::FmwpcDataList::iterator fmwpcDataIter = fmwpcDataList.begin();
+
+         auto locFMWPCMatchParams = std::make_shared<DFMWPCMatchParams>();
+	 for(; fmwpcDataIter != fmwpcDataList.end(); ++fmwpcDataIter){
+	   locFMWPCMatchParams->dLayers.push_back(fmwpcDataIter->getLayer());
+	   locFMWPCMatchParams->dNhits.push_back(fmwpcDataIter->getNhits());
+	   locFMWPCMatchParams->dDists.push_back(fmwpcDataIter->getDist());
+	   locFMWPCMatchParams->dClosestWires.push_back(fmwpcDataIter->getClosestwire());
+	 }
+	 locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex], std::const_pointer_cast<const DFMWPCMatchParams>(locFMWPCMatchParams));
+      }
+
       // Extract track matching data for CTOF
       const hddm_r::CtofMatchParamsList &ctofList = iter->getCtofMatchParamses();
       hddm_r::CtofMatchParamsList::iterator ctofIter = ctofList.begin();

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -633,10 +633,16 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				fcalList().setTflightvar(locFCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
 				// Additional energy information
 				if (ADD_FCAL_DATA_FOR_CPP){
-				  hddm_r::FcalEnergyParamsList fcalEnergyParamsList = fcalList().addFcalEnergyParamses(1);
-				  fcalEnergyParamsList().setEcenter(locFCALShowerMatchParamsVector[loc_k]->dEcenter);
-				  fcalEnergyParamsList().setE3x3(locFCALShowerMatchParamsVector[loc_k]->dE3x3);
-				  fcalEnergyParamsList().setE5x5(locFCALShowerMatchParamsVector[loc_k]->dE5x5);
+				  // Sanity check for this additional info
+				  double myE5x5=locFCALShowerMatchParamsVector[loc_k]->dE5x5;
+				  double myE3x3=locFCALShowerMatchParamsVector[loc_k]->dE3x3;
+				  double myEcenter=locFCALShowerMatchParamsVector[loc_k]->dEcenter;
+				  if (myEcenter>0. || myE3x3>0. || myE5x5>0.){ 
+				    hddm_r::FcalEnergyParamsList fcalEnergyParamsList = fcalList().addFcalEnergyParamses(1);
+				    fcalEnergyParamsList().setEcenter(myEcenter);
+				    fcalEnergyParamsList().setE3x3(myE3x3);
+				    fcalEnergyParamsList().setE5x5(myE5x5);
+				  }
 				}
 			}
 

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -606,27 +606,6 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				fcalList().setTflightvar(locFCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
 			}
 
-			vector<shared_ptr<const DCTOFHitMatchParams>> locCTOFHitMatchParamsVector;
-			locDetectorMatches[loc_i]->Get_CTOFMatchParams(tracks[loc_j], locCTOFHitMatchParamsVector);
-			for(size_t loc_k = 0; loc_k < locCTOFHitMatchParamsVector.size(); ++loc_k)
-			{
-				hddm_r::CtofMatchParamsList ctofList = matches().addCtofMatchParamses(1);
-				ctofList().setTrack(loc_j);
-
-				size_t locCTOFindex = 0;
-				for(; locCTOFindex < ctofpoints.size(); ++locCTOFindex)
-				{
-					if(ctofpoints[locCTOFindex] == locCTOFHitMatchParamsVector[loc_k]->dCTOFPoint)
-						break;
-				}
-				ctofList().setHit(locCTOFindex);
-				ctofList().setDEdx(locCTOFHitMatchParamsVector[loc_k]->dEdx);
-				ctofList().setTflight(locCTOFHitMatchParamsVector[loc_k]->dFlightTime);
-
-				ctofList().setDeltax(locCTOFHitMatchParamsVector[loc_k]->dDeltaXToHit);
-				ctofList().setDeltay(locCTOFHitMatchParamsVector[loc_k]->dDeltaYToHit);
-			}
-
 			vector<shared_ptr<const DFCALSingleHitMatchParams>> locFCALSingleHitMatchParamsVector;
 			locDetectorMatches[loc_i]->Get_FCALSingleHitMatchParams(tracks[loc_j], locFCALSingleHitMatchParamsVector);
 			for (size_t loc_k = 0; loc_k < locFCALSingleHitMatchParamsVector.size(); ++loc_k)
@@ -771,6 +750,46 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				correlationList().setTrack(loc_j);
 				correlationList().setSystem(SYS_START);
 				correlationList().setCorrelation(locFlightTimePCorrelation);
+			}
+
+			//---------  The following are for CPP -------------//
+			vector<shared_ptr<const DFMWPCMatchParams>> locFMWPCMatchParamsVector;
+			locDetectorMatches[loc_i]->Get_FMWPCMatchParams(tracks[loc_j], locFMWPCMatchParamsVector);
+			for(size_t loc_k = 0; loc_k < locFMWPCMatchParamsVector.size(); ++loc_k){
+			  hddm_r::FmwpcMatchParamsList fmwpcList = matches().addFmwpcMatchParamses(1);
+			  fmwpcList().setTrack(loc_j);
+			  vector<int>locLayers=locFMWPCMatchParamsVector[loc_k]->dLayers;
+			  vector<int>locNhits=locFMWPCMatchParamsVector[loc_k]->dNhits;
+			  vector<int>locDists=locFMWPCMatchParamsVector[loc_k]->dDists;
+			  vector<int>locClosestWires=locFMWPCMatchParamsVector[loc_k]->dClosestWires;
+			  for (size_t loc_m=0;loc_m<locLayers.size();loc_m++){
+			    hddm_r::FmwpcDataList fmwpcDataList = fmwpcList().addFmwpcDatas(1);
+			    fmwpcDataList().setLayer(locLayers[loc_m]);
+			    fmwpcDataList().setNhits(locNhits[loc_m]);
+			    fmwpcDataList().setDist(locDists[loc_m]);
+			    fmwpcDataList().setClosestwire(locClosestWires[loc_m]);
+			  }
+			}
+
+			vector<shared_ptr<const DCTOFHitMatchParams>> locCTOFHitMatchParamsVector;
+			locDetectorMatches[loc_i]->Get_CTOFMatchParams(tracks[loc_j], locCTOFHitMatchParamsVector);
+			for(size_t loc_k = 0; loc_k < locCTOFHitMatchParamsVector.size(); ++loc_k)
+			{
+				hddm_r::CtofMatchParamsList ctofList = matches().addCtofMatchParamses(1);
+				ctofList().setTrack(loc_j);
+
+				size_t locCTOFindex = 0;
+				for(; locCTOFindex < ctofpoints.size(); ++locCTOFindex)
+				{
+					if(ctofpoints[locCTOFindex] == locCTOFHitMatchParamsVector[loc_k]->dCTOFPoint)
+						break;
+				}
+				ctofList().setHit(locCTOFindex);
+				ctofList().setDEdx(locCTOFHitMatchParamsVector[loc_k]->dEdx);
+				ctofList().setTflight(locCTOFHitMatchParamsVector[loc_k]->dFlightTime);
+
+				ctofList().setDeltax(locCTOFHitMatchParamsVector[loc_k]->dDeltaXToHit);
+				ctofList().setDeltay(locCTOFHitMatchParamsVector[loc_k]->dDeltaYToHit);
 			}
 		}
 

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -605,10 +605,12 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				fcalList().setTflight(locFCALShowerMatchParamsVector[loc_k]->dFlightTime);
 				fcalList().setTflightvar(locFCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
 				// Additional energy information
-				hddm_r::FcalEnergyParamsList fcalEnergyParamsList = fcalList().addFcalEnergyParamses(1);
-				fcalEnergyParamsList().setEcenter(locFCALShowerMatchParamsVector[loc_k]->dEcenter);
-				fcalEnergyParamsList().setE3x3(locFCALShowerMatchParamsVector[loc_k]->dE3x3);
-				fcalEnergyParamsList().setE5x5(locFCALShowerMatchParamsVector[loc_k]->dE5x5);
+				if (ADD_FCAL_DATA_FOR_CPP){
+				  hddm_r::FcalEnergyParamsList fcalEnergyParamsList = fcalList().addFcalEnergyParamses(1);
+				  fcalEnergyParamsList().setEcenter(locFCALShowerMatchParamsVector[loc_k]->dEcenter);
+				  fcalEnergyParamsList().setE3x3(locFCALShowerMatchParamsVector[loc_k]->dE3x3);
+				  fcalEnergyParamsList().setE5x5(locFCALShowerMatchParamsVector[loc_k]->dE5x5);
+				}
 			}
 
 			vector<shared_ptr<const DFCALSingleHitMatchParams>> locFCALSingleHitMatchParamsVector;

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -51,6 +51,10 @@ DEventWriterREST::DEventWriterREST(JEventLoop* locEventLoop, string locOutputFil
 	REST_WRITE_CCAL_SHOWERS = true;
 	gPARMS->SetDefaultParameter("REST:WRITE_CCAL_SHOWERS", REST_WRITE_CCAL_SHOWERS);
 
+	ADD_FCAL_DATA_FOR_CPP=false;
+	gPARMS->SetDefaultParameter("PID:ADD_FCAL_DATA_FOR_CPP",ADD_FCAL_DATA_FOR_CPP);
+
+
     CCDB_CONTEXT_STRING = "";
     // if we can get the calibration context from the DANA interface, then save this as well
     DApplication *dapp = dynamic_cast<DApplication*>(locEventLoop->GetJApplication());

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -604,6 +604,11 @@ bool DEventWriterREST::Write_RESTEvent(JEventLoop* locEventLoop, string locOutpu
 				fcalList().setPathlength(locFCALShowerMatchParamsVector[loc_k]->dPathLength);
 				fcalList().setTflight(locFCALShowerMatchParamsVector[loc_k]->dFlightTime);
 				fcalList().setTflightvar(locFCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
+				// Additional energy information
+				hddm_r::FcalEnergyParamsList fcalEnergyParamsList = fcalList().addFcalEnergyParamses(1);
+				fcalEnergyParamsList().setEcenter(locFCALShowerMatchParamsVector[loc_k]->dEcenter);
+				fcalEnergyParamsList().setE3x3(locFCALShowerMatchParamsVector[loc_k]->dE3x3);
+				fcalEnergyParamsList().setE5x5(locFCALShowerMatchParamsVector[loc_k]->dE5x5);
 			}
 
 			vector<shared_ptr<const DFCALSingleHitMatchParams>> locFCALSingleHitMatchParamsVector;

--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -59,6 +59,7 @@ class DEventWriterREST : public JObject
 		bool REST_WRITE_DIRC_HITS;
 		bool REST_WRITE_CCAL_SHOWERS;
 		bool REST_WRITE_TRACK_EXIT_PARAMS;
+		bool ADD_FCAL_DATA_FOR_CPP;
 
         // metadata to save in the REST file
         // these should be consistent during program execution

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -140,6 +140,12 @@
                 track="int" hit="int" dEdx="float" 
                 deltax="float" deltay="float" tflight="float"
 		tunit="ns" lunit="cm" dEdx_unit="GeV/cm"/>
+      <fmwpcMatchParams maxOccurs="unbounded" minOccurs="0"
+			track="int">
+	<fmwpcData maxOccurs="6" minOccurs="0"
+		   layer="int" nhits="int"
+		   dist="int" closestwire="int" />
+      </fmwpcMatchParams>
       <tofMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" hit="int"
                 dEdx="float" thit="float" thitvar="float" ehit="float"

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -131,7 +131,10 @@
       <fcalMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" shower="int"
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
-                tunit="ns" lunit="cm"/>
+                tunit="ns" lunit="cm">
+	<fcalEnergyParams maxOccurs="1" minOccurs="0"
+		      Ecenter="float" E3x3="float" E5x5="float"/>
+      </fcalMatchParams>
       <fcalSingleHitMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" ehit="float" thit="float"
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"

--- a/src/libraries/PID/DChargedTrackHypothesis.h
+++ b/src/libraries/PID/DChargedTrackHypothesis.h
@@ -69,6 +69,7 @@ class DChargedTrackHypothesis : public DKinematicData
 		shared_ptr<const DFCALSingleHitMatchParams> Get_FCALSingleHitMatchParams(void) const{return dTrackingInfo->dFCALSingleHitMatchParams;}
 		shared_ptr<const DDIRCMatchParams> Get_DIRCMatchParams(void) const{return dTrackingInfo->dDIRCMatchParams;}
 		shared_ptr<const DCTOFHitMatchParams> Get_CTOFHitMatchParams(void) const{return dTrackingInfo->dCTOFHitMatchParams;}
+		shared_ptr<const DFMWPCMatchParams> Get_FMWPCMatchParams(void) const{return dTrackingInfo->dFMWPCMatchParams;}
 
 		//SETTERS
 
@@ -93,6 +94,7 @@ class DChargedTrackHypothesis : public DKinematicData
 		void Set_FCALSingleHitMatchParams(shared_ptr<const DFCALSingleHitMatchParams> locMatchParams){dTrackingInfo->dFCALSingleHitMatchParams = locMatchParams;}
 		void Set_DIRCMatchParams(shared_ptr<const DDIRCMatchParams> locMatchParams){dTrackingInfo->dDIRCMatchParams = locMatchParams;}	
 		void Set_CTOFHitMatchParams(shared_ptr<const DCTOFHitMatchParams> locMatchParams){dTrackingInfo->dCTOFHitMatchParams = locMatchParams;}
+		void Set_FMWPCMatchParams(shared_ptr<const DFMWPCMatchParams> locMatchParams){dTrackingInfo->dFMWPCMatchParams = locMatchParams;}
 
 		void toStrings(vector<pair<string,string> > &items) const
 		{
@@ -171,6 +173,7 @@ class DChargedTrackHypothesis : public DKinematicData
 				shared_ptr<const DFCALSingleHitMatchParams> dFCALSingleHitMatchParams = nullptr;
 				shared_ptr<const DDIRCMatchParams> dDIRCMatchParams = nullptr;	
 				shared_ptr<const DCTOFHitMatchParams> dCTOFHitMatchParams = nullptr;
+				shared_ptr<const DFMWPCMatchParams> dFMWPCMatchParams=nullptr;
 		};
 
 	private:
@@ -405,11 +408,12 @@ inline void DChargedTrackHypothesis::DTrackingInfo::Reset(void)
 	dTrackTimeBased = nullptr;
 	dSCHitMatchParams = nullptr;
 	dTOFHitMatchParams = nullptr;
-	dCTOFHitMatchParams = nullptr;
+	dCTOFHitMatchParams = nullptr; 
 	dBCALShowerMatchParams = nullptr;
 	dFCALShowerMatchParams = nullptr;
 	dFCALSingleHitMatchParams = nullptr;
 	dDIRCMatchParams = nullptr;
+	dFMWPCMatchParams = nullptr;
 }
 
 inline void DChargedTrackHypothesis::DEOverPInfo::Reset(void)

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -288,15 +288,6 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 	if (locDetectorMatches->Get_FMWPCMatchParams(locTrackTimeBased,
 						     locFMWPCMatchParamsVec)){
 	  locChargedTrackHypothesis->Set_FMWPCMatchParams(locFMWPCMatchParamsVec[0]);
-	  shared_ptr<const DFMWPCMatchParams> myshared=locChargedTrackHypothesis->Get_FMWPCMatchParams();
-	  if (myshared){
-	    for (int k=0;k<myshared->dLayers.size();k++){
-	      cout << myshared->dLayers[k]<<": " <<myshared->dNhits[k] 
-		   << " " << myshared->dDists[k]
-		   <<"  " << myshared->dClosestWires[k]<<endl;
-	    }
-	  }
-	  
 	}
 
 	//PID

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -283,6 +283,21 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 		locChargedTrackHypothesis->Set_DIRCMatchParams(locDIRCMatchParams);
 	if(dPIDAlgorithm->Get_BestCTOFMatchParams(locTrackTimeBased, locDetectorMatches, locCTOFHitMatchParams))
 	  locChargedTrackHypothesis->Set_CTOFHitMatchParams(locCTOFHitMatchParams);
+	// Matching to CPP wire chambers
+	vector<shared_ptr<const DFMWPCMatchParams> > locFMWPCMatchParamsVec;
+	if (locDetectorMatches->Get_FMWPCMatchParams(locTrackTimeBased,
+						     locFMWPCMatchParamsVec)){
+	  locChargedTrackHypothesis->Set_FMWPCMatchParams(locFMWPCMatchParamsVec[0]);
+	  shared_ptr<const DFMWPCMatchParams> myshared=locChargedTrackHypothesis->Get_FMWPCMatchParams();
+	  if (myshared){
+	    for (int k=0;k<myshared->dLayers.size();k++){
+	      cout << myshared->dLayers[k]<<": " <<myshared->dNhits[k] 
+		   << " " << myshared->dDists[k]
+		   <<"  " << myshared->dClosestWires[k]<<endl;
+	    }
+	  }
+	  
+	}
 
 	//PID
 	if(locChargedTrackHypothesis->t1_detector() == SYS_BCAL)

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -16,6 +16,7 @@
 #include <TRACKING/DTrackingData.h>
 #include <TOF/DTOFPoint.h>
 #include <FMWPC/DCTOFPoint.h>
+#include <FMWPC/DFMWPCCluster.h>
 #include <BCAL/DBCALShower.h>
 #include <FCAL/DFCALShower.h>
 #include <START_COUNTER/DSCHit.h>
@@ -155,6 +156,15 @@ class DDIRCMatchParams
 		double dExtrapolatedTime;
 };
 
+class DFMWPCMatchParams
+{
+ public:
+  vector<int>dLayers;
+  vector<int>dNhits;
+  vector<int>dDists;
+  vector<int>dClosestWires;
+};
+
 class DDetectorMatches : public JObject
 {
 	public:
@@ -166,9 +176,10 @@ class DDetectorMatches : public JObject
 		inline bool Get_FCALMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DFCALShowerMatchParams> >& locMatchParams) const;
 		inline bool Get_TOFMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DTOFHitMatchParams> >& locMatchParams) const;
 		inline bool Get_CTOFMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DCTOFHitMatchParams> >& locMatchParams) const;
+		inline bool Get_FMWPCMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DFMWPCMatchParams> >& locMatchParams) const;
 		inline bool Get_SCMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DSCHitMatchParams> >& locMatchParams) const;
 		inline bool Get_DIRCMatchParams(const DTrackingData* locTrack, shared_ptr<const DDIRCMatchParams>& locMatchParams) const;
-
+	
 		inline bool Get_IsMatchedToTrack(const DBCALShower* locBCALShower) const;
 		inline bool Get_IsMatchedToTrack(const DFCALShower* locFCALShower) const;
 		inline bool Get_IsMatchedToHit(const DTrackingData* locTrack) const;
@@ -179,7 +190,7 @@ class DDetectorMatches : public JObject
 		inline bool Get_TrackMatchParams(const DTOFPoint* locTOFPoint, vector<shared_ptr<const DTOFHitMatchParams> >& locMatchParams) const;
 		inline bool Get_TrackMatchParams(const DSCHit* locSCHit, vector<shared_ptr<const DSCHitMatchParams> >& locMatchParams) const;
 		inline bool Get_DIRCTrackMatchParamsMap(map<shared_ptr<const DDIRCMatchParams>, vector<const DDIRCPmtHit*> >& locDIRCTrackMatchParamsMap);
-		inline bool Get_TrackMatchParams(const DCTOFPoint* locCTOFPoint, vector<shared_ptr<const DCTOFHitMatchParams> >& locMatchParams) const;
+		inline bool Get_TrackMatchParams(const DCTOFPoint* locCTOFPoint, vector<shared_ptr<const DCTOFHitMatchParams> >& locMatchParams) const;	
 
 		inline bool Get_DistanceToNearestTrack(const DBCALShower* locBCALShower, double& locDistance) const;
 		inline bool Get_DistanceToNearestTrack(const DBCALShower* locBCALShower, double& locDeltaPhi, double& locDeltaZ) const;
@@ -194,6 +205,8 @@ class DDetectorMatches : public JObject
 		inline size_t Get_NumTrackSCMatches(void) const;
 		inline size_t Get_NumTrackDIRCMatches(void) const;
 		inline size_t Get_NumTrackCTOFMatches(void) const;
+		inline size_t Get_NumTrackFMWPCMatches(void) const;
+
 
 		//SETTERS:
 		inline void Add_Match(const DTrackingData* locTrack, const DBCALShower* locBCALShower, const shared_ptr<const DBCALShowerMatchParams>& locShowerMatchParams);
@@ -203,6 +216,9 @@ class DDetectorMatches : public JObject
 		inline void Add_Match(const DTrackingData* locTrack, const DCTOFPoint* locCTOFPoint, const shared_ptr<const DCTOFHitMatchParams>& locHitMatchParams);
 		inline void Add_Match(const DTrackingData* locTrack, const DSCHit* locSCHit, const shared_ptr<const DSCHitMatchParams>& locHitMatchParams);
 		inline void Add_Match(const DTrackingData* locTrack, const shared_ptr<const DDIRCMatchParams>& locDIRCMatchParams);
+		inline void Add_Match(const DTrackingData *locTrack,
+				      const shared_ptr<const DFMWPCMatchParams>& locFMWPCMatchParams);
+
 		inline void Set_DistanceToNearestTrack(const DBCALShower* locBCALShower, double locDeltaPhi, double locDeltaZ);
 		inline void Set_DistanceToNearestTrack(const DFCALShower* locFCALShower, double locDistanceToNearestTrack);
 		inline void Set_FlightTimePCorrelation(const DTrackingData* locTrack, DetectorSystem_t locDetectorSystem, double locCorrelation);
@@ -214,7 +230,8 @@ class DDetectorMatches : public JObject
 			AddString(items, "#_Track_TOF_Matches", "%d", Get_NumTrackTOFMatches());
 			AddString(items, "#_Track_SC_Matches", "%d", Get_NumTrackSCMatches());
 			AddString(items, "#_Track_DIRC_Matches", "%d", Get_NumTrackDIRCMatches());	
-			AddString(items, "#_Track_CTOF_Matches", "%d", Get_NumTrackCTOFMatches());
+			AddString(items, "#_Track_CTOF_Matches", "%d", Get_NumTrackCTOFMatches());	
+			AddString(items, "#_Track_FMWPC_Matches", "%d", Get_NumTrackFMWPCMatches());
 		}
 
 	private:
@@ -225,6 +242,7 @@ class DDetectorMatches : public JObject
 		map<const DTrackingData*, vector<shared_ptr<const DFCALShowerMatchParams> > > dTrackFCALMatchParams;
 		map<const DTrackingData*, vector<shared_ptr<const DTOFHitMatchParams> > > dTrackTOFMatchParams;
 		map<const DTrackingData*, vector<shared_ptr<const DCTOFHitMatchParams> > > dTrackCTOFMatchParams;
+		map<const DTrackingData*, vector<shared_ptr<const DFMWPCMatchParams> > > dTrackFMWPCMatchParams;
 		map<const DTrackingData*, vector<shared_ptr<const DSCHitMatchParams> > > dTrackSCMatchParams;
 		map<const DTrackingData*, shared_ptr<const DDIRCMatchParams> > dTrackDIRCMatchParams;
 
@@ -285,6 +303,16 @@ inline bool DDetectorMatches::Get_CTOFMatchParams(const DTrackingData* locTrack,
 	return true;
 }
 
+inline bool DDetectorMatches::Get_FMWPCMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DFMWPCMatchParams> >& locMatchParams) const
+{
+	locMatchParams.clear();
+	auto locIterator = dTrackFMWPCMatchParams.find(locTrack);
+	if(locIterator == dTrackFMWPCMatchParams.end())
+		return false;
+	locMatchParams = locIterator->second;
+	return true;
+}
+
 inline bool DDetectorMatches::Get_TOFMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DTOFHitMatchParams> >& locMatchParams) const
 {
 	locMatchParams.clear();
@@ -334,8 +362,6 @@ inline bool DDetectorMatches::Get_IsMatchedToHit(const DTrackingData* locTrack) 
 		return true;
 	if(dTrackSCMatchParams.find(locTrack) != dTrackSCMatchParams.end())
 		return true;
-	if(dTrackCTOFMatchParams.find(locTrack) != dTrackCTOFMatchParams.end())
-		return true;
 	return false;
 }
 
@@ -351,6 +377,8 @@ inline bool DDetectorMatches::Get_IsMatchedToDetector(const DTrackingData* locTr
 		return (dTrackSCMatchParams.find(locTrack) != dTrackSCMatchParams.end());
 	else if(locDetectorSystem == SYS_CTOF)
 		return (dTrackCTOFMatchParams.find(locTrack) != dTrackCTOFMatchParams.end());
+	else if(locDetectorSystem == SYS_FMWPC)
+		return (dTrackFMWPCMatchParams.find(locTrack) != dTrackFMWPCMatchParams.end());
 	else
 		return false;
 }
@@ -384,8 +412,6 @@ inline bool DDetectorMatches::Get_TrackMatchParams(const DCTOFPoint* locCTOFPoin
 	locMatchParams = locIterator->second;
 	return true;
 }
-
-
 
 inline bool DDetectorMatches::Get_TrackMatchParams(const DTOFPoint* locTOFPoint, vector<shared_ptr<const DTOFHitMatchParams> >& locMatchParams) const
 {
@@ -492,6 +518,15 @@ inline size_t DDetectorMatches::Get_NumTrackCTOFMatches(void) const
 	return locNumTrackMatches;
 }
 
+inline size_t DDetectorMatches::Get_NumTrackFMWPCMatches(void) const
+{
+	auto locIterator = dTrackFMWPCMatchParams.begin();
+	unsigned int locNumTrackMatches = 0;
+	for(; locIterator != dTrackFMWPCMatchParams.end(); ++locIterator)
+		locNumTrackMatches += locIterator->second.size();
+	return locNumTrackMatches;
+}
+
 inline size_t DDetectorMatches::Get_NumTrackSCMatches(void) const
 {
 	auto locIterator = dTrackSCMatchParams.begin();
@@ -529,6 +564,10 @@ inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const DCT
 {
 	dTrackCTOFMatchParams[locTrack].push_back(locHitMatchParams);
 	dCTOFTrackMatchParams[locCTOFPoint].push_back(locHitMatchParams);
+}
+inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const shared_ptr<const DFMWPCMatchParams>& locHitMatchParams)
+{
+	dTrackFMWPCMatchParams[locTrack].push_back(locHitMatchParams);
 }
 inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const DSCHit* locSCHit, const shared_ptr<const DSCHitMatchParams>& locHitMatchParams)
 {

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -65,7 +65,7 @@ class DFCALShowerMatchParams
 {
 	public:
 		DFCALShowerMatchParams(void) : dFCALShower(NULL),
-		dx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDOCAToShower(0.0){}
+    dx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDOCAToShower(0.0), dE5x5(0.0), dE3x3(0.0), dEcenter(0.0){}
 
 		const DFCALShower* dFCALShower;
 
@@ -74,6 +74,9 @@ class DFCALShowerMatchParams
 		double dFlightTimeVariance;
 		double dPathLength; //path length from DKinematicData::position() to the shower
 		double dDOCAToShower; //DOCA of track to shower
+		double dE5x5; // energy sum over 5x5 array centered on track projection
+		double dE3x3; // energy sum over 3x3 array centered on track projection
+		double dEcenter; // energy in "center" block
 };
 
 class DCTOFHitMatchParams

--- a/src/libraries/PID/DDetectorMatches_factory.cc
+++ b/src/libraries/PID/DDetectorMatches_factory.cc
@@ -69,6 +69,9 @@ DDetectorMatches* DDetectorMatches_factory::Create_DDetectorMatches(jana::JEvent
 	vector<const DCTOFPoint*> locCTOFPoints;
 	locEventLoop->Get(locCTOFPoints);
 
+	vector<const DFMWPCCluster *> locFMWPCClusters;
+	locEventLoop->Get(locFMWPCClusters);
+
 	DDetectorMatches* locDetectorMatches = new DDetectorMatches();
 
 	//Match tracks to showers/hits
@@ -79,7 +82,10 @@ DDetectorMatches* DDetectorMatches_factory::Create_DDetectorMatches(jana::JEvent
 		MatchToFCAL(locParticleID, locTrackTimeBasedVector[loc_i], locFCALShowers, locDetectorMatches);
 		MatchToSC(locParticleID, locTrackTimeBasedVector[loc_i], locSCHits, locDetectorMatches);
 		MatchToDIRC(locParticleID, locTrackTimeBasedVector[loc_i], locDIRCHits, locDetectorMatches, locDIRCBarHits);
-		MatchToCTOF(locParticleID, locTrackTimeBasedVector[loc_i], locCTOFPoints, locDetectorMatches);
+		if (locTrackTimeBasedVector[loc_i]->PID()<10){ // GEANT ids; ignore proton=14 and kaons=11+12
+		  MatchToCTOF(locParticleID, locTrackTimeBasedVector[loc_i], locCTOFPoints, locDetectorMatches);
+		  MatchToFMWPC(locTrackTimeBasedVector[loc_i], locFMWPCClusters, locDetectorMatches);
+		}
 	}
 
 	//Find nearest tracks to showers
@@ -139,6 +145,78 @@ void DDetectorMatches_factory::MatchToBCAL(const DParticleID* locParticleID, con
 	  if(locParticleID->Cut_MatchDistance(extrapolations, locBCALShowers[loc_i], locInputStartTime, locShowerMatchParams))
 	    locDetectorMatches->Add_Match(locTrackTimeBased, locBCALShowers[loc_i], locShowerMatchParams);
 	}
+}
+
+void DDetectorMatches_factory::MatchToFMWPC(const DTrackTimeBased* locTrackTimeBased, const vector<const DFMWPCCluster*>& locFMWPCClusters, DDetectorMatches* locDetectorMatches) const{
+  auto fmwpc_projections=locTrackTimeBased->extrapolations.at(SYS_FMWPC);
+  if (fmwpc_projections.size()==0) return;
+  
+  // Loop over projections filling in arrays of matching info
+  vector<int>locLayers;
+  vector<int>locNhits;
+  vector<int>locDists;
+  vector<int>locClosestWires;
+  const double FMWPC_WIRE_SPACING=1.016; //cm
+  bool got_match=false;
+  for( int layer=1; layer<=(int)fmwpc_projections.size(); layer++){
+    auto proj = fmwpc_projections[layer-1];
+    // x and y projections from track
+    double xpos=proj.position.x();
+    double ypos=proj.position.y();
+ 
+    // Loop over DFMWPCClusters and find closest match to this projection
+    int min_dist = 1000000;
+    int wire_trk_proj=0;
+    const DFMWPCCluster* closest_fmwpc_cluster= nullptr;
+    for(auto fmwpccluster : locFMWPCClusters){
+      if( fmwpccluster->layer != layer ) continue;
+      
+      // Convert into local coordinates so we can work with wire numbers
+      double s=fmwpccluster->orientation==DGeometry::kFMWPC_WIRE_ORIENTATION_VERTICAL ? xpos+fmwpccluster->xoffset : ypos+fmwpccluster->yoffset;
+      wire_trk_proj = round(71.5 + s/FMWPC_WIRE_SPACING) + 1; // 1-144
+      
+      // If the projection is outside of the wire range then bail now
+      if( (wire_trk_proj<1) || (wire_trk_proj>144) ) continue; 
+
+      int dist=1000000;
+      if( wire_trk_proj >= fmwpccluster->first_wire ){
+	dist = wire_trk_proj - fmwpccluster->last_wire; // distance beyond last wire (will be negative if inside cluster)
+	if( dist < 0 ) dist = 0; // force dist to 0 if inside cluster
+      }else{
+	dist = fmwpccluster->first_wire - wire_trk_proj; // distance before first wire
+      }
+      
+      if( dist < min_dist ){
+	min_dist = dist;
+	closest_fmwpc_cluster = fmwpccluster;
+      }
+    }
+  
+    // If a DFMWPCCluster was found, add the match info to the track
+    if( closest_fmwpc_cluster ){
+      int closest_wire=wire_trk_proj;
+      if (wire_trk_proj < closest_fmwpc_cluster->first_wire ) {
+	closest_wire = closest_fmwpc_cluster->first_wire;
+      }
+      else if (wire_trk_proj > closest_fmwpc_cluster->last_wire){
+	closest_wire = closest_fmwpc_cluster->last_wire;
+      }
+      locLayers.push_back(layer);
+      locNhits.push_back(closest_fmwpc_cluster->Nhits);
+      locDists.push_back(min_dist);
+      locClosestWires.push_back(closest_wire);
+
+      got_match=true;
+    }
+  }
+  if (got_match){
+    shared_ptr<DFMWPCMatchParams>locFMWPCMatchParams=std::make_shared<DFMWPCMatchParams>();
+    locFMWPCMatchParams->dLayers=locLayers;
+    locFMWPCMatchParams->dNhits=locNhits;
+    locFMWPCMatchParams->dDists=locDists;
+    locFMWPCMatchParams->dClosestWires=locClosestWires;
+    locDetectorMatches->Add_Match(locTrackTimeBased,locFMWPCMatchParams);
+  }
 }
 
 void DDetectorMatches_factory::MatchToCTOF(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DCTOFPoint*>& locCTOFPoints, DDetectorMatches* locDetectorMatches) const

--- a/src/libraries/PID/DDetectorMatches_factory.h
+++ b/src/libraries/PID/DDetectorMatches_factory.h
@@ -18,6 +18,7 @@
 #include <PID/DParticleID.h>
 #include <TOF/DTOFPoint.h>
 #include <FMWPC/DCTOFPoint.h>
+#include <FMWPC/DFMWPCCluster.h>
 #include <BCAL/DBCALShower.h>
 #include <FCAL/DFCALShower.h>
 #include <DIRC/DDIRCPmtHit.h>
@@ -48,6 +49,7 @@ class DDetectorMatches_factory : public jana::JFactory<DDetectorMatches>
 		void MatchToSC(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DSCHit*>& locSCHits, DDetectorMatches* locDetectorMatches) const;
 		void MatchToDIRC(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DDIRCPmtHit*>& locDIRCHits, DDetectorMatches* locDetectorMatches, const vector<const DDIRCTruthBarHit*>& locDIRCBarHits) const;
 		void MatchToCTOF(const DParticleID* locParticleID, const DTrackTimeBased* locTrackTimeBased, const vector<const DCTOFPoint*>& locCTOFPoints, DDetectorMatches* locDetectorMatches) const;
+		void MatchToFMWPC(const DTrackTimeBased* locTrackTimeBased, const vector<const DFMWPCCluster*>& locFMWPCClusters, DDetectorMatches* locDetectorMatches) const;
 
 		void MatchToFCAL(const DParticleID* locParticleID,
 				 const DTrackTimeBased *locTrackTimeBased,

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -46,6 +46,8 @@ DParticleID::DParticleID(JEventLoop *loop)
   CDC_TRUNCATE_DEDX = true;
   gPARMS->SetDefaultParameter("PID:CDC_TRUNCATE_DEDX",CDC_TRUNCATE_DEDX);
 
+  ADD_FCAL_DATA_FOR_CPP=false;
+  gPARMS->SetDefaultParameter("PID:ADD_FCAL_DATA_FOR_CPP",ADD_FCAL_DATA_FOR_CPP);
 
   DApplication* dapp = dynamic_cast<DApplication*>(loop->GetJApplication());
   if(!dapp){
@@ -1302,6 +1304,38 @@ bool DParticleID::Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &
   locShowerMatchParams->dPathLength = locPathLength;
   locShowerMatchParams->dDOCAToShower = d;
   
+  // The following additional information is needed for CPP ML mu/pi separation
+  if (ADD_FCAL_DATA_FOR_CPP){
+    // Row/column corresponding to projected position
+    auto row = dFCALGeometry->row( (float)locProjPos.y() );
+    auto col = dFCALGeometry->column( (float)locProjPos.x() );
+    if (row>=0 && col>=0){
+      locShowerMatchParams->dE5x5=0.;
+      locShowerMatchParams->dE3x3=0.;
+      locShowerMatchParams->dEcenter=0.;
+      // Get the list of hits from the cluster associated with the shower
+      const DFCALCluster*cluster=NULL;
+      locFCALShower->GetSingle(cluster);
+      if (cluster){
+	vector<DFCALCluster::DFCALClusterHit_t>hits=cluster->GetHits();
+	for( auto hit : hits ){
+	  auto delta_row = abs( dFCALGeometry->row(hit.ch) - row );
+	  auto delta_col = abs( dFCALGeometry->column(hit.ch) - col );
+	  cout << "Deltas " << delta_row <<" " << delta_col << endl;
+	  if( (delta_row<=2) && (delta_col<=2) ){
+	    locShowerMatchParams->dE5x5 += hit.E;
+	    if( (delta_row<=1) && (delta_col<=1) ){
+	      locShowerMatchParams->dE3x3 += hit.E;
+	      if( (delta_row==0) && (delta_col==0) ){
+		locShowerMatchParams->dEcenter = hit.E;
+	      }
+	    }
+	  }
+	}
+      }
+    }
+  } // for CPP
+
   return true;
 }
 bool DParticleID::Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t>&extrapolations, const DTOFPoint* locTOFPoint, double locInputStartTime,shared_ptr<DTOFHitMatchParams>& locTOFHitMatchParams, DVector3* locOutputProjPos, DVector3* locOutputProjMom) const

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -1321,7 +1321,6 @@ bool DParticleID::Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &
 	for( auto hit : hits ){
 	  auto delta_row = abs( dFCALGeometry->row(hit.ch) - row );
 	  auto delta_col = abs( dFCALGeometry->column(hit.ch) - col );
-	  cout << "Deltas " << delta_row <<" " << delta_col << endl;
 	  if( (delta_row<=2) && (delta_col<=2) ){
 	    locShowerMatchParams->dE5x5 += hit.E;
 	    if( (delta_row<=1) && (delta_col<=1) ){

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -333,6 +333,7 @@ class DParticleID:public jana::JObject
 		double CDC_TIME_CUT_FOR_DEDX;
         
                 bool CDC_TRUNCATE_DEDX;            // dE/dx truncation: ignore hits with highest dE
+		bool ADD_FCAL_DATA_FOR_CPP;
 
 		double dTargetZCenter;
 


### PR DESCRIPTION
Added matching for FMWPC clusters to track projections to REST output and optionally some additional FCAL-related quantities.  To enable writing the latter, set -PPID:ADD_FCAL_DATA_FOR_CPP=1.   Changed DCPPEpEm code to get parameters needed for mu/pi separation directly from the track matching data for each track.  To fully test this, one needs to enable TensorFlowLite.