### PR TITLE
Add BCAL occupancy plot for calibrated hits

### DIFF
--- a/src/libraries/BCAL/DBCALHit_factory.cc
+++ b/src/libraries/BCAL/DBCALHit_factory.cc
@@ -120,7 +120,7 @@ jerror_t DBCALHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
    if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_tdiff_u_d" << endl;
    FillCalibTableShort(tdiff_u_d, raw_tdiff_u_d);
    if (PRINTCALIBRATION) jout << "DBCALHit_factory >> raw_bad_channels" << endl;
-   FillCalibTableShort(bad_channels, raw_bad_channels);
+   FillCalibTable(bad_channels, raw_bad_channels);
    
    std::vector<std::map<string,double> > saturation_ADC_pars;
    if(eventLoop->GetCalib("/BCAL/ADC_saturation", saturation_ADC_pars))

--- a/src/plugins/monitoring/BCAL_online/bcal_hit_occupancy.C
+++ b/src/plugins/monitoring/BCAL_online/bcal_hit_occupancy.C
@@ -1,0 +1,48 @@
+
+// hnamepath: /bcal/bcal_fadc_occ
+// hnamepath: /bcal/bcal_tdc_occ
+//
+
+{
+	TDirectory *savedir = gDirectory;
+	TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("bcal");
+	if(dir) dir->cd();
+
+	TH2I *bcal_adc_occ = (TH2I*)gDirectory->FindObjectAny("bcal_fadc_occ");
+	TH2I *bcal_tdc_occ = (TH2I*)gDirectory->FindObjectAny("bcal_tdc_occ");
+
+	// Just for testing
+	if(gPad == NULL){
+		TCanvas *c1 = new TCanvas("c1");
+		c1->cd(0);
+		c1->Draw();
+		c1->Update();
+	}
+	if(!gPad) {savedir->cd(); return;}
+
+	TCanvas *c1 = gPad->GetCanvas();
+	c1->cd(0);
+	
+	c1->Divide(2,1);
+	
+	TVirtualPad *pad1 = c1->cd(1);
+	pad1->SetTicks();
+	pad1->SetLeftMargin(0.15);
+	pad1->SetRightMargin(0.15);
+	if(bcal_adc_occ){
+		bcal_adc_occ->SetStats(0);
+		bcal_adc_occ->Draw("colz");
+	}
+
+	TVirtualPad *pad2 = c1->cd(2);
+	pad2->SetTicks();
+	pad2->SetLeftMargin(0.15);
+	pad2->SetRightMargin(0.15);
+	if(bcal_tdc_occ){
+		bcal_tdc_occ->SetStats(0);
+		bcal_tdc_occ->Draw("colz");
+	}
+
+}
+
+


### PR DESCRIPTION
The other occupancy plots use digihits.  We need to monitor the
calibrated hits to check the BCAL bad channel map
