### PR TITLE
move all include directives from the .cc code to the .h incude file and

### DIFF
--- a/src/libraries/CDC/DCDCHit_factory_Calib.cc
+++ b/src/libraries/CDC/DCDCHit_factory_Calib.cc
@@ -6,21 +6,8 @@
 //
 
 
-#include <iostream>
-#include <iomanip>
-using namespace std;
-
-
 #include <CDC/DCDCHit_factory_Calib.h>
-#include <CDC/DCDCDigiHit.h>
-#include <CDC/DCDCWire.h>
-#include <DAQ/Df125PulseIntegral.h>
-#include <DAQ/Df125Config.h>
-#include <DAQ/Df125CDCPulse.h>
 
-using namespace jana;
-
-int CDC_HIT_THRESHOLD = 0;
 
 //#define ENABLE_UPSAMPLING
 
@@ -30,6 +17,7 @@ int CDC_HIT_THRESHOLD = 0;
 jerror_t DCDCHit_factory_Calib::init(void)
 {
   
+  CDC_HIT_THRESHOLD = 0;
   gPARMS->SetDefaultParameter("CDC:CDC_HIT_THRESHOLD", CDC_HIT_THRESHOLD,
                               "Remove CDC Hits with peak amplitudes smaller than CDC_HIT_THRESHOLD");
   

--- a/src/libraries/CDC/DCDCHit_factory_Calib.h
+++ b/src/libraries/CDC/DCDCHit_factory_Calib.h
@@ -8,19 +8,21 @@
 #ifndef _DCDCHit_factory_Calib_
 #define _DCDCHit_factory_Calib_
 
+#include <iostream>
+#include <iomanip>
 #include <vector>
-using namespace std;
-
 #include <JANA/JFactory.h>
 #include <HDGEOMETRY/DGeometry.h>
 #include <TTAB/DTranslationTable.h>
 #include <DAQ/Df125PulseIntegral.h>
 #include <DAQ/Df125Config.h>
 #include <DAQ/Df125CDCPulse.h>
+#include <CDC/DCDCDigiHit.h>
+#include <CDC/DCDCWire.h>
+#include "CDC/DCDCHit.h"
 
-#include "DCDCHit.h"
-#include "DCDCDigiHit.h"
-#include "DCDCWire.h"
+using namespace std;
+using namespace jana;
 
 // store constants indexed by ring/straw number
 typedef  vector< vector<double> >  cdc_digi_constants_t;
@@ -30,6 +32,8 @@ class DCDCHit_factory_Calib:public jana::JFactory<DCDCHit>{
   DCDCHit_factory_Calib(){};
   ~DCDCHit_factory_Calib(){};
   const char* Tag(void){return "Calib";}
+
+  int CDC_HIT_THRESHOLD;
 
   // overall scale factors.
   double a_scale, amp_a_scale;


### PR DESCRIPTION
also move the variable CDC_HIT_THRESHOLD from being a global variable definition in the .cc file to be a public member the the class in the .h file. This makes the code hopfefull more complient with standards and more thread safe.

The is needed to make sure the use of the variable CDC_HIT_THRESHOLD is threadsafe