### PR TITLE
CCAL Shower Cleanup

### DIFF
--- a/src/libraries/CCAL/DCCALShower.cc
+++ b/src/libraries/CCAL/DCCALShower.cc
@@ -12,7 +12,6 @@
 
 DCCALShower::DCCALShower():ExyztCovariance(5)
 {
-
   E        =  0.;
   Esum     =  0.;
   
@@ -32,10 +31,9 @@ DCCALShower::DCCALShower():ExyztCovariance(5)
   idmax    =  0;
   id       =  0;
   type     =  0;
-
 }
 
 DCCALShower::~DCCALShower()
 {
-
+  
 }

--- a/src/libraries/CCAL/DCCALShower.h
+++ b/src/libraries/CCAL/DCCALShower.h
@@ -26,157 +26,151 @@ using namespace jana;
 
 #define CCAL_USER_HITS_MAX  1000
 
-
 class DCCALShower : public JObject {
-  	
-	public:
-      		JOBJECT_PUBLIC(DCCALShower);
-      
-      		DCCALShower();
-      		~DCCALShower();
-      
-      		/*----------------------------------------//
-      
-      		Description of DCCALShower variables:
-      		
-      		- E:       Energy of shower as reconstructed from island algorithm
-      		- Esum:    Energy of shower calculated as simple sum of block energies
-      		
-      		- x , y :  Shower position reported from island algorithm
-      		- x1, y1:  Shower position calculated using logarithmic weights
-      		- z:       Z-Position of CCAL Face
-      		
-      		- dime:    Number of hits contributing to shower
-      		- idmax:   The channel number of cell with maximum energy deposition
-      		- id:      Only non-zero for showers that share a single peak
-			
-      		- chi2:    The chi2-value reported from island
-      		- sigma_E: Energy resolution (needs work)
-      		- Emax:    Energy of maximum cell
-      		- time:    Energy-weighted average of shower's constituent times 
-				(with time-walk correction)
-      		
-      		- ClusterType (enum):
-        	
-		  SinglePeak - shower is in a single-peak cluster
-		  MultiPeak  - shower is in a multi-peak cluster
-		
-      		- PeakType (enum) :
-      		
-        	  OneGamma  - The peak this shower belongs to has just one gamma reconstructed
-		  TwoGammas - The peak this shower belongs to has two gammas reconstructed
-		
-		
-      		
-      		//----------------------------------------*/
-		
-      		double E;
-      		double Esum;
-      		
-      		double x;
-      		double y;
-      		double x1;
-      		double y1;
-      		double z;
-      		
-      		double chi2;
-      		double sigma_E;
-      		double Emax;
-      		double time;
-      		double sigma_t;
-      		
-      		int dime;
-      		int idmax;
-      		int id;
-      		int type;
-		
-		ClusterType_t ClusterType;
-		PeakType_t PeakType;
-      		
-		vector<DCCALHit>hitsInCluster;
-		
-		TMatrixFSym ExyztCovariance;
-		
-		float EErr() const { return sqrt(ExyztCovariance(0,0)); }
-		float xErr() const { return sqrt(ExyztCovariance(1,1)); }
-		float yErr() const { return sqrt(ExyztCovariance(2,2)); }
-		float zErr() const { return sqrt(ExyztCovariance(3,3)); }
-		float tErr() const { return sqrt(ExyztCovariance(4,4)); }
-		float XYcorr() const {
-		  if (xErr()>0 && yErr()>0) return ExyztCovariance(1,2)/xErr()/yErr();
-		  else return 0;
-		}
-		float XZcorr() const {
-		  if (xErr()>0 && zErr()>0) return ExyztCovariance(1,3)/xErr()/zErr();
-		  else return 0;
-		}
-		float YZcorr() const {
-		  if (yErr()>0 && zErr()>0) return ExyztCovariance(2,3)/yErr()/zErr();
-		  else return 0;
-		}
-		float EXcorr() const {
-		  if (EErr()>0 && xErr()>0) return ExyztCovariance(0,1)/EErr()/xErr();
-		  else return 0;
-		}
-		float EYcorr() const {
-		  if (EErr()>0 && yErr()>0) return ExyztCovariance(0,2)/EErr()/yErr();
-		  else return 0;
-		}
-		float EZcorr() const {
-		  if (EErr()>0 && zErr()>0) return ExyztCovariance(0,3)/EErr()/zErr();
-		  else return 0;
-		}
-		float XTcorr() const {
-		  if (xErr()>0 && tErr()>0) return ExyztCovariance(1,4)/xErr()/tErr();
-		  else return 0;
-		}
-		float YTcorr() const {
-		  if (yErr()>0 && tErr()>0) return ExyztCovariance(2,4)/yErr()/tErr();
-		  else return 0;
-		}
-		float ZTcorr() const {
-		  if (zErr()>0 && tErr()>0) return ExyztCovariance(3,4)/zErr()/tErr();
-		  else return 0;
-		}
-		float ETcorr() const {
-		  if (EErr()>0 && tErr()>0) return ExyztCovariance(0,4)/EErr()/tErr();
-		  else return 0;
-		}
-
-      		void toStrings(vector<pair<string,string> > &items) const {
-		  AddString(items, "E(GeV)",      "%2.3f",  E);
-		  AddString(items, "Emax(GeV)",   "%2.3f",  Emax);
-		  AddString(items, "x(cm)",       "%3.3f",  x);
-		  AddString(items, "y(cm)",       "%3.3f",  y);
-		  AddString(items, "x1(cm)",      "%3.3f",  x1);
-		  AddString(items, "y1(cm)",      "%3.3f",  y1);
-		  AddString(items, "z(cm)",       "%3.3f",  z);
-		  AddString(items, "chi2",        "%3.3f",  chi2);
-		  AddString(items, "dime",        "%3d",    dime);
-		  AddString(items, "idmax",       "%3d",    idmax);
-		  AddString(items, "id",          "%3d",    id);
-		  AddString(items, "sigma_E",     "%3.1f",  sigma_E);
-		  AddString(items, "t(ns)",       "%2.3f",  time);
-		  AddString(items, "ClusterType", "%d",     (int)ClusterType);
-		  AddString(items, "PeakType",    "%d",     (int)PeakType);
-
-		  AddString(items, "EXcorr", "%5.3f", EXcorr());
-		  AddString(items, "EYcorr", "%5.3f", EYcorr());
-		  AddString(items, "EZcorr", "%5.3f", EZcorr());
-		  AddString(items, "ETcorr", "%5.3f", ETcorr());
-		  AddString(items, "XYcorr", "%5.3f", XYcorr());
-		  AddString(items, "XZcorr", "%5.3f", XZcorr());
-		  AddString(items, "XTcorr", "%5.3f", XTcorr());
-		  AddString(items, "YZcorr", "%5.3f", YZcorr());
-		  AddString(items, "YTcorr", "%5.3f", YTcorr());
-		  AddString(items, "ZTcorr", "%5.3f", ZTcorr());
-      		}
-      		
-         private:
-
-
+  
+ public:
+  JOBJECT_PUBLIC(DCCALShower);
+  
+  DCCALShower();
+  ~DCCALShower();
+  
+  /*----------------------------------------
+    
+    Description of DCCALShower variables:
+    
+    - E:       Energy of shower as reconstructed from island algorithm
+    - Esum:    Energy of shower calculated as simple sum of block energies
+    
+    - x , y :  Shower position reported from island algorithm
+    - x1, y1:  Shower position calculated using logarithmic weights
+    - z:       Z-Position of CCAL Face
+    
+    - dime:    Number of hits contributing to shower
+    - idmax:   The channel number of cell with maximum energy deposition
+    - id:      Only non-zero for showers that share a single peak
+    
+    - chi2:    The chi2-value reported from island
+    - sigma_E: Energy resolution (needs work)
+    - Emax:    Energy of maximum cell
+    - time:    Energy-weighted average of shower's constituent times 
+    (with time-walk correction)
+    
+    - ClusterType (enum):
+    
+    SinglePeak - shower is in a single-peak cluster
+    MultiPeak  - shower is in a multi-peak cluster
+    
+    - PeakType (enum) :
+    
+    OneGamma  - The peak this shower belongs to has just one gamma reconstructed
+    TwoGammas - The peak this shower belongs to has two gammas reconstructed
+    
+    ----------------------------------------*/
+  
+  double E;
+  double Esum;
+  
+  double x;
+  double y;
+  double x1;
+  double y1;
+  double z;
+  
+  double chi2;
+  double sigma_E;
+  double Emax;
+  double time;
+  double sigma_t;
+  
+  int dime;
+  int idmax;
+  int id;
+  int type;
+  
+  ClusterType_t ClusterType;
+  PeakType_t PeakType;
+  
+  vector<DCCALHit>hitsInCluster;
+  
+  TMatrixFSym ExyztCovariance;
+  
+  float EErr() const { return sqrt(ExyztCovariance(0,0)); }
+  float xErr() const { return sqrt(ExyztCovariance(1,1)); }
+  float yErr() const { return sqrt(ExyztCovariance(2,2)); }
+  float zErr() const { return sqrt(ExyztCovariance(3,3)); }
+  float tErr() const { return sqrt(ExyztCovariance(4,4)); }
+  float XYcorr() const {
+    if (xErr()>0 && yErr()>0) return ExyztCovariance(1,2)/xErr()/yErr();
+    else return 0;
+  }
+  float XZcorr() const {
+    if (xErr()>0 && zErr()>0) return ExyztCovariance(1,3)/xErr()/zErr();
+    else return 0;
+  }
+  float YZcorr() const {
+    if (yErr()>0 && zErr()>0) return ExyztCovariance(2,3)/yErr()/zErr();
+    else return 0;
+  }
+  float EXcorr() const {
+    if (EErr()>0 && xErr()>0) return ExyztCovariance(0,1)/EErr()/xErr();
+    else return 0;
+  }
+  float EYcorr() const {
+    if (EErr()>0 && yErr()>0) return ExyztCovariance(0,2)/EErr()/yErr();
+    else return 0;
+  }
+  float EZcorr() const {
+    if (EErr()>0 && zErr()>0) return ExyztCovariance(0,3)/EErr()/zErr();
+    else return 0;
+  }
+  float XTcorr() const {
+    if (xErr()>0 && tErr()>0) return ExyztCovariance(1,4)/xErr()/tErr();
+    else return 0;
+  }
+  float YTcorr() const {
+    if (yErr()>0 && tErr()>0) return ExyztCovariance(2,4)/yErr()/tErr();
+    else return 0;
+  }
+  float ZTcorr() const {
+    if (zErr()>0 && tErr()>0) return ExyztCovariance(3,4)/zErr()/tErr();
+    else return 0;
+  }
+  float ETcorr() const {
+    if (EErr()>0 && tErr()>0) return ExyztCovariance(0,4)/EErr()/tErr();
+    else return 0;
+  }
+  
+  void toStrings(vector<pair<string,string> > &items) const {
+    AddString(items, "E(GeV)",      "%2.3f",  E);
+    AddString(items, "Emax(GeV)",   "%2.3f",  Emax);
+    AddString(items, "x(cm)",       "%3.3f",  x);
+    AddString(items, "y(cm)",       "%3.3f",  y);
+    AddString(items, "x1(cm)",      "%3.3f",  x1);
+    AddString(items, "y1(cm)",      "%3.3f",  y1);
+    AddString(items, "z(cm)",       "%3.3f",  z);
+    AddString(items, "chi2",        "%3.3f",  chi2);
+    AddString(items, "dime",        "%3d",    dime);
+    AddString(items, "idmax",       "%3d",    idmax);
+    AddString(items, "id",          "%3d",    id);
+    AddString(items, "sigma_E",     "%3.1f",  sigma_E);
+    AddString(items, "t(ns)",       "%2.3f",  time);
+    AddString(items, "ClusterType", "%d",     (int)ClusterType);
+    AddString(items, "PeakType",    "%d",     (int)PeakType);
+    
+    AddString(items, "EXcorr", "%5.3f", EXcorr());
+    AddString(items, "EYcorr", "%5.3f", EYcorr());
+    AddString(items, "EZcorr", "%5.3f", EZcorr());
+    AddString(items, "ETcorr", "%5.3f", ETcorr());
+    AddString(items, "XYcorr", "%5.3f", XYcorr());
+    AddString(items, "XZcorr", "%5.3f", XZcorr());
+    AddString(items, "XTcorr", "%5.3f", XTcorr());
+    AddString(items, "YZcorr", "%5.3f", YZcorr());
+    AddString(items, "YTcorr", "%5.3f", YTcorr());
+    AddString(items, "ZTcorr", "%5.3f", ZTcorr());
+  }
+  
+ private:
+  
 };
 
-
 #endif  //  _DCCALShower_
-

--- a/src/libraries/CCAL/DCCALShower_factory.cc
+++ b/src/libraries/CCAL/DCCALShower_factory.cc
@@ -8,10 +8,8 @@
 
 #include "CCAL/DCCALShower_factory.h"
 
-
 static mutex CCAL_MUTEX;
 //static bool CCAL_PROFILE_LOADED = false;
-
 
 //==========================================================
 //
@@ -21,45 +19,44 @@ static mutex CCAL_MUTEX;
 
 DCCALShower_factory::DCCALShower_factory()
 {
-	// Set defaults:
-	
-    	MIN_CLUSTER_BLOCK_COUNT   =  2;
-	MAX_HITS_FOR_CLUSTERING   =  80;
-    	MIN_CLUSTER_SEED_ENERGY   =  0.035;  /* [GeV] */
-	MIN_CLUSTER_ENERGY        =  0.05;   /* [GeV] */
-	MAX_CLUSTER_ENERGY        =  15.9;   /* [GeV] */
-	TIME_CUT                  =  15.0;   /*  [ns] */
-	
-	SHOWER_DEBUG              =  0;
-	DO_NONLINEAR_CORRECTION   =  1;
-	
-	CCAL_RADIATION_LENGTH     =  0.86;
-	CCAL_CRITICAL_ENERGY      =  1.1e-3;
-	
-	LOG_POS_CONST             =  4.2;
-	
-	
-	gPARMS->SetDefaultParameter( "CCAL:SHOWER_DEBUG", SHOWER_DEBUG );
-	gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_BLOCK_COUNT", MIN_CLUSTER_BLOCK_COUNT, 
-			"minimum number of blocks to form a cluster" );
-	gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_SEED_ENERGY", MIN_CLUSTER_SEED_ENERGY, 
-			"minimum energy for a block to be considered as a seed for a cluster" );
-	gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_ENERGY", MIN_CLUSTER_ENERGY, 
-			"minimum allowed cluster energy" );
-	gPARMS->SetDefaultParameter( "CCAL:MAX_CLUSTER_ENERGY", MAX_CLUSTER_ENERGY, 
-			"maximum allowed cluster energy" );
-	gPARMS->SetDefaultParameter( "CCAL:MAX_HITS_FOR_CLUSTERING", MAX_HITS_FOR_CLUSTERING, 
-			"maximum hits allowed to call clustering algorithm" );
-	gPARMS->SetDefaultParameter( "CCAL:TIME_CUT", TIME_CUT, 
-			"time cut for associating CCAL hits together into a cluster" );
-	gPARMS->SetDefaultParameter( "CCAL:DO_NONLINEAR_CORRECTION", DO_NONLINEAR_CORRECTION, 
-			"set this to zero when no nonlinear correction is desired" );
-	gPARMS->SetDefaultParameter( "CCAL:CCAL_RADIATION_LENGTH", CCAL_RADIATION_LENGTH );
-	gPARMS->SetDefaultParameter( "CCAL:CCAL_CRITICAL_ENERGY", CCAL_CRITICAL_ENERGY );
-	gPARMS->SetDefaultParameter( "CCAL:LOG_POS_CONST", LOG_POS_CONST );
-
-	VERBOSE = 0;              ///< >0 once off info ; >2 event by event ; >3 everything
-	gPARMS->SetDefaultParameter("DFCALShower:VERBOSE", VERBOSE, "Verbosity level for DFCALShower objects and factories");
+  // Set defaults:
+  
+  MIN_CLUSTER_BLOCK_COUNT   =  2;
+  MAX_HITS_FOR_CLUSTERING   =  80;
+  MIN_CLUSTER_SEED_ENERGY   =  0.035;  /* [GeV] */
+  MIN_CLUSTER_ENERGY        =  0.05;   /* [GeV] */
+  MAX_CLUSTER_ENERGY        =  15.9;   /* [GeV] */
+  TIME_CUT                  =  15.0;   /*  [ns] */
+  
+  SHOWER_DEBUG              =  0;
+  DO_NONLINEAR_CORRECTION   =  1;
+  
+  CCAL_RADIATION_LENGTH     =  0.86;
+  CCAL_CRITICAL_ENERGY      =  1.1e-3;
+  
+  LOG_POS_CONST             =  4.2;
+  
+  gPARMS->SetDefaultParameter( "CCAL:SHOWER_DEBUG", SHOWER_DEBUG );
+  gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_BLOCK_COUNT", MIN_CLUSTER_BLOCK_COUNT, 
+			       "minimum number of blocks to form a cluster" );
+  gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_SEED_ENERGY", MIN_CLUSTER_SEED_ENERGY, 
+			       "minimum energy for a block to be considered as a seed for a cluster" );
+  gPARMS->SetDefaultParameter( "CCAL:MIN_CLUSTER_ENERGY", MIN_CLUSTER_ENERGY, 
+			       "minimum allowed cluster energy" );
+  gPARMS->SetDefaultParameter( "CCAL:MAX_CLUSTER_ENERGY", MAX_CLUSTER_ENERGY, 
+			       "maximum allowed cluster energy" );
+  gPARMS->SetDefaultParameter( "CCAL:MAX_HITS_FOR_CLUSTERING", MAX_HITS_FOR_CLUSTERING, 
+			       "maximum hits allowed to call clustering algorithm" );
+  gPARMS->SetDefaultParameter( "CCAL:TIME_CUT", TIME_CUT, 
+			       "time cut for associating CCAL hits together into a cluster" );
+  gPARMS->SetDefaultParameter( "CCAL:DO_NONLINEAR_CORRECTION", DO_NONLINEAR_CORRECTION, 
+			       "set this to zero when no nonlinear correction is desired" );
+  gPARMS->SetDefaultParameter( "CCAL:CCAL_RADIATION_LENGTH", CCAL_RADIATION_LENGTH );
+  gPARMS->SetDefaultParameter( "CCAL:CCAL_CRITICAL_ENERGY", CCAL_CRITICAL_ENERGY );
+  gPARMS->SetDefaultParameter( "CCAL:LOG_POS_CONST", LOG_POS_CONST );
+  
+  VERBOSE = 0;              ///< >0 once off info ; >2 event by event ; >3 everything
+  gPARMS->SetDefaultParameter("DFCALShower:VERBOSE", VERBOSE, "Verbosity level for DFCALShower objects and factories");
 }
 
 
@@ -73,182 +70,165 @@ DCCALShower_factory::DCCALShower_factory()
 
 jerror_t DCCALShower_factory::brun(JEventLoop *locEventLoop, int32_t runnumber)
 {
-    // Only print messages for one thread whenever run number change
-    static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
-    static set<int> runs_announced;
-    pthread_mutex_lock(&print_mutex);
-    bool print_messages = false;
-    if(runs_announced.find(runnumber) == runs_announced.end()){
-        print_messages = true;
-        runs_announced.insert(runnumber);
+  // Only print messages for one thread whenever run number change
+  static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
+  static set<int> runs_announced;
+  pthread_mutex_lock(&print_mutex);
+  bool print_messages = false;
+  if(runs_announced.find(runnumber) == runs_announced.end()){
+    print_messages = true;
+    runs_announced.insert(runnumber);
+  }
+  pthread_mutex_unlock(&print_mutex);
+  
+  DApplication *dapp = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
+  const DGeometry *geom = dapp->GetDGeometry(runnumber);
+  
+  if (geom) {
+    geom->GetTargetZ(m_zTarget);
+    geom->GetCCALPosition(m_CCALdX,m_CCALdY,m_CCALfront);
+  }
+  else{
+    jerr << "No geometry accessible." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }
+  
+  //------------------------------------------------------//
+  //-----------   Read in shower profile data  -----------//
+  
+  std::unique_lock<std::mutex> lck(CCAL_MUTEX);
+  
+  string ccal_profile_file;
+  gPARMS->SetDefaultParameter("CCAL_PROFILE_FILE", ccal_profile_file, 
+			      "CCAL profile data file name");
+  
+  // follow similar procedure as other resources (DMagneticFieldMapFineMesh)
+  
+  map< string,string > profile_file_name;
+  JCalibration *jcalib = dapp->GetJCalibration(runnumber);
+  
+  if(jcalib->GetCalib("/CCAL/profile_data/profile_data_map", profile_file_name))
+  {
+    jout << "Can't find requested /CCAL/profile_data/profile_data_map in CCDB for this run!"
+	 << endl;
+  } else if( profile_file_name.find("map_name") != profile_file_name.end() 
+	     && profile_file_name["map_name"] != "None" )
+  {
+    JResourceManager *jresman = dapp->GetJResourceManager(runnumber);
+    ccal_profile_file = jresman->GetResource(profile_file_name["map_name"]);
+  }
+  
+  if(print_messages)
+    jout<<"Reading CCAL profile data from "<<ccal_profile_file<<" ..."<<endl;
+  
+  // check to see if we actually have a file
+  if(ccal_profile_file.empty())
+  {
+    if(print_messages)
+      jerr << "Empty file..." << endl;
+    return RESOURCE_UNAVAILABLE;
+  }
+  
+  ifstream ccal_profile(ccal_profile_file.c_str());
+  for(int i=0; i<=500; i++) {
+    for(int j=0; j<=i; j++) {
+      int id1, id2;
+      double fcell_hyc, fd2c;
+      
+      ccal_profile >> id1 >> id2 >> fcell_hyc >> fd2c;
+      
+      acell[id1][id2] = fcell_hyc;
+      acell[id2][id1] = fcell_hyc;
+      ad2c[id1][id2] = fd2c;
+      ad2c[id2][id1] = fd2c;
     }
-    pthread_mutex_unlock(&print_mutex);
-
-
-	DApplication *dapp = dynamic_cast<DApplication*>(eventLoop->GetJApplication());
-    	const DGeometry *geom = dapp->GetDGeometry(runnumber);
-	
-	if (geom) {
-      	  geom->GetTargetZ(m_zTarget);
-      	  geom->GetCCALPosition(m_CCALdX,m_CCALdY,m_CCALfront);
-    	}
-    	else{
-      	  jerr << "No geometry accessible." << endl;
-      	  return RESOURCE_UNAVAILABLE;
-    	}
-	
-	
-	//------------------------------------------------------//
-	//-----------   Read in shower profile data  -----------//
-	
-	std::unique_lock<std::mutex> lck(CCAL_MUTEX);
-	
-	string ccal_profile_file;
-	gPARMS->SetDefaultParameter("CCAL_PROFILE_FILE", ccal_profile_file, 
-		"CCAL profile data file name");
-	
-	// follow similar procedure as other resources (DMagneticFieldMapFineMesh)
-	
-	map< string,string > profile_file_name;
-	JCalibration *jcalib = dapp->GetJCalibration(runnumber);
-	
-	if( jcalib->GetCalib("/CCAL/profile_data/profile_data_map", profile_file_name) ) 
-	{
-	  jout << "Can't find requested /CCAL/profile_data/profile_data_map in CCDB for this run!"
-	  	<< endl;
-	
-	} else if( profile_file_name.find("map_name") != profile_file_name.end() 
-		&& profile_file_name["map_name"] != "None" ) 
-	{
-	  JResourceManager *jresman = dapp->GetJResourceManager(runnumber);
-	  ccal_profile_file = jresman->GetResource(profile_file_name["map_name"]);
+  }
+  ccal_profile.close();
+  
+  lck.unlock();
+  
+  //------------------------------------------------------//
+  //----------  Initialize channel status array ----------//
+  
+  for(int icol = 0; icol < MCOL; ++icol) {
+    for(int irow = 0; irow < MROW; ++irow) {
+      if(icol>=5 && icol<=6 && irow>=5 && irow<=6) { stat_ch[irow][icol] = -1; }
+      else { stat_ch[irow][icol] = 0; }
+    }
+  }
+  
+  //------------------------------------------------------//
+  //----------  Read shower timewalk parameters ----------//
+  
+  vector< vector<double> > timewalk_params;
+  if( eventLoop->GetCalib("/CCAL/shower_timewalk_correction",timewalk_params) )
+    jout << "Error loading /CCAL/shower_timewalk_correction !" << endl;
+  else {
+    if( (int)timewalk_params.size() != 2 ) {
+      cout << "DCCALShower_factory: Wrong number of entries to timewalk correction table (should be 144)." << endl;
+      for( int ii = 0; ii < 2; ++ii ) {
+	timewalk_p0.push_back(0.0);
+	timewalk_p1.push_back(0.0);
+	timewalk_p2.push_back(0.0);
+	timewalk_p3.push_back(0.0);
+      }
+    } else {
+      for( vector< vector<double> >::const_iterator iter = timewalk_params.begin(); 
+	   iter != timewalk_params.end(); ++iter ) {
+	if( iter->size() != 4 ) {
+	  cout << "DCCALShower_factory: Wrong number of values in timewalk correction table (should be 4)" << endl;
+	  continue;
 	}
-	
-	if(print_messages)
-		jout<<"Reading CCAL profile data from "<<ccal_profile_file<<" ..."<<endl;
-	
-	// check to see if we actually have a file
-	if(ccal_profile_file.empty()) 
-	{
-	  if(print_messages)
-	    jerr << "Empty file..." << endl;
-	  return RESOURCE_UNAVAILABLE;
+	timewalk_p0.push_back( (*iter)[0] );
+	timewalk_p1.push_back( (*iter)[1] );
+	timewalk_p2.push_back( (*iter)[2] );
+	timewalk_p3.push_back( (*iter)[3] );
+      }
+    }
+  }
+  
+  //------------------------------------------------------//
+  //---------  Read in non-linearity parameters ----------//
+  
+  vector< vector<double> > nonlin_params;
+  if( eventLoop->GetCalib("/CCAL/nonlinear_energy_correction",nonlin_params) )
+    jout << "Error loading /CCAL/nonlinear_energy_correction !" << endl;
+  else {
+    if( (int)nonlin_params.size() != CCAL_CHANS ) {
+      cout << "DCCALShower_factory: Wrong number of entries to nonlinear energy correction table (should be 144)."
+	   << endl;
+      for( int ii = 0; ii < CCAL_CHANS; ++ii ) {
+	Nonlin_p0.push_back(0.0);
+	Nonlin_p1.push_back(0.0);
+	Nonlin_p2.push_back(0.0);
+	Nonlin_p3.push_back(0.0);
+      }
+    } else {
+      for( vector< vector<double> >::const_iterator iter = nonlin_params.begin(); 
+	   iter != nonlin_params.end(); ++iter ) {
+	if( iter->size() != 4 ) {
+	  cout << "DCCALShower_factory: Wrong number of values in nonlinear energy correction table (should be 4)"
+	       << endl;
+	  continue;
 	}
-	
-	ifstream ccal_profile(ccal_profile_file.c_str());
-	for(int i=0; i<=500; i++) {
-	     for(int j=0; j<=i; j++) {
-			int id1, id2;
-			double fcell_hyc, fd2c;
-			
-			ccal_profile >> id1 >> id2 >> fcell_hyc >> fd2c;
-		
-			acell[id1][id2] = fcell_hyc;
-			acell[id2][id1] = fcell_hyc;
-			ad2c[id1][id2] = fd2c;
-			ad2c[id2][id1] = fd2c;
-		}
-	}
-	ccal_profile.close();
-	
-	lck.unlock();
-	
-	
-	
-	
-	//------------------------------------------------------//
-	//----------  Initialize channel status array ----------//
-	
-	for(int icol = 0; icol < MCOL; ++icol) {
-	  for(int irow = 0; irow < MROW; ++irow) {
-	    if(icol>=5 && icol<=6 && irow>=5 && irow<=6) { stat_ch[irow][icol] = -1; }
-	    else { stat_ch[irow][icol] = 0; }
-	  }
-	}
-	
-	
-	
-	
-	//------------------------------------------------------//
-	//----------  Read shower timewalk parameters ----------//
-	
-	vector< vector<double> > timewalk_params;
-	if( eventLoop->GetCalib("/CCAL/shower_timewalk_correction",timewalk_params) )
-	  jout << "Error loading /CCAL/shower_timewalk_correction !" << endl;
-	else {
-	  if( (int)timewalk_params.size() != 2 ) {
-	    cout << "DCCALShower_factory: Wrong number of entries to timewalk correction table (should be 144)." << endl;
-	    for( int ii = 0; ii < 2; ++ii ) {
-	      timewalk_p0.push_back(0.0);
-	      timewalk_p1.push_back(0.0);
-	      timewalk_p2.push_back(0.0);
-	      timewalk_p3.push_back(0.0);
-	    }
-	  } else {
-	    for( vector< vector<double> >::const_iterator iter = timewalk_params.begin(); 
-	    	iter != timewalk_params.end(); ++iter ) {
-	      if( iter->size() != 4 ) {
-	        cout << "DCCALShower_factory: Wrong number of values in timewalk correction table (should be 4)" << endl;
-                continue;
-	      }
-	    
-	      timewalk_p0.push_back( (*iter)[0] );
-	      timewalk_p1.push_back( (*iter)[1] );
-	      timewalk_p2.push_back( (*iter)[2] );
-	      timewalk_p3.push_back( (*iter)[3] );
-	    
-	    }
-	  }
-	}
-	
-	
-	
-	
-	//------------------------------------------------------//
-	//---------  Read in non-linearity parameters ----------//
-	
-	vector< vector<double> > nonlin_params;
-	if( eventLoop->GetCalib("/CCAL/nonlinear_energy_correction",nonlin_params) )
-	  jout << "Error loading /CCAL/nonlinear_energy_correction !" << endl;
-	else {
-	  if( (int)nonlin_params.size() != CCAL_CHANS ) {
-	    cout << "DCCALShower_factory: Wrong number of entries to nonlinear energy correction table (should be 144)." << endl;
-	    for( int ii = 0; ii < CCAL_CHANS; ++ii ) {
-	      Nonlin_p0.push_back(0.0);
-	      Nonlin_p1.push_back(0.0);
-	      Nonlin_p2.push_back(0.0);
-	      Nonlin_p3.push_back(0.0);
-	    }
-	  } else {
-	    for( vector< vector<double> >::const_iterator iter = nonlin_params.begin(); 
-	    	iter != nonlin_params.end(); ++iter ) {
-	      if( iter->size() != 4 ) {
-	        cout << "DCCALShower_factory: Wrong number of values in nonlinear energy correction table (should be 4)" << endl;
-                continue;
-	      }
-	    
-	      Nonlin_p0.push_back( (*iter)[0] );
-	      Nonlin_p1.push_back( (*iter)[1] );
-	      Nonlin_p2.push_back( (*iter)[2] );
-	      Nonlin_p3.push_back( (*iter)[3] );
-	    
-	    }
-	  }
-	}
-	
-	if( SHOWER_DEBUG ) {
-	  cout << "\n\nNONLIN_P0  NONLIN_P1  NONLIN_P2  NONLIN_P3" << endl;
-	  for(int ii = 0; ii < (int)Nonlin_p0.size(); ii++) {
-	    cout << Nonlin_p0[ii] << " " << Nonlin_p1[ii] << " " << Nonlin_p2[ii] << " " << 
-	    	Nonlin_p3[ii] << endl;
-	  }
-	  cout << "\n\n";
-	}
-	
-	
-	
-	
-	return NOERROR;
+	Nonlin_p0.push_back( (*iter)[0] );
+	Nonlin_p1.push_back( (*iter)[1] );
+	Nonlin_p2.push_back( (*iter)[2] );
+	Nonlin_p3.push_back( (*iter)[3] );
+      }
+    }
+  }
+  
+  if(SHOWER_DEBUG) {
+    cout << "\n\nNONLIN_P0  NONLIN_P1  NONLIN_P2  NONLIN_P3" << endl;
+    for(int ii = 0; ii < (int)Nonlin_p0.size(); ii++) {
+      cout << Nonlin_p0[ii] << " " << Nonlin_p1[ii] << " " << Nonlin_p2[ii] << " " << 
+	Nonlin_p3[ii] << endl;
+    }
+    cout << "\n\n";
+  }
+  
+  return NOERROR;
 }
 
 
@@ -262,172 +242,148 @@ jerror_t DCCALShower_factory::brun(JEventLoop *locEventLoop, int32_t runnumber)
 
 jerror_t DCCALShower_factory::evnt(JEventLoop *locEventLoop, uint64_t eventnumber)
 {
-	
-	
-	vector< const DCCALGeometry* > ccalGeomVect;
-    	locEventLoop->Get( ccalGeomVect );
-	if (ccalGeomVect.size() < 1)
-      	  return OBJECT_NOT_AVAILABLE;
-    	const DCCALGeometry& ccalGeom = *(ccalGeomVect[0]);
-	
-	
-	
-	
-	//------- Get the CCALHits and organize hit pattern -------//
-	
-	
-	vector< const DCCALHit* > ccalhits;
-	locEventLoop->Get( ccalhits );
-	
-	int n_hits = static_cast<int>( ccalhits.size() );
-	if( n_hits < 1 || n_hits > MAX_HITS_FOR_CLUSTERING ) return NOERROR;
-	
-	
-	vector< vector< const DCCALHit* > > hitPatterns;
-	getHitPatterns( ccalhits, hitPatterns );
-	
-	int n_patterns = static_cast<int>( hitPatterns.size() );
-	if( n_patterns < 1 ) return NOERROR;
-	
-	vector< ccalcluster_t > ccalClusters; // will hold all clusters
-	vector< cluster_t > clusterStorage;   // will hold the constituents of every cluster
-	
-	
-	
-	
-	//-------  Call island clusterizer on each pattern  -------//
-	
-	
-	for( int ipat = 0; ipat < n_patterns; ipat++ ) 
-	{
-	
-	  
-	  /*-----  prepare data in dimensionless format  -----*/
-	  
-	  vector< const DCCALHit* > rawHitPattern = hitPatterns[ipat];
-	  vector< const DCCALHit* > locHitPattern;
-	  cleanHitPattern( rawHitPattern, locHitPattern );
-	  
-	  int n_hits = static_cast<int>( locHitPattern.size() );
-	  
-	  vector< int > ia;
-	  vector< int > id;
-	  	  
-	  for( int ih = 0; ih < n_hits; ih++ ) {
-	    const DCCALHit *ccalhit = locHitPattern[ih];
-	    int row = 12 - ccalhit->row;
-	    int col = 12 - ccalhit->column;
-	    int ie  = static_cast<int>( ccalhit->E*10. + 0.5 );
-	    if( ie > 0 ) {
-	      int address = 100*col + row;
-	      ia.push_back( address );
-	      id.push_back( ie );
-	    }
-	  }
-	  
-	  
-	  /*-------------     call to island     -------------*/
-	  	  
-	  vector< gamma_t > gammas; gammas.clear();// Output of main_island (holds reconstructed photons)
-	  main_island( ia, id, gammas );
-	
-	
-	  /*------------  post-island processing  ------------*/
-	  	
-	  int init_clusters = static_cast<int>( gammas.size() );
-	  if( !init_clusters ) continue;
-	  
-	  processShowers( gammas, ccalGeom, locHitPattern, eventnumber, 
-	  	ccalClusters, clusterStorage );
-	  
-	  
-	} // end looping over hit patterns
-	
-	
-	
-	
-	//--------------   Fill DCCALShower Object   --------------//
-	
-	int n_clusters = static_cast<int>( ccalClusters.size() );
-	
-	for( int k = 0; k < n_clusters; k++ ) {
-	
-	  DCCALShower *shower = new DCCALShower;
-	  
-	  shower->E        =   ccalClusters[k].E;
-	  shower->Esum     =   ccalClusters[k].Esum;
-	  
-	  shower->x        =   ccalClusters[k].x+m_CCALdX;
-	  shower->y        =   ccalClusters[k].y+m_CCALdY;
-	  shower->x1       =   ccalClusters[k].x1+m_CCALdX;
-	  shower->y1       =   ccalClusters[k].y1+m_CCALdY;
-	  shower->z        =   m_CCALfront;
-	  
-	  shower->chi2     =   ccalClusters[k].chi2;
-	  shower->sigma_E  =   ccalClusters[k].sigma_E;
-	  shower->Emax     =   ccalClusters[k].emax;
-	  shower->time     =   ccalClusters[k].time;
-	  
-	  shower->dime     =   ccalClusters[k].nhits;
-	  shower->idmax    =   ccalClusters[k].idmax;
-	  shower->id       =   ccalClusters[k].id;
-	  
-	  shower->type     =   ccalClusters[k].type;
-	  
-	  int showTypeVal     = (ccalClusters[k].type)/10;	  
-	  shower->ClusterType = static_cast<ClusterType_t>( showTypeVal/2 );
-	  shower->PeakType    = static_cast<PeakType_t>( showTypeVal%2 );
-	  //shower->ExyztCovariance(i, j)
-	  float xerr = 0.1016;// / sqrt(ccalClusters[k].E) + 0.2219; // HARD CODED VALUE!!!!   
-	  float yerr = 0.1016;// / sqrt(ccalClusters[k].E) + 0.2219; // HARD CODED VALUE!!!!   
-	  float zerr = 2.5; // HARD CODED VALUE!!!!   
-	  float terr = 0.2; // HARD CODED VALUE!!!!   
-	  float eerr = 0.5;//pow(ccalClusters[k].E, 2) * (0.01586 / ccalClusters[k].E + 0.0002342 / pow(ccalClusters[k].E, 2) + 1.696e-6); // HARD CODED VALUE!!!!   
-	  //copy xyz errors into covariance matrix
-	  shower->ExyztCovariance.ResizeTo(5,5);
-	  for (int col = 0; col < 5; col ++) {
-	    for (int row = 0; row < 5; row ++) {
-	      if (col != row) shower->ExyztCovariance[col][row] = 0;
-	    }
-	  }
-	  shower->ExyztCovariance[0][0] = pow(xerr, 2);
-	  shower->ExyztCovariance[1][1] = pow(yerr, 2);
-	  shower->ExyztCovariance[2][2] = pow(zerr, 2);
-	  shower->ExyztCovariance[3][3] = pow(terr, 2);
-	  shower->ExyztCovariance[4][4] = pow(eerr, 2);
-	  
-	  if (VERBOSE>2) {printf("(E,x,y,z,t)    "); shower->ExyztCovariance.Print(); }
-
-	  shower->hitsInCluster.clear();
-	  for( int icell = 0; icell < ccalClusters[k].nhits; icell++ ) {
-	    
-	    int hitID   = clusterStorage[k].id[icell];
-	    float hitX = ccalGeom.positionOnFace( hitID ).X();
-	    float hitY = ccalGeom.positionOnFace( hitID ).Y();
-	    int hitROW  = ccalGeom.row( hitY );
-	    int hitCOL  = ccalGeom.column( hitX );
-	    	    
-	    DCCALHit clusHit;
-	    clusHit.row    = hitROW;
-	    clusHit.column = hitCOL;
-	    clusHit.x      = hitX;
-	    clusHit.y      = hitY;
-	    clusHit.E      = static_cast<float>( 1000.*clusterStorage[k].E[icell] );
-	    clusHit.t      = static_cast<float>( clusterStorage[k].t[icell] );
-	    
-	    shower->hitsInCluster.push_back( clusHit );
-	    
-	  }
-
-	  _data.push_back( shower );
-	}
-
-
-	return NOERROR;
-	
+  vector< const DCCALGeometry* > ccalGeomVect;
+  locEventLoop->Get( ccalGeomVect );
+  if (ccalGeomVect.size() < 1)
+    return OBJECT_NOT_AVAILABLE;
+  const DCCALGeometry& ccalGeom = *(ccalGeomVect[0]);
+  
+  //------- Get the CCALHits and organize hit pattern -------//
+  
+  vector< const DCCALHit* > ccalhits;
+  locEventLoop->Get( ccalhits );
+  
+  int n_hits = static_cast<int>( ccalhits.size() );
+  if( n_hits < 1 || n_hits > MAX_HITS_FOR_CLUSTERING ) return NOERROR;
+  
+  vector< vector< const DCCALHit* > > hitPatterns;
+  getHitPatterns( ccalhits, hitPatterns );
+  
+  int n_patterns = static_cast<int>( hitPatterns.size() );
+  if( n_patterns < 1 ) return NOERROR;
+  
+  vector< ccalcluster_t > ccalClusters; // will hold all clusters
+  vector< cluster_t > clusterStorage;   // will hold the constituents of every cluster
+  
+  //-------  Call island clusterizer on each pattern  -------//
+  
+  for( int ipat = 0; ipat < n_patterns; ipat++ ) 
+  {
+    
+    /*-----  prepare data in dimensionless format  -----*/
+    
+    vector< const DCCALHit* > rawHitPattern = hitPatterns[ipat];
+    vector< const DCCALHit* > locHitPattern;
+    cleanHitPattern( rawHitPattern, locHitPattern );
+    
+    int n_hits = static_cast<int>( locHitPattern.size() );
+    
+    vector< int > ia;
+    vector< int > id;
+    
+    for( int ih = 0; ih < n_hits; ih++ ) {
+      const DCCALHit *ccalhit = locHitPattern[ih];
+      int row = 12 - ccalhit->row;
+      int col = 12 - ccalhit->column;
+      int ie  = static_cast<int>( ccalhit->E*10. + 0.5 );
+      if( ie > 0 ) {
+	int address = 100*col + row;
+	ia.push_back( address );
+	id.push_back( ie );
+      }
+    }
+    
+    /*-------------     call to island     -------------*/
+    
+    vector< gamma_t > gammas; gammas.clear();// Output of main_island (holds reconstructed photons)
+    main_island( ia, id, gammas );
+    
+    /*------------  post-island processing  ------------*/
+    
+    int init_clusters = static_cast<int>( gammas.size() );
+    if( !init_clusters ) continue;
+    
+    processShowers( gammas, ccalGeom, locHitPattern, eventnumber, 
+		    ccalClusters, clusterStorage );
+    
+  } // end looping over hit patterns
+  
+  //--------------   Fill DCCALShower Object   --------------//
+  
+  int n_clusters = static_cast<int>( ccalClusters.size() );
+  
+  for( int k = 0; k < n_clusters; k++ ) {
+    
+    DCCALShower *shower = new DCCALShower;
+    
+    shower->E        =   ccalClusters[k].E;
+    shower->Esum     =   ccalClusters[k].Esum;
+    
+    shower->x        =   ccalClusters[k].x+m_CCALdX;
+    shower->y        =   ccalClusters[k].y+m_CCALdY;
+    shower->x1       =   ccalClusters[k].x1+m_CCALdX;
+    shower->y1       =   ccalClusters[k].y1+m_CCALdY;
+    shower->z        =   m_CCALfront;
+    
+    shower->chi2     =   ccalClusters[k].chi2;
+    shower->sigma_E  =   ccalClusters[k].sigma_E;
+    shower->Emax     =   ccalClusters[k].emax;
+    shower->time     =   ccalClusters[k].time;
+    
+    shower->dime     =   ccalClusters[k].nhits;
+    shower->idmax    =   ccalClusters[k].idmax;
+    shower->id       =   ccalClusters[k].id;
+    
+    shower->type     =   ccalClusters[k].type;
+    
+    int showTypeVal     = (ccalClusters[k].type)/10;	  
+    shower->ClusterType = static_cast<ClusterType_t>( showTypeVal/2 );
+    shower->PeakType    = static_cast<PeakType_t>( showTypeVal%2 );
+    //shower->ExyztCovariance(i, j)
+    float xerr = 0.1016;// / sqrt(ccalClusters[k].E) + 0.2219; // HARD CODED VALUE!!!!   
+    float yerr = 0.1016;// / sqrt(ccalClusters[k].E) + 0.2219; // HARD CODED VALUE!!!!   
+    float zerr = 2.5; // HARD CODED VALUE!!!!   
+    float terr = 0.2; // HARD CODED VALUE!!!!   
+    float eerr = 0.5;//pow(ccalClusters[k].E, 2) * (0.01586 / ccalClusters[k].E + 0.0002342 / pow(ccalClusters[k].E, 2) + 1.696e-6); // HARD CODED VALUE!!!!   
+    //copy xyz errors into covariance matrix
+    shower->ExyztCovariance.ResizeTo(5,5);
+    for (int col = 0; col < 5; col ++) {
+      for (int row = 0; row < 5; row ++) {
+	if (col != row) shower->ExyztCovariance[col][row] = 0;
+      }
+    }
+    shower->ExyztCovariance[0][0] = pow(xerr, 2);
+    shower->ExyztCovariance[1][1] = pow(yerr, 2);
+    shower->ExyztCovariance[2][2] = pow(zerr, 2);
+    shower->ExyztCovariance[3][3] = pow(terr, 2);
+    shower->ExyztCovariance[4][4] = pow(eerr, 2);
+    
+    if (VERBOSE>2) {printf("(E,x,y,z,t)    "); shower->ExyztCovariance.Print(); }
+    
+    shower->hitsInCluster.clear();
+    for( int icell = 0; icell < ccalClusters[k].nhits; icell++ ) {
+      
+      int hitID   = clusterStorage[k].id[icell];
+      float hitX = ccalGeom.positionOnFace( hitID ).X();
+      float hitY = ccalGeom.positionOnFace( hitID ).Y();
+      int hitROW  = ccalGeom.row( hitY );
+      int hitCOL  = ccalGeom.column( hitX );
+      
+      DCCALHit clusHit;
+      clusHit.row    = hitROW;
+      clusHit.column = hitCOL;
+      clusHit.x      = hitX;
+      clusHit.y      = hitY;
+      clusHit.E      = static_cast<float>( 1000.*clusterStorage[k].E[icell] );
+      clusHit.t      = static_cast<float>( clusterStorage[k].t[icell] );
+      
+      shower->hitsInCluster.push_back( clusHit );
+    }
+    _data.push_back( shower );
+  }
+  
+  return NOERROR;
 }
-
-
 
 
 //==========================================================
@@ -436,84 +392,73 @@ jerror_t DCCALShower_factory::evnt(JEventLoop *locEventLoop, uint64_t eventnumbe
 //
 //==========================================================
 
-void DCCALShower_factory::getHitPatterns( vector< const DCCALHit* > hitarray, 
-		vector< vector< const DCCALHit* > > &hitPatterns ) 
+void DCCALShower_factory::getHitPatterns(vector<const DCCALHit*> hitarray, 
+					 vector<vector< const DCCALHit*>> &hitPatterns) 
 {
-
-	/*------------------------------
-	
-	Method for sorting hit patterns:
-	
-	1. Find hit with largest energy.
-	2. Sort hit vector in order of increasing time-difference from this hit
-	3. Push all hits within 15 ns of max hit to a new vector (first few elements of sorted vec)
-	4. Erase the elements that were moved from the previous vector
-		- maybe steps 3&4 can be done simultaneously? 
-	5. Push the new vector back to the hitPatterns vector
-	6. Repeat steps 1-5 until no hits remain in original hitarray
-	
-	--------------------------------*/
-
-	
-	int n_hits = static_cast<int>( hitarray.size() );
-	
-	if( n_hits < 1 ) return;
-	if( n_hits < 2 ) {
-	  vector< const DCCALHit* > hitVec;
-	  hitVec.push_back( hitarray[0] );
-	  hitPatterns.push_back( hitVec );
-	  return;
-	}
-	
-	
-	vector< const DCCALHit* > clonedHitArray = hitarray;
-	
-	while( clonedHitArray.size() ) 
-	{
-	
-	  vector< const DCCALHit* > locHitVec;
-	
-	  float maxE  = -1.;
-	  float maxT  = 1.e6;
-	  
-	  for( unsigned int ih = 0; ih < clonedHitArray.size(); ih++ ) {
-	    float trialE = clonedHitArray[ih]->E;
-	    if( trialE > maxE ) { maxE = trialE; maxT = clonedHitArray[ih]->t; }
-	  }
-	  
-	  if( maxE < 0. ) break;
-	  
-	  
-	  sortByTime( clonedHitArray, maxT );
-	  
-	  
-	  n_hits = static_cast<int>( clonedHitArray.size() );
-	  
-	  int n_good_hits = 0;
-	  for( int ih = 0; ih < n_hits; ih++ ) {
-	  
-	    const DCCALHit *locHit = clonedHitArray[ih];
-	    float timeDiff = fabs( locHit->t - maxT );
-	    
-	    if( timeDiff < TIME_CUT ) {
-	      locHitVec.push_back( locHit );
-	      n_good_hits++;
-	    } else { break; }
-	  
-	  }
-	  
-	  if( locHitVec.size() ) hitPatterns.push_back( locHitVec );
-	  
-	  clonedHitArray.erase( clonedHitArray.begin(), clonedHitArray.begin() + n_good_hits );
-	  
-	}
-	
-	
-	return;
-
+  /*------------------------------
+    
+    Method for sorting hit patterns:
+    
+    1. Find hit with largest energy.
+    2. Sort hit vector in order of increasing time-difference from this hit
+    3. Push all hits within 15 ns of max hit to a new vector (first few elements of sorted vec)
+    4. Erase the elements that were moved from the previous vector
+    - maybe steps 3&4 can be done simultaneously? 
+    5. Push the new vector back to the hitPatterns vector
+    6. Repeat steps 1-5 until no hits remain in original hitarray
+    
+    --------------------------------*/
+  
+  int n_hits = static_cast<int>( hitarray.size() );
+  
+  if( n_hits < 1 ) return;
+  if( n_hits < 2 ) {
+    vector< const DCCALHit* > hitVec;
+    hitVec.push_back( hitarray[0] );
+    hitPatterns.push_back( hitVec );
+    return;
+  }
+  
+  vector< const DCCALHit* > clonedHitArray = hitarray;
+  
+  while(clonedHitArray.size()) 
+  {
+    vector< const DCCALHit* > locHitVec;
+    
+    float maxE  = -1.;
+    float maxT  = 1.e6;
+    
+    for(unsigned int ih = 0; ih < clonedHitArray.size(); ih++) {
+      float trialE = clonedHitArray[ih]->E;
+      if(trialE > maxE) { maxE = trialE; maxT = clonedHitArray[ih]->t; }
+    }
+    
+    if(maxE < 0.) break;
+    
+    sortByTime(clonedHitArray, maxT);
+    
+    n_hits = static_cast<int>(clonedHitArray.size());
+    
+    int n_good_hits = 0;
+    for(int ih = 0; ih < n_hits; ih++) {
+      
+      const DCCALHit *locHit = clonedHitArray[ih];
+      float timeDiff = fabs( locHit->t - maxT );
+      
+      if(timeDiff < TIME_CUT) {
+	locHitVec.push_back(locHit);
+	n_good_hits++;
+      } else { break; }
+      
+    }
+    
+    if(locHitVec.size()) hitPatterns.push_back(locHitVec);
+    
+    clonedHitArray.erase(clonedHitArray.begin(), clonedHitArray.begin() + n_good_hits);
+  }
+  
+  return;
 }
-
-
 
 
 //==========================================================
@@ -522,50 +467,43 @@ void DCCALShower_factory::getHitPatterns( vector< const DCCALHit* > hitarray,
 //
 //==========================================================
 
-void DCCALShower_factory::sortByTime( vector< const DCCALHit* > &hitarray, float hitTime )
+void DCCALShower_factory::sortByTime(vector< const DCCALHit* > &hitarray, float hitTime)
 {
-	
-	int nhits = static_cast<int>( hitarray.size() );
-	
-	if( nhits < 2 ) return; // nothing to sort
-	
-	for( int ih = 1; ih < nhits; ih++ ) 
-	{
+  int nhits = static_cast<int>( hitarray.size() );
+  
+  if( nhits < 2 ) return; // nothing to sort
+  
+  for( int ih = 1; ih < nhits; ih++ ) 
+  {
+    float timeDiff     = fabs( hitarray[ih]->t - hitTime );
+    float lastTimeDiff = fabs( hitarray[ih-1]->t - hitTime );
+    
+    if( timeDiff <= lastTimeDiff ) 
+    {
+      const DCCALHit *Hit = hitarray[ih];
+      
+      for( int ii = ih-1; ii >= -1; ii-- )
+      {
+	if( ii >= 0 ) {
+	  const DCCALHit *locHit = hitarray[ii];
+	  float locTimeDiff = fabs( locHit->t - hitTime );
 	  
-	  float timeDiff     = fabs( hitarray[ih]->t - hitTime );
-	  float lastTimeDiff = fabs( hitarray[ih-1]->t - hitTime );
-	  
-	  if( timeDiff <= lastTimeDiff ) 
-	  {
-	  
-	    const DCCALHit *Hit = hitarray[ih];
-	    
-	    for( int ii = ih-1; ii >= -1; ii-- ) { 
-	      
-	      if( ii >= 0 ) {
-	      
-	        const DCCALHit *locHit = hitarray[ii];
-	        float locTimeDiff = fabs( locHit->t - hitTime );
-	      
-	        if( timeDiff < locTimeDiff ) {
-	          hitarray[ii+1] = locHit;
-	        } else {
-	          hitarray[ii+1] = Hit;
-		  break;
-	        }
-	      } else {
-	        hitarray[0] = Hit;
-	      }
-	    }
-	    
-	  } // end if statement
-	
-	} // end loop over hits
-	
-	return;
+	  if( timeDiff < locTimeDiff ) {
+	    hitarray[ii+1] = locHit;
+	  } else {
+	    hitarray[ii+1] = Hit;
+	    break;
+	  }
+	} else {
+	  hitarray[0] = Hit;
+	}
+      }
+      
+    } // end if statement
+  } // end loop over hits
+  
+  return;
 }
-
-
 
 
 //==========================================================
@@ -574,35 +512,30 @@ void DCCALShower_factory::sortByTime( vector< const DCCALHit* > &hitarray, float
 //
 //==========================================================
 
-void DCCALShower_factory::cleanHitPattern( vector< const DCCALHit* > hitarray, 
-	vector< const DCCALHit* > &hitarrayClean ) 
+void DCCALShower_factory::cleanHitPattern(vector< const DCCALHit* > hitarray, 
+					  vector< const DCCALHit* > &hitarrayClean ) 
 {
-
-	for( vector< const DCCALHit* >::const_iterator iHit = hitarray.begin(); 
-		iHit != hitarray.end(); ++iHit ) {
-	  
-	  int id12 = ((*iHit)->row)*12 + (*iHit)->column;
-	  int findVal = -1;
-	  for( vector<const DCCALHit*>::size_type ii = 0; ii != hitarrayClean.size(); ++ii ) {
-	    int id = 12*(hitarrayClean[ii]->row) + hitarrayClean[ii]->column;
-	    if( id == id12 ) { findVal = (int)ii; break; }
-	  }
-	  if( findVal >= 0 ) {
-	    if( (*iHit)->E > hitarrayClean[findVal]->E ) {
-	      hitarrayClean.erase( hitarrayClean.begin()+findVal );
-	      hitarrayClean.push_back( (*iHit) );
-	    }
-	  } else {
-	    hitarrayClean.push_back( (*iHit) );
-	  }
-	  
- 	}
-
-	return;
-
+  for(vector< const DCCALHit* >::const_iterator iHit = hitarray.begin(); 
+      iHit != hitarray.end(); ++iHit) {
+    
+    int id12 = ((*iHit)->row)*12 + (*iHit)->column;
+    int findVal = -1;
+    for(vector<const DCCALHit*>::size_type ii = 0; ii != hitarrayClean.size(); ++ii) {
+      int id = 12*(hitarrayClean[ii]->row) + hitarrayClean[ii]->column;
+      if(id == id12) { findVal = (int)ii; break; }
+    }
+    if(findVal >= 0) {
+      if((*iHit)->E > hitarrayClean[findVal]->E) {
+	hitarrayClean.erase(hitarrayClean.begin()+findVal);
+	hitarrayClean.push_back((*iHit));
+      }
+    } else {
+      hitarrayClean.push_back((*iHit));
+    }  
+  }
+  
+  return;
 }
-
-
 
 
 //==========================================================
@@ -612,208 +545,185 @@ void DCCALShower_factory::cleanHitPattern( vector< const DCCALHit* > hitarray,
 //==========================================================
 
 void DCCALShower_factory::processShowers( vector< gamma_t > gammas, DCCALGeometry ccalGeom, 
-		vector< const DCCALHit* > locHitPattern, int eventnumber, 
-		vector< ccalcluster_t > &ccalClusters, vector< cluster_t > &clusterStorage )
+					  vector< const DCCALHit* > locHitPattern, int eventnumber, 
+					  vector< ccalcluster_t > &ccalClusters,
+					  vector< cluster_t > &clusterStorage )
 {
-
-
-	//-------------   Do some post-island processing   -------------//
-	
-	
-	int n_clusters = 0;
-	int n_hits = static_cast<int>( locHitPattern.size() );
-	
-	int init_clusters = static_cast<int>( gammas.size() );
-	for( int k = 0; k < init_clusters; k++ )  {
-	  
-	  ccalcluster_t locCluster;    // stores cluster parameters
-	  cluster_t locClusterStorage; // stores hit information of cluster cells
-	  
-	  int type     = gammas[k].type;
-	  int dime     = gammas[k].dime;
-	  int id       = gammas[k].id;
-	  double chi2  = gammas[k].chi2;
-	  double e     = gammas[k].energy;
-	  double x     = gammas[k].x;
-	  double y     = gammas[k].y;
-	  double xc    = gammas[k].xc;
-	  double yc    = gammas[k].yc;
-	  
-	  
-	  // check that shower is not just a single module and that energy is reasonable:
-	  
-	  if( dime < MIN_CLUSTER_BLOCK_COUNT ) { continue; } 
-	  if( e < MIN_CLUSTER_ENERGY || e > MAX_CLUSTER_ENERGY ) { continue; }
-	  
-	  n_clusters++;
-	  
-	  
-	  //------------   Find cell with max energy   ------------//
-	  
-	  double ecellmax = -1; int idmax = -1;
-	  double e1 = 0.0;
-	  for( int j = 0; j < (dime>MAX_CC ? MAX_CC : dime); j++ ) {
-	  
-	    
-	    double ecell = 1.e-4*static_cast<double>( gammas[k].icl_en[j] );
-	    
-	    int ccal_id = gammas[k].icl_in[j];
-	    int kx  = 12 - (ccal_id/100), ky = 12 - (ccal_id%100);
-	    
-	    ccal_id = ky*12 + kx;
-	    
-	    e1 += ecell;
-	    if( ecell > ecellmax ) {
-	      ecellmax = ecell;
-	      idmax = ccal_id;
-	    }
-	  
-	  }
-	  
-	  double xmax = ccalGeom.positionOnFace(idmax).X();
-	  double ymax = ccalGeom.positionOnFace(idmax).Y();
-	  
-	  
-	  //-----------   Loop over constituent hits   ------------//
-	  
-	  double sW   = 0.0;
-	  double xpos = 0.0;
-	  double ypos = 0.0;
-	  double W;
-	  
-	  for( int j = 0; j < (dime>MAX_CC ? MAX_CC : dime); j++ ) {
-	  
-	    int ccal_id = gammas[k].icl_in[j];
-	    int kx  = 12 - (ccal_id/100), ky = 12 - (ccal_id%100);
-	    ccal_id = ky*12 + kx;
-	  
-	    double ecell  = 1.e-4*static_cast<double>( gammas[k].icl_en[j] );
-	    double xcell  = ccalGeom.positionOnFace( ccal_id ).X();
-	    double ycell  = ccalGeom.positionOnFace( ccal_id ).Y();
-	    
-	    if(id%10 == 1 || id%10 == 2) {
-	      xcell += xc;
-	      ycell += yc;
-	    }
-	    
-	    double hittime = 0.;
-	    for( int ihit = 0; ihit < n_hits; ihit++ ) {
-	      int trialid = 12*( locHitPattern[ihit]->row) + locHitPattern[ihit]->column;
-	      if( trialid == ccal_id ) {
-	        hittime = locHitPattern[ihit]->t;
-		break;
-	      }
-	    }
-	    
-	    locClusterStorage.id[j] = ccal_id;
-	    locClusterStorage.E[j]  = ecell;
-	    locClusterStorage.x[j]  = xcell;
-	    locClusterStorage.y[j]  = ycell;
-	    locClusterStorage.t[j]  = hittime;
-	    
-	    
-	    // The shower position is calculated using logarithmic weighting:
-	    
-	    if( ecell > 0.009 && fabs(xcell-xmax) < 6. && fabs(ycell-ymax) < 6.) {
-	      W = LOG_POS_CONST + log(ecell/e);
-	      if( W > 0 ) {
-		sW   += W;
-		xpos += xcell*W;
-		ypos += ycell*W;
-	      }
-	    }
-	    
-	  }
-	  
-	  for( int j = dime; j < MAX_CC; j++ )  // zero the rest
-	    locClusterStorage.id[j] = -1;
-	  
-	  double weightedTime = getEnergyWeightedTime( locClusterStorage, dime );
-	  double showerTime   = getCorrectedTime( weightedTime, e );
-	  
-	  
-	  
-	  //-------  Get position at surface of Calorimeter -------//
-	  
-	  DVector3 vertex(0.0, 0.0, m_zTarget); // for now, use center of target as vertex
-	  
-	  double x1, y1;
-	  double zV = vertex.Z();
-	  double z0 = m_CCALfront - zV;
-	  if(sW) {
-	    double dz = getShowerDepth( e );
-	    double zk = 1. / (1. + dz/z0);
-	    x1 = zk*xpos/sW;
-	    y1 = zk*ypos/sW;
-	  } else {
-	    printf("WRN bad cluster log. coord at event %i: center id = %i, energy = %f\n",
-	    	eventnumber, idmax, e);
-	    x1 = 0.0;
-	    y1 = 0.0;
-	  }
-	  
-	  
-	  
-	  
-	  //--------  Calculate nonlinear-corrected energy --------//
-	  
-	  
-	  if( idmax < 0 ) {
-	    printf("WRN negative idmax recorded at event %i; energy = %f\n", eventnumber, e);
-	  }
-	  
-	  double ecorr = e;
-	  if( DO_NONLINEAR_CORRECTION ) ecorr = getCorrectedEnergy( e, idmax );
-	  
-	  if( SHOWER_DEBUG ) {
-	    cout << "\n\nShower energy before correction: " << e << " GeV" << endl;
-	    cout << "Shower energy after  correction: " << ecorr << " GeV\n\n" << endl;
-	  }
-	  
-	  
-	  
-	  
-	  //--------  Get energy resolution (needs updating) --------//
-	  
-	  double se = sqrt( 0.9*0.9*ecorr*ecorr + 2.5*2.5*ecorr + 1.0 ); 
-	  	// from HYCAL reconstruction, need to tune
-      	  se /= 100.;
-	  
-      	  if( (type%10)==1 )
-            se *= 1.5;
-      	  else if( (type%10)==2 )
-            se *= 1.25;
-	  
-	  
-	  
-	  //-----------------  Fill cluster bank  -----------------//
-	  
-	  locCluster.type    = type;
-	  locCluster.nhits   = dime;
-	  locCluster.id      = id;
-	  locCluster.idmax   = idmax;
-	  
-	  locCluster.E       = ecorr;
-	  locCluster.Esum    = e1;
-	  locCluster.x       = x;
-	  locCluster.y       = y;
-	  locCluster.x1      = x1;
-	  locCluster.y1      = y1;
-	  locCluster.chi2    = chi2;
-	  locCluster.time    = showerTime;
-	  locCluster.emax    = ecellmax;
-	  locCluster.sigma_E = se;
-	  
-	  clusterStorage.push_back( locClusterStorage );
-	  ccalClusters.push_back( locCluster );
-	
+  //-------------   Do some post-island processing   -------------//
+  
+  int n_clusters = 0;
+  int n_hits = static_cast<int>(locHitPattern.size());
+  
+  int init_clusters = static_cast<int>(gammas.size());
+  for(int k = 0; k < init_clusters; k++) {
+    
+    ccalcluster_t locCluster;    // stores cluster parameters
+    cluster_t locClusterStorage; // stores hit information of cluster cells
+    
+    int type     = gammas[k].type;
+    int dime     = gammas[k].dime;
+    int id       = gammas[k].id;
+    double chi2  = gammas[k].chi2;
+    double e     = gammas[k].energy;
+    double x     = gammas[k].x;
+    double y     = gammas[k].y;
+    double xc    = gammas[k].xc;
+    double yc    = gammas[k].yc;
+    
+    // check that shower is not just a single module and that energy is reasonable:
+    
+    if( dime < MIN_CLUSTER_BLOCK_COUNT ) { continue; } 
+    if( e < MIN_CLUSTER_ENERGY || e > MAX_CLUSTER_ENERGY ) { continue; }
+    
+    n_clusters++;
+    
+    //------------   Find cell with max energy   ------------//
+    
+    double ecellmax = -1; int idmax = -1;
+    double e1 = 0.0;
+    for(int j = 0; j < (dime>MAX_CC ? MAX_CC : dime); j++) {
+      
+      double ecell = 1.e-4*static_cast<double>(gammas[k].icl_en[j]);
+      
+      int ccal_id = gammas[k].icl_in[j];
+      int kx  = 12 - (ccal_id/100), ky = 12 - (ccal_id%100);
+      
+      ccal_id = ky*12 + kx;
+      
+      e1 += ecell;
+      if(ecell > ecellmax) {
+	ecellmax = ecell;
+	idmax = ccal_id;
+      }
+      
+    }
+    
+    double xmax = ccalGeom.positionOnFace(idmax).X();
+    double ymax = ccalGeom.positionOnFace(idmax).Y();
+    
+    //-----------   Loop over constituent hits   ------------//
+    
+    double sW   = 0.0;
+    double xpos = 0.0;
+    double ypos = 0.0;
+    double W;
+    
+    for(int j = 0; j < (dime>MAX_CC ? MAX_CC : dime); j++) {
+      
+      int ccal_id = gammas[k].icl_in[j];
+      int kx  = 12 - (ccal_id/100), ky = 12 - (ccal_id%100);
+      ccal_id = ky*12 + kx;
+      
+      double ecell  = 1.e-4*static_cast<double>(gammas[k].icl_en[j]);
+      double xcell  = ccalGeom.positionOnFace(ccal_id).X();
+      double ycell  = ccalGeom.positionOnFace(ccal_id).Y();
+      
+      if(id%10 == 1 || id%10 == 2) {
+	xcell += xc;
+	ycell += yc;
+      }
+      
+      double hittime = 0.;
+      for( int ihit = 0; ihit < n_hits; ihit++ ) {
+	int trialid = 12*( locHitPattern[ihit]->row) + locHitPattern[ihit]->column;
+	if( trialid == ccal_id ) {
+	  hittime = locHitPattern[ihit]->t;
+	  break;
 	}
-
-
-	return;
+      }
+      
+      locClusterStorage.id[j] = ccal_id;
+      locClusterStorage.E[j]  = ecell;
+      locClusterStorage.x[j]  = xcell;
+      locClusterStorage.y[j]  = ycell;
+      locClusterStorage.t[j]  = hittime;
+      
+      // The shower position is calculated using logarithmic weighting:
+      
+      if(ecell > 0.009 && fabs(xcell-xmax) < 6. && fabs(ycell-ymax) < 6.) {
+	W = LOG_POS_CONST + log(ecell/e);
+	if(W > 0) {
+	  sW   += W;
+	  xpos += xcell*W;
+	  ypos += ycell*W;
+	}
+      }
+    }
+    
+    for(int j = dime; j < MAX_CC; j++)  // zero the rest
+      locClusterStorage.id[j] = -1;
+    
+    double weightedTime = getEnergyWeightedTime(locClusterStorage, dime);
+    double showerTime   = getCorrectedTime(weightedTime, e);
+    
+    //-------  Get position at surface of Calorimeter -------//
+    
+    DVector3 vertex(0.0, 0.0, m_zTarget); // for now, use center of target as vertex
+    
+    double x1, y1;
+    double zV = vertex.Z();
+    double z0 = m_CCALfront - zV;
+    if(sW) {
+      double dz = getShowerDepth(e);
+      double zk = 1. / (1. + dz/z0);
+      x1 = zk*xpos/sW;
+      y1 = zk*ypos/sW;
+    } else {
+      printf("WRN bad cluster log. coord at event %i: center id = %i, energy = %f\n",
+	     eventnumber, idmax, e);
+      x1 = 0.0;
+      y1 = 0.0;
+    }
+    
+    //--------  Calculate nonlinear-corrected energy --------//
+    
+    if(idmax < 0) {
+      printf("WRN negative idmax recorded at event %i; energy = %f\n", eventnumber, e);
+    }
+    
+    double ecorr = e;
+    if(DO_NONLINEAR_CORRECTION) ecorr = getCorrectedEnergy(e, idmax);
+    
+    if(SHOWER_DEBUG) {
+      cout << "\n\nShower energy before correction: " << e << " GeV" << endl;
+      cout << "Shower energy after  correction: " << ecorr << " GeV\n\n" << endl;
+    }
+    
+    //--------  Get energy resolution (needs updating) --------//
+    
+    double se = sqrt(0.9*0.9*ecorr*ecorr + 2.5*2.5*ecorr + 1.0); 
+    // from HYCAL reconstruction, need to tune
+    se /= 100.;
+    
+    if((type%10)==1)
+      se *= 1.5;
+    else if((type%10)==2)
+      se *= 1.25;
+    
+    //-----------------  Fill cluster bank  -----------------//
+    
+    locCluster.type    = type;
+    locCluster.nhits   = dime;
+    locCluster.id      = id;
+    locCluster.idmax   = idmax;
+    
+    locCluster.E       = ecorr;
+    locCluster.Esum    = e1;
+    locCluster.x       = x;
+    locCluster.y       = y;
+    locCluster.x1      = x1;
+    locCluster.y1      = y1;
+    locCluster.chi2    = chi2;
+    locCluster.time    = showerTime;
+    locCluster.emax    = ecellmax;
+    locCluster.sigma_E = se;
+    
+    clusterStorage.push_back(locClusterStorage);
+    ccalClusters.push_back(locCluster);
+  }
+  
+  return;
 }
-
-
 
 
 //==========================================================
@@ -822,22 +732,18 @@ void DCCALShower_factory::processShowers( vector< gamma_t > gammas, DCCALGeometr
 //
 //==========================================================
 
-double DCCALShower_factory::getEnergyWeightedTime( cluster_t clusterStorage, int nHits )
+double DCCALShower_factory::getEnergyWeightedTime(cluster_t clusterStorage, int nHits)
 {
-
-	double weightedtime = 0.;
-	double totEn = 0;
-	for( int j = 0; j < (nHits > MAX_CC ? MAX_CC : nHits); j++ ) {
-	  weightedtime += clusterStorage.t[j]*clusterStorage.E[j];
-	  totEn += clusterStorage.E[j];
-	}
-	weightedtime /= totEn;
-	
-	return weightedtime;
-
+  double weightedtime = 0.;
+  double totEn = 0;
+  for(int j = 0; j < (nHits > MAX_CC ? MAX_CC : nHits); j++) {
+    weightedtime += clusterStorage.t[j]*clusterStorage.E[j];
+    totEn += clusterStorage.E[j];
+  }
+  weightedtime /= totEn;
+  
+  return weightedtime;
 }
-
-
 
 
 //==========================================================
@@ -846,22 +752,19 @@ double DCCALShower_factory::getEnergyWeightedTime( cluster_t clusterStorage, int
 //
 //==========================================================
 
-double DCCALShower_factory::getCorrectedTime( double time, double energy ) 
+double DCCALShower_factory::getCorrectedTime(double time, double energy) 
 {
-	// timewalk correction:
-	
-	int iPar;
-	if( energy < 1.0 ) iPar = 0;
-	else iPar = 1;
-	
-	double dt = timewalk_p0[iPar]*exp( timewalk_p1[iPar] + timewalk_p2[iPar]*energy ) + timewalk_p3[iPar];
-	double t_cor = time - dt;
-	
-	return t_cor;
-	
+  // timewalk correction:
+  
+  int iPar;
+  if(energy < 1.0) iPar = 0;
+  else iPar = 1;
+  
+  double dt = timewalk_p0[iPar]*exp(timewalk_p1[iPar] + timewalk_p2[iPar]*energy) + timewalk_p3[iPar];
+  double t_cor = time - dt;
+  
+  return t_cor;
 }
-
-
 
 
 //==========================================================
@@ -870,16 +773,12 @@ double DCCALShower_factory::getCorrectedTime( double time, double energy )
 //
 //==========================================================
 
-double DCCALShower_factory::getShowerDepth( double energy ) 
+double DCCALShower_factory::getShowerDepth(double energy) 
 {
-
-	double z0 = CCAL_RADIATION_LENGTH, e0 = CCAL_CRITICAL_ENERGY;
-	double depth = (energy > 0.) ? z0*log(1.+energy/e0) : 0.;
-	return depth;
-
+  double z0 = CCAL_RADIATION_LENGTH, e0 = CCAL_CRITICAL_ENERGY;
+  double depth = (energy > 0.) ? z0*log(1.+energy/e0) : 0.;
+  return depth;
 }
-
-
 
 
 //==========================================================
@@ -888,40 +787,35 @@ double DCCALShower_factory::getShowerDepth( double energy )
 //
 //==========================================================
 
-double DCCALShower_factory::getCorrectedEnergy( double energy, int id ) 
+double DCCALShower_factory::getCorrectedEnergy(double energy, int id) 
 {
-	
-	if( id < 0 ) return energy;
-	
-	if( Nonlin_p1[id] == 0. && Nonlin_p2[id] == 0. && Nonlin_p3[id] == 0.) return energy;
-	if( Nonlin_p0[id] == 0. ) return energy;
-  	//if( energy < 0.5 || energy > 12. ) return energy;
+  if(id < 0) return energy;
+  
+  if(Nonlin_p1[id] == 0. && Nonlin_p2[id] == 0. && Nonlin_p3[id] == 0.) return energy;
+  if(Nonlin_p0[id] == 0.) return energy;
+  //if( energy < 0.5 || energy > 12. ) return energy;
+  
+  double emin = 0., emax = 12.;
+  double e0 = (emin+emax)/2.;
+  
+  double de1 = energy - emin*nonlin_func(emin,id);
+  double de2 = energy - emax*nonlin_func(emax,id);
+  double de  = energy - e0*nonlin_func(e0,id);
+  
+  while(fabs(emin-emax) > 1.e-5) {
+    if(de1*de > 0. && de2*de < 0.) {
+      emin = e0;
+      de1 = energy - emin*nonlin_func(emin,id);
+    } else {
+      emax = e0;
+      de2 = energy - emax*nonlin_func(emax,id);
+    }
+    e0 = (emin+emax)/2.;
+    de = energy - e0*nonlin_func(e0,id);
+  }
 
-
-	double emin = 0., emax = 12.;
-  	double e0 = (emin+emax)/2.;
-
-  	double de1 = energy - emin*nonlin_func( emin, id );
-  	double de2 = energy - emax*nonlin_func( emax, id );
-  	double de  = energy - e0*nonlin_func( e0, id );
-
-  	while( fabs(emin-emax) > 1.e-5 ) {
-    	  if( de1*de > 0. && de2*de < 0.) {
-      	    emin = e0;
-      	    de1 = energy - emin*nonlin_func( emin, id );
-    	  } else {
-      	    emax = e0;
-      	    de2 = energy - emax*nonlin_func( emax, id );
-    	  }
-    	  e0 = (emin+emax)/2.;
-    	  de  = energy - e0*nonlin_func( e0, id );
-  	}
-	
-  	return e0;
-
+  return e0;
 }
-
-
 
 
 //==========================================================
@@ -930,30 +824,10 @@ double DCCALShower_factory::getCorrectedEnergy( double energy, int id )
 //
 //==========================================================
 
-double DCCALShower_factory::nonlin_func( double e, int id ) 
+double DCCALShower_factory::nonlin_func(double e, int id) 
 {
-
-  	return pow( (e/Nonlin_p0[id]), Nonlin_p1[id] + Nonlin_p2[id]*e + Nonlin_p3[id]*e*e );
-
+  return pow((e/Nonlin_p0[id]), Nonlin_p1[id] + Nonlin_p2[id]*e + Nonlin_p3[id]*e*e);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/libraries/CCAL/DCCALShower_factory.cc
+++ b/src/libraries/CCAL/DCCALShower_factory.cc
@@ -91,7 +91,6 @@ jerror_t DCCALShower_factory::brun(JEventLoop *locEventLoop, int32_t runnumber)
   const DGeometry *geom = dapp->GetDGeometry(runnumber);
   
   if (geom) {
-    geom->GetTargetZ(m_zTarget);
     geom->GetCCALPosition(m_CCALdX,m_CCALdY,m_CCALfront);
   }
   else{
@@ -100,11 +99,6 @@ jerror_t DCCALShower_factory::brun(JEventLoop *locEventLoop, int32_t runnumber)
   }
   
   JCalibration *jcalib = dapp->GetJCalibration(runnumber);
-  std::map<string, float> beam_spot;
-  jcalib->Get("PHOTON_BEAM/beam_spot", beam_spot);
-  
-  m_beamSpotX = beam_spot.at("x");
-  m_beamSpotY = beam_spot.at("y");
   
   //------------------------------------------------------//
   //-----------   Read in shower profile data  -----------//
@@ -667,9 +661,6 @@ void DCCALShower_factory::processShowers( vector< gamma_t > gammas, DCCALGeometr
       locClusterStorage.id[j] = -1;
     
     //-------  Get position inside Calorimeter -------//
-    
-    // assume interaction vertex comes from center of the beam spot on target:
-    DVector3 vertex(m_beamSpotX, m_beamSpotY, m_zTarget);
     
     double x1, y1;
     if(sW) {

--- a/src/libraries/CCAL/DCCALShower_factory.h
+++ b/src/libraries/CCAL/DCCALShower_factory.h
@@ -33,148 +33,131 @@ using namespace jana;
 
 
 class DCCALShower_factory:public JFactory<DCCALShower>{
+  
+ public:
+  DCCALShower_factory();
+  ~DCCALShower_factory(){};
+  
+  /* 
+  store these values before passing them on to the island code
+  keep them simply public and static for now
+  */
+  
+ private:
+  
+  JApplication *japp;
+  
+  jerror_t brun(JEventLoop *eventLoop, int32_t runnumber);
+  jerror_t evnt(JEventLoop *eventLoop, uint64_t eventnumber);
+  
+  void getHitPatterns(vector<const DCCALHit*> hitarray, 
+		      vector<vector< const DCCALHit*>> &hitPatterns);
+  
+  void sortByTime(vector<const DCCALHit*> &hitarray, float hitTime);
+  
+  void cleanHitPattern(vector<const DCCALHit*> hitarray, 
+		       vector<const DCCALHit*> &hitarrayClean);
+  
+  void processShowers(vector<gamma_t> gammas, DCCALGeometry ccalGeom, 
+		      vector<const DCCALHit*> locHitPattern, int eventnumber, 
+		      vector<ccalcluster_t> &ccalClusters, 
+		      vector<cluster_t> &clusterStorage);
+  
+  double getEnergyWeightedTime(cluster_t clusterStorage, int nHits);
+  double getCorrectedTime(double time, double energy);
+  double getShowerDepth(double energy);
+  double getCorrectedEnergy(double energy, int id);
+  double nonlin_func(double e, int id);
+  
+  double m_zTarget;
+  double m_CCALfront;
+  double m_CCALdX,m_CCALdY;	
+  
+  //-------------------  Nonlinearity & Timewalk Parameters -------------------//
+  
+  int CCAL_CHANS = DCCALGeometry::kCCALMaxChannels;
+  vector< double > Nonlin_p0;
+  vector< double > Nonlin_p1;
+  vector< double > Nonlin_p2;
+  vector< double > Nonlin_p3;
+  
+  vector< double > timewalk_p0;
+  vector< double > timewalk_p1;
+  vector< double > timewalk_p2;
+  vector< double > timewalk_p3;
+  
+  //-----------------   Shower Profile Data & Channel Status  -----------------//
+  
+  double acell[501][501] = { {0.} };
+  double  ad2c[501][501] = { {0.} };
+  
+  int stat_ch[MROW][MCOL];
+  
+  //----------------------- Island Functions -----------------------//
+  
+  void main_island(vector<int> &ia, vector<int> &id, vector<gamma_t> &gammas);
+  
+  int  clus_hyc(int nw, vector<int> &ia, vector<int> &id, vector<int> &lencl);
+  
+  void order_hyc(int nw, vector<int> &ia, vector<int> &id);
+  
+  void gams_hyc(int nadc, vector<int> &ia, vector<int> &id, int &nadcgam,
+		vector<gamma_t> &gammas);
+  
+  int  peak_type(int ix, int iy);
+  
+  void gamma_hyc(int nadc, vector<int> ia, vector<int> id, double &chisq, 
+		 double &e1, double &x1, double &y1, 
+		 double &e2, double &x2, double &y2);
+  
+  void fill_zeros(int nadc, vector<int> ia, int &nneib, vector<int> &iaz);
+  
+  void mom1_pht(int nadc, vector<int> ia, vector<int> id, int nzero, 
+		vector<int> iaz, double &e1, double &x1, double &y1);
+  
+  void chisq1_hyc(int nadc, vector<int> ia, vector<int> id, int nneib, 
+		  vector<int> iaz, double e1, double x1, double y1, double &chisq);
+  
+  double sigma2(double dx, double dy, double fc, double e);
+  double d2c(double x, double y);
+  double cell_hyc(double dx, double dy);
+  
+  void tgamma_hyc(int nadc, vector<int> ia, vector<int> id, int nneib, 
+		  vector<int> iaz, double &chisq, double &e1, double &x1, 
+		  double &y1, double &e2, double &x2, double &y2);
+  
+  void mom2_pht(int nadc, vector<int> ia, vector<int> id, int nzero, 
+		vector<int> iaz, double &a0, double &x0, double &y0, 
+		double &xx, double &yy, double &yx);
+  
+  void c3to5_pht(double e0, double x0, double y0, double eps, double dx, 
+		 double dy, double &e1, double &x1, double &y1, double &e2, 
+		 double &x2, double &y2);
+  
+  void chisq2t_hyc(double ecell, double e1c, double dx1, double dy1, 
+		   double e2c, double dx2, double dy2, double f1c, 
+		   double f2c, double &chisqt);
+  
+  void ucopy1(vector<int> &ia, vector<int> &iwork, int start, int length);
+  void ucopy2(vector<int> &ia, int start1, int start2, int length);
+  void ucopy3(vector<int> &iwork, vector<int> &ia, int start, int length);
+  
+  //---------------------- Default Parameters ----------------------//
 
-	public:
-		DCCALShower_factory();
-		~DCCALShower_factory(){};
-		
-		/* 
-		store these values before passing them on to the island code
-		keep them simply public and static for now
-		*/
-		
-
-	private:
-
-		JApplication *japp;
-		
-		jerror_t brun(JEventLoop *eventLoop, int32_t runnumber);	
-		jerror_t evnt(JEventLoop *eventLoop, uint64_t eventnumber);	
-		
-		
-		
-		void getHitPatterns( vector< const DCCALHit* > hitarray, 
-				vector< vector< const DCCALHit* > > &hitPatterns );
-		
-		void sortByTime( vector< const DCCALHit* > &hitarray, float hitTime );
-		
-		void cleanHitPattern( vector< const DCCALHit* > hitarray, 
-				vector< const DCCALHit* > &hitarrayClean );
-		
-		void processShowers( vector< gamma_t > gammas, DCCALGeometry ccalGeom, 
-				vector< const DCCALHit* > locHitPattern, int eventnumber, 
-				vector< ccalcluster_t > &ccalClusters, 
-				vector< cluster_t > &clusterStorage );
-		
-		double getEnergyWeightedTime( cluster_t clusterStorage, int nHits );
-		double getCorrectedTime( double time, double energy );
-		double getShowerDepth( double energy );
-		double getCorrectedEnergy( double energy, int id );
-		double nonlin_func( double e, int id );
-	
-		double m_zTarget;
-		double m_CCALfront;
-		double m_CCALdX,m_CCALdY;	
-		
-		
-		//-------------------  Nonlinearity & Timewalk Parameters -------------------//
-		
-		int CCAL_CHANS = DCCALGeometry::kCCALMaxChannels;
-		vector< double > Nonlin_p0;
-		vector< double > Nonlin_p1;
-		vector< double > Nonlin_p2;
-		vector< double > Nonlin_p3;
-		
-		vector< double > timewalk_p0;
-		vector< double > timewalk_p1;
-		vector< double > timewalk_p2;
-		vector< double > timewalk_p3;
-		
-		
-		//-----------------   Shower Profile Data & Channel Status  -----------------//
-		
-		double acell[501][501] = { {0.} };
-		double  ad2c[501][501] = { {0.} };
-		
-		int stat_ch[MROW][MCOL];	
-		
-		
-		
-		//----------------------- Island Functions -----------------------//
-		
-		
-		void main_island( vector<int> &ia, vector<int> &id, vector<gamma_t> &gammas );
-		
-		int  clus_hyc( int nw, vector<int> &ia, vector<int> &id, vector<int> &lencl );
-		
-		void order_hyc( int nw, vector<int> &ia, vector<int> &id );
-		
-		void gams_hyc( int nadc, vector<int> &ia, vector<int> &id, int &nadcgam,
-				vector<gamma_t> &gammas );
-				
-		int  peak_type( int ix, int iy );
-		
-		void gamma_hyc( int nadc, vector<int> ia, vector<int> id, double &chisq, 
-				double &e1, double &x1, double &y1, 
-				double &e2, double &x2, double &y2 );
-				
-		void fill_zeros( int nadc, vector<int> ia, int &nneib, vector<int> &iaz );
-		
-		void mom1_pht( int nadc, vector<int> ia, vector<int> id, int nzero, 
-				vector<int> iaz, double &e1, double &x1, double &y1 );
-				
-		void chisq1_hyc( int nadc, vector<int> ia, vector<int> id, int nneib, 
-				vector<int> iaz, double e1, double x1, double y1, double &chisq );
-				
-		double sigma2( double dx, double dy, double fc, double e );
-		double d2c( double x, double y );
-		double cell_hyc( double dx, double dy );
-		
-		void tgamma_hyc( int nadc, vector<int> ia, vector<int> id, int nneib, 
-				vector<int> iaz, double &chisq, double &e1, double &x1, 
-				double &y1, double &e2, double &x2, double &y2 );
-				
-		void mom2_pht( int nadc, vector<int> ia, vector<int> id, int nzero, 
-				vector<int> iaz, double &a0, double &x0, double &y0, 
-				double &xx, double &yy, double &yx );
-				
-		void c3to5_pht( double e0, double x0, double y0, double eps, double dx, 
-				double dy, double &e1, double &x1, double &y1, double &e2, 
-				double &x2, double &y2 );
-				
-		void chisq2t_hyc( double ecell, double e1c, double dx1, double dy1, 
-				  double e2c, double dx2, double dy2, double f1c, 
-				  double f2c, double &chisqt );
-				
-		void ucopy1( vector<int> &ia, vector<int> &iwork, int start, int length );
-		void ucopy2( vector<int> &ia, int start1, int start2, int length );
-		void ucopy3( vector<int> &iwork, vector<int> &ia, int start, int length );
-						
-		
-		
-		
-		
-		
-		//---------------------- Default Parameters ----------------------//
-		
-		int           SHOWER_DEBUG;
-		int           MIN_CLUSTER_BLOCK_COUNT;
-		double        MIN_CLUSTER_SEED_ENERGY;
-		double        MIN_CLUSTER_ENERGY;
-		double        MAX_CLUSTER_ENERGY;
-		double        TIME_CUT;
-		int           MAX_HITS_FOR_CLUSTERING;
-		int           DO_NONLINEAR_CORRECTION;
-		
-		double        CCAL_RADIATION_LENGTH;
-		double        CCAL_CRITICAL_ENERGY;
-		
-		double        LOG_POS_CONST;
-		
-		
-		
-		int VERBOSE;
+  int    VERBOSE;
+  int    SHOWER_DEBUG;
+  int    MIN_CLUSTER_BLOCK_COUNT;
+  double MIN_CLUSTER_SEED_ENERGY;
+  double MIN_CLUSTER_ENERGY;
+  double MAX_CLUSTER_ENERGY;
+  double TIME_CUT;
+  int    MAX_HITS_FOR_CLUSTERING;
+  int    DO_NONLINEAR_CORRECTION;
+  
+  double CCAL_RADIATION_LENGTH;
+  double CCAL_CRITICAL_ENERGY;
+  
+  double LOG_POS_CONST;
 };
 
 #endif // _DCCALShower_factory_
-

--- a/src/libraries/CCAL/DCCALShower_factory.h
+++ b/src/libraries/CCAL/DCCALShower_factory.h
@@ -69,8 +69,6 @@ class DCCALShower_factory:public JFactory<DCCALShower>{
   double getCorrectedEnergy(double energy, int id);
   double nonlin_func(double e, int id);
   
-  double m_zTarget;
-  double m_beamSpotX,m_beamSpotY;
   double m_CCALfront;
   double m_CCALdX,m_CCALdY;	
   

--- a/src/libraries/CCAL/DCCALShower_factory.h
+++ b/src/libraries/CCAL/DCCALShower_factory.h
@@ -70,6 +70,7 @@ class DCCALShower_factory:public JFactory<DCCALShower>{
   double nonlin_func(double e, int id);
   
   double m_zTarget;
+  double m_beamSpotX,m_beamSpotY;
   double m_CCALfront;
   double m_CCALdX,m_CCALdY;	
   
@@ -153,11 +154,14 @@ class DCCALShower_factory:public JFactory<DCCALShower>{
   double TIME_CUT;
   int    MAX_HITS_FOR_CLUSTERING;
   int    DO_NONLINEAR_CORRECTION;
+  int    DO_TIMEWALK_CORRECTION;
   
   double CCAL_RADIATION_LENGTH;
   double CCAL_CRITICAL_ENERGY;
   
   double LOG_POS_CONST;
+
+  double CCAL_C_EFFECTIVE;
 };
 
 #endif // _DCCALShower_factory_

--- a/src/libraries/CCAL/ccal.h
+++ b/src/libraries/CCAL/ccal.h
@@ -1,8 +1,6 @@
 #ifndef _CCAL_H_
 #define _CCAL_H_
 
-
-
 #define MCOL 12
 #define MROW 12
 
@@ -17,8 +15,6 @@
 #define COUNT_ZERO 1
 #define TEST_P 1
 
-
-
 enum ClusterType_t{ 
 	SinglePeak=0, 
 	MultiPeak 
@@ -30,7 +26,6 @@ enum PeakType_t{
 };
 
 
-
 typedef struct {
 
   int  id[MAX_CC];    /* ID of ith block, where i runs from 0 to 8 */
@@ -40,8 +35,8 @@ typedef struct {
   double t[MAX_CC];
 
 } cluster_t;
-		
-		
+
+
 typedef struct {
 
   int type;       /* cluster types: 0,1,2,10,11,12 */
@@ -61,8 +56,8 @@ typedef struct {
   double emax;
   
 } ccalcluster_t;
-		
-		
+
+
 typedef struct {
   
   int type;
@@ -80,7 +75,5 @@ typedef struct {
   int icl_en[MAX_CC];
   
 } gamma_t;
-
-
 
 #endif

--- a/src/libraries/CCAL/ccal.h
+++ b/src/libraries/CCAL/ccal.h
@@ -50,6 +50,7 @@ typedef struct {
   double y;       /* Cluster's y-position [cm] */
   double x1;      /* Cluster's x1-position [cm] */
   double y1;      /* Cluster's y1-position [cm] */
+  double z;       /* Cluster's z-position [cm] */
   double chi2;    /* Cluster's profile fit to single shower profile */
   double time;    /* Cluster's time [ns] */
   double sigma_E; 


### PR DESCRIPTION
- Cleaned DCCALShower_factory code aesthetically (fixed several misaligned tabs and removed long white spaces)
- Changed output of DCCALShower_factory to give the position of showers as reconstructed inside the Calorimeter, instead of projecting them to the face of the CCAL. This is more in-line with how the FCAL showers are given, plus this projection requires knowledge of the interaction vertex position which isn't known event-to-event.
- Added a small correction for the shower timing calculation. This correction was used when doing the timing calibration, and is necessary to have properly aligned CCAL shower times without redoing the calibration (currently, they are shifted by about 1ns).