### PR TITLE
Add channel quality cuts to tagger TDC channels

### DIFF
--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
@@ -211,6 +211,11 @@ jerror_t DTAGHHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
     for (unsigned int i=0; i < tdcdigihits.size(); i++) {
         const DTAGHTDCDigiHit *digihit = tdcdigihits[i];
 
+        // throw away hits from bad or noisy counters
+        int quality = counter_quality[digihit->counter_id];
+        if (quality == k_counter_dead || quality == k_counter_bad || quality == k_counter_noisy)
+            continue;
+
         // Apply calibration constants here
         int counter = digihit->counter_id;
         double T = locTTabUtilities->Convert_DigiTimeToNs_F1TDC(digihit) - tdc_time_offsets[counter] + t_tdc_base;

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -242,6 +242,11 @@ jerror_t DTAGMHit_factory_Calib::evnt(JEventLoop *loop, uint64_t eventnumber)
     for (unsigned int i=0; i < tdcdigihits.size(); i++) {
         const DTAGMTDCDigiHit *digihit = tdcdigihits[i];
 
+        // throw away hits from bad or noisy fibers
+        int quality = fiber_quality[digihit->row][digihit->column];
+        if (quality == k_fiber_dead || quality == k_fiber_bad || quality == k_fiber_noisy)
+            continue;
+        
         // Apply calibration constants here
         int row = digihit->row;
         int column = digihit->column;


### PR DESCRIPTION
If these aren't applied, then when we try to label these as bad quality channels, we just get a bunch of TDC-only hits, which we want to avoid.