### PR TITLE
Add dedx vs p histos with best FOM (the existing histos show all hypos)

### DIFF
--- a/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.h
+++ b/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.h
@@ -14,6 +14,9 @@
 #include "PID/DVertex.h"
 
 #include "TRACKING/DTrackTimeBased.h"
+#include <PID/DChargedTrackHypothesis.h>
+#include <PID/DChargedTrack.h>
+#include <TRACKING/DTrackFitter.h>
 
 #include <vector>
 
@@ -30,6 +33,10 @@ class JEventProcessor_CDC_dedx:public jana::JEventProcessor{
 		const char* className(void){return "JEventProcessor_CDC_dedx";}
 
 	private:
+
+                TH2D *bestfom_dedx_p = NULL;
+                TH2D *bestfom_dedx_p_pos = NULL;
+                TH2D *bestfom_dedx_p_neg = NULL;
 
                 TH2D *dedx_p = NULL;
                 TH2D *dedx_p_pos = NULL;


### PR DESCRIPTION
I'm not sure if there is a neater way of coding this.  

Is it possible to query DTrackTimeBased to find out if it used the mass hypothesis with the best FOM? 

I assumed not and made a separate loop through the charged tracks to get to the best FOM track that way.