### PR TITLE
add four histograms plotting the intensity distribution over the tagger

### DIFF
--- a/src/plugins/monitoring/TAGM_online/HistMacro_TAGMCOL.C
+++ b/src/plugins/monitoring/TAGM_online/HistMacro_TAGMCOL.C
@@ -1,0 +1,105 @@
+// hnamepath: /tagm/tagmCol9
+// hnamepath: /tagm/tagmCol27
+// hnamepath: /tagm/tagmCol81
+// hnamepath: /tagm/tagmCol99
+
+{
+  cout<< "Entered macro: TAGM_online/HistMacro_TAGMCOL.C" << endl;
+
+  //Goto directory tagm
+  TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("tagm");
+  if(!locDirectory)
+    return;
+  locDirectory->cd();
+
+  //fetch the histograms
+  TH1I *locHistTAGMcol9  = (TH1I*)gDirectory->Get("tagmCol9");
+  TH1I *locHistTAGMcol27 = (TH1I*)gDirectory->Get("tagmCol27");
+  TH1I *locHistTAGMcol81 = (TH1I*)gDirectory->Get("tagmCol81");
+  TH1I *locHistTAGMcol99 = (TH1I*)gDirectory->Get("tagmCol99");
+
+  TCanvas *locCanvas = NULL;
+  if(TVirtualPad::Pad() == NULL)
+    locCanvas = new TCanvas("TAGM_Cols", "TAGM Columns", 1200, 800); //for testing
+  else
+    locCanvas = gPad->GetCanvas();
+  locCanvas->Divide(2, 2);
+  
+  //Draw
+  locCanvas->cd(1);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (locHistTAGMcol9 != NULL){
+    TH1I* hist = locHistTAGMcol9;
+    hist->SetStats(0);
+    hist->GetXaxis()->SetTitleSize(0.05);
+    hist->GetYaxis()->SetTitleSize(0.05);
+    hist->GetXaxis()->SetLabelSize(0.05);
+    hist->GetYaxis()->SetLabelSize(0.05);
+    hist->Fit("gaus", "Q", "R", 1., 6.);
+    hist->Draw();    
+  }
+  locCanvas->cd(2);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (locHistTAGMcol27 != NULL){
+    TH1I* hist = locHistTAGMcol27;
+    hist->SetStats(0);
+    hist->GetXaxis()->SetTitleSize(0.05);
+    hist->GetYaxis()->SetTitleSize(0.05);
+    hist->GetXaxis()->SetLabelSize(0.05);
+    hist->GetYaxis()->SetLabelSize(0.05);
+    hist->Fit("gaus", "Q", "R", 1., 6.);
+    hist->Draw();    
+  }
+  locCanvas->cd(3);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (locHistTAGMcol81 != NULL){
+    TH1I* hist = locHistTAGMcol81;
+    hist->SetStats(0);
+    hist->GetXaxis()->SetTitleSize(0.05);
+    hist->GetYaxis()->SetTitleSize(0.05);
+    hist->GetXaxis()->SetLabelSize(0.05);
+    hist->GetYaxis()->SetLabelSize(0.05);
+    hist->Fit("gaus", "Q", "R", 1., 6.);
+    hist->Draw();    
+  }
+  locCanvas->cd(4);
+  gPad->SetTicks();
+  gPad->SetGrid();
+  if (locHistTAGMcol99 != NULL){
+    TH1I* hist = locHistTAGMcol99;
+    hist->SetStats(0);
+    hist->GetXaxis()->SetTitleSize(0.05);
+    hist->GetYaxis()->SetTitleSize(0.05);
+    hist->GetXaxis()->SetLabelSize(0.05);
+    hist->GetYaxis()->SetLabelSize(0.05);
+    hist->Fit("gaus", "Q", "R", 1., 6.);
+    hist->Draw();    
+  }
+
+  cout<< "Entered macro: TAGM_online/HistMacro_TAGMCOL.C" << endl;
+
+#ifdef ROOTSPY_MACROS
+
+  // -- The following is used by RSAI --
+  cout<< "the following code for RSAI is in macro TAGM_online/HistMacro_TAGMCOL.C" << endl;
+
+  if (rs_GetFlag("Is_RSAI") == 1) {
+
+    int Nhits = tagmCol9->GetEntries();
+    if (Nhits>1e4) {
+      rs_SavePad("TAGM_Column9",1);
+      rs_SavePad("TAGM_Column27",2);
+      rs_SavePad("TAGM_Column81",3);
+      rs_SavePad("TAGM_Column99",4);    
+
+      rs_ResetAllMacroHistos("//HistMacro_TAGMCOL");
+    }
+  }
+
+
+#endif
+
+}

--- a/src/plugins/monitoring/TAGM_online/HistMacro_TAGMCOL.C
+++ b/src/plugins/monitoring/TAGM_online/HistMacro_TAGMCOL.C
@@ -90,10 +90,11 @@
 
     int Nhits = tagmCol9->GetEntries();
     if (Nhits>1e4) {
-      rs_SavePad("TAGM_Column9",1);
-      rs_SavePad("TAGM_Column27",2);
-      rs_SavePad("TAGM_Column81",3);
-      rs_SavePad("TAGM_Column99",4);    
+      rs_SavePad("TAGM_ColumnsAll4",0);
+      //rs_SavePad("TAGM_Column9",1);
+      //rs_SavePad("TAGM_Column27",2);
+      //rs_SavePad("TAGM_Column81",3);
+      //rs_SavePad("TAGM_Column99",4);    
 
       rs_ResetAllMacroHistos("//HistMacro_TAGMCOL");
     }

--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.cc
@@ -1,6 +1,6 @@
 // $Id$
 //
-//    File: JEventProcessor_FCAL_online.cc
+//    File: JEventProcessor_TAGM_online.cc
 // Created: Fri Nov  9 11:58:09 EST 2012
 // Creator: wolin (on Linux stan.jlab.org 2.6.32-279.11.1.el6.x86_64 x86_64)
 
@@ -133,6 +133,7 @@ static TH2F *tagm_adc_mult_2d,  *tagms_adc_mult_2d;
 static TH2F *tagm_tdc_mult_2d,  *tagms_tdc_mult_2d;
 static TH2F *tagm_adc_tdc_mult;
 
+static TH1F *tagmCol9, *tagmCol27, *tagmCol81, *tagmCol99;
 
 //----------------------------------------------------------------------------------
 
@@ -169,6 +170,11 @@ jerror_t JEventProcessor_TAGM_online::init(void) {
   TDirectory *main = gDirectory;
   TDirectory *tagmdir = gDirectory->mkdir("tagm");
   tagmdir->cd();
+
+  tagmCol9  = new TH1F("tagmCol9",  "TAGM Hits in Column9", 7, -0.5, 6.5);
+  tagmCol27 = new TH1F("tagmCol27", "TAGM Hits in Column27", 7, -0.5, 6.5);
+  tagmCol81 = new TH1F("tagmCol81", "TAGM Hits in Column81", 7, -0.5, 6.5);
+  tagmCol99 = new TH1F("tagmCol99", "TAGM Hits in Column99", 7, -0.5, 6.5);
  
   // Book DTAGMDigiHit histosgrams 
   tagm_adc_seen    = new TH1F("tagm_adc_seen", 
@@ -649,6 +655,18 @@ jerror_t JEventProcessor_TAGM_online::evnt(JEventLoop *eventLoop, uint64_t event
       // Calculate the FADC250 multiplicities for each channel
       ++column_adc_hits[column - 1];
       ++column_adc_hits_total;
+    } else {
+      // fill hits into col 9, 27, 81 and 99
+      //cout<<eventnumber<<"  "<<column<<"  "<<row<<endl;
+      if (column == 9){
+	tagmCol9->Fill(row);
+      } else if  (column == 27){
+	tagmCol27->Fill(row);
+      } else if  (column == 81){
+	tagmCol81->Fill(row);
+      } else if  (column == 99){
+	tagmCol99->Fill(row);
+      } 
     }
   }
 


### PR DESCRIPTION
microscope column 9, 27, 81 and 99 and add a root macro to plot these histograms to be also used in online monitoring and HYDRA
this will serve as a monitoring tool to check that the focal plane of the electrons in the tagger hodoscope is where is should be. During the last run period 2023-01 we moved the center to counter 4 from the bottom. (total of 6 segments)
