### PR TITLE
Nsj fix locks

### DIFF
--- a/src/plugins/Utilities/SConscript
+++ b/src/plugins/Utilities/SConscript
@@ -14,5 +14,5 @@ SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 # Optional targets
 optdirs = ['danahddm', 'dumpcandidates', 'dumpthrowns', 'l3bdt']
 optdirs.extend(['merge_rawevents', 'syncskim', 'DAQ', 'TTab', 'rawevent'])
-optdirs.extend(['cdc_amp_t','cdc_echo','cdc_emu', 'fmwpc_scan', 'epem_ml_skim'])
+optdirs.extend(['cdc_amp_t','cdc_echo','cdc_emu','cdc_scan', 'fmwpc_scan', 'epem_ml_skim'])
 sbms.OptionallyBuild(env, optdirs)

--- a/src/plugins/Utilities/cdc_amp_t/JEventProcessor_cdc_amp_t.cc
+++ b/src/plugins/Utilities/cdc_amp_t/JEventProcessor_cdc_amp_t.cc
@@ -61,11 +61,16 @@ jerror_t JEventProcessor_cdc_amp_t::init(void)
 {
 	// This is called once at program startup. 
 
+    TDirectory *main = gDirectory;
+    gDirectory->mkdir("cdc_amp_t")->cd();
+
     amp_t = new TH2I("amp_t","Digihit pulse height - pedestal vs sample number;sample number;pulse height-pedestal", 200,0,200,205,0,4100);
     amp_tt = new TH2I("amp_tt","Digihit pulse height - pedestal vs sample number, hits on tracks;sample number; pulse height-pedestal", 200,0,200,205,0,4100);
   
     hitamp_t = new TH2I("hitamp_t","Hit amplitude vs time;time (ns);hit amplitude", 125,0,1000,205,0,4100);
     hitamp_tt = new TH2I("hitamp_tt","Tracked hit amplitude vs time;time (ns);hit amplitude", 125,0,1000,205,0,4100);
+
+    main->cd();
 
     return NOERROR;
 }

--- a/src/plugins/Utilities/cdc_echo/JEventProcessor_cdc_echo.cc
+++ b/src/plugins/Utilities/cdc_echo/JEventProcessor_cdc_echo.cc
@@ -403,9 +403,9 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       if (locCDCHits.size() > 0) {
       
-          japp->RootWriteLock();    
+          japp->RootFillLock(this);    
           counts->Fill(0);
-          japp->RootUnLock();
+          japp->RootFillUnLock(this);
       } 
       
       vector<DTrackFitter::pull_t> pulls = track->pulls;
@@ -441,7 +441,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
       
       ULong64_t eventnum = (ULong64_t)eventnumber;
       
-      japp->RootWriteLock();    
+      japp->RootFillLock(this);    
 
       TT->SetBranchAddress("eventnum",&eventnum);
       TT->SetBranchAddress("ntrackhits",&ntrackhits);
@@ -454,7 +454,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       TT->Fill();
 
-      japp->RootUnLock();          
+      japp->RootFillUnLock(this);          
 
     }    
 
@@ -481,7 +481,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       // increment counts histo    0: tracks  1:all pulses  2:hits  3:hits on tracks  4: echo pulses  5: echo hits  6:  echoes on tracks  7: saturated pulses  8:saturated hits  9:saturated hits on tracks
       
-      japp->RootWriteLock();
+      japp->RootFillLock(this);
 
       counts->Fill(1);
 
@@ -508,7 +508,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
         if ( ontrack[rocid-25][slot-3][channel] >0 ) counts->Fill(9);
       }
            
-      japp->RootUnLock();
+      japp->RootFillUnLock(this);
       
 
       if (parent[rocid-25][slot-3][channel] == 0 ) continue; // not a parent or an echo
@@ -578,7 +578,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       ULong64_t eventnum = (ULong64_t)eventnumber;
       
-      japp->RootWriteLock();    
+      japp->RootFillLock(this);    
 
       if ( parentamp[rocid-25][slot-3][channel] >0 && timeovert < 8 ) {  // probable echoes
 	counts->Fill(4);
@@ -626,7 +626,7 @@ jerror_t JEventProcessor_cdc_echo::evnt(JEventLoop *loop, uint64_t eventnumber)
       
       T->Fill();
     
-      japp->RootUnLock();    
+      japp->RootFillUnLock(this);    
 
     }
   

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -295,7 +295,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
   ULong64_t eventnum = (ULong64_t)eventnumber;
 
   
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
   t->SetBranchAddress("eventnum",&eventnum);
   t->SetBranchAddress("CDCPulsecount",&nc);
@@ -304,7 +304,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
     
   t->Fill();  
 
-  japp->RootUnLock();
+  japp->RootFillUnLock(this);
   
  
   
@@ -312,7 +312,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
   
   if (ntt > 0) { //   Df125TriggerTime 
 
-    japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!    
 
     tt->SetBranchAddress("eventnum",&eventnum);
 
@@ -340,7 +340,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
       tt->Fill();
     }
 
-    japp->RootUnLock();
+    japp->RootFillUnLock(this);
 
   }
 
@@ -350,7 +350,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
 
   if (nc || (nf&&FDC)) {  // branches are almost the same for CDC & FDC - only amp differs
 
-    japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
     
     p->SetBranchAddress("eventnum",&eventnum);
 
@@ -705,7 +705,7 @@ jerror_t JEventProcessor_cdc_scan::evnt(JEventLoop *loop, uint64_t eventnumber)
   
     }
 
-    japp->RootUnLock();    
+    japp->RootFillUnLock(this);    
   }
     
   return NOERROR;

--- a/src/plugins/Utilities/fmwpc_scan/JEventProcessor_fmwpc_scan.cc
+++ b/src/plugins/Utilities/fmwpc_scan/JEventProcessor_fmwpc_scan.cc
@@ -55,9 +55,7 @@ jerror_t JEventProcessor_fmwpc_scan::init(void)
 {
 	// This is called once at program startup. 
 
-  const uint32_t NSAMPLES = 300;
-
-  japp->RootWriteLock();
+  const uint32_t NSAMPLES = 200;
 
   t = new TTree("T","FWMPC events");
   
@@ -109,9 +107,6 @@ jerror_t JEventProcessor_fmwpc_scan::init(void)
   uint16_t adc[NSAMPLES];
   t->Branch("adc",&adc,Form("adc[%i]/s",NSAMPLES));         
 
-  japp->RootUnLock();
-
-
   return NOERROR;
 
 }
@@ -154,7 +149,7 @@ jerror_t JEventProcessor_fmwpc_scan::evnt(JEventLoop *loop, uint64_t eventnumber
   if (!nmp) return NOERROR;
 
 
-  const uint NSAMPLES=300;
+  const uint NSAMPLES=200;
 
   for (uint32_t i=0; i<nmp; i++) {
 
@@ -165,13 +160,14 @@ jerror_t JEventProcessor_fmwpc_scan::evnt(JEventLoop *loop, uint64_t eventnumber
 
       const Df125WindowRawData *wrd = NULL;
       cp->GetSingle(wrd);
-
+      
       uint32_t eventnum = eventnumber&0xFFFFFFFF;
       uint32_t rocid = cp->rocid;
       uint32_t slot = cp->slot;
       uint32_t channel = cp->channel;
       uint32_t itrigger = cp->itrigger;
 
+      
       uint32_t word1 = cp->word1;
       uint32_t word2 = cp->word2;
       uint32_t time = cp->le_time;
@@ -180,17 +176,18 @@ jerror_t JEventProcessor_fmwpc_scan::evnt(JEventLoop *loop, uint64_t eventnumber
       uint32_t q = cp->time_quality_bit;
       uint32_t overflows = cp->overflow_count;
       uint32_t amp = cp->first_max_amp;
-
+      
       bool emulated = cp->emulated;
 
       uint16_t adc[NSAMPLES]= {0};
 
-      uint32_t ns = (uint32_t)wrd->samples.size();
+      uint32_t ns = 0;
+      if (wrd) ns = (uint32_t)wrd->samples.size();
 
       for (uint j=0; j<ns; j++) {
           adc[j] = wrd->samples[j];
       }
-
+      
 
       japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
@@ -201,7 +198,7 @@ jerror_t JEventProcessor_fmwpc_scan::evnt(JEventLoop *loop, uint64_t eventnumber
       t->SetBranchAddress("itrigger",&itrigger); 
       t->SetBranchAddress("word1",&word1);
       t->SetBranchAddress("word2",&word2);
-
+      
       t->SetBranchAddress("pedestal",&pedestal);
       t->SetBranchAddress("integral",&integral);
       t->SetBranchAddress("amp",&amp);
@@ -214,9 +211,9 @@ jerror_t JEventProcessor_fmwpc_scan::evnt(JEventLoop *loop, uint64_t eventnumber
       t->SetBranchAddress("adc",&adc);
       
       t->Fill();
-      japp->RootUnLock();
+      japp->RootUnLock(); 
   }
-
+      
 
 
   return NOERROR;

--- a/src/plugins/monitoring/CDC_PerStrawReco/JEventProcessor_CDC_PerStrawReco.cc
+++ b/src/plugins/monitoring/CDC_PerStrawReco/JEventProcessor_CDC_PerStrawReco.cc
@@ -8,7 +8,6 @@
 #include "JEventProcessor_CDC_PerStrawReco.h"
 #include "PID/DChargedTrack.h"
 #include "TRACKING/DTrackTimeBased.h"
-#include "HistogramTools.h"
 
 using namespace jana;
 
@@ -435,6 +434,8 @@ jerror_t JEventProcessor_CDC_PerStrawReco::evnt(JEventLoop *loop, uint64_t event
     vector <const DChargedTrack *> chargedTrackVector;
     loop->Get(chargedTrackVector);
 
+    japp->RootFillLock(this);
+    
     for (unsigned int iTrack = 0; iTrack < chargedTrackVector.size(); iTrack++){
 
         const DChargedTrackHypothesis* bestHypothesis = chargedTrackVector[iTrack]->Get_BestTrackingFOM();
@@ -533,6 +534,8 @@ jerror_t JEventProcessor_CDC_PerStrawReco::evnt(JEventLoop *loop, uint64_t event
 
         } 
     }
+
+    japp->RootFillUnLock(this);
     return NOERROR;
 }
 

--- a/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
+++ b/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
@@ -99,8 +99,6 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
   const Int_t TMAX = 2000;  //max for time
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
   // create root folder for cdc and cd to it, store main dir
   TDirectory *main = gDirectory;
   gDirectory->mkdir("CDC_drift")->cd();
@@ -145,8 +143,6 @@ jerror_t JEventProcessor_CDC_drift::init(void) {
     tfit->Branch("tdiff_ns",&tdiff,"tdiff/D");
 
   } 
-
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
 
   main->cd();
 

--- a/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
+++ b/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.cc
@@ -217,7 +217,7 @@ jerror_t JEventProcessor_CDC_drift::evnt(JEventLoop *eventLoop, uint64_t eventnu
   eventLoop->Get(digihits);
 
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
   fithisto = kFALSE;
 
@@ -600,7 +600,7 @@ jerror_t JEventProcessor_CDC_drift::evnt(JEventLoop *eventLoop, uint64_t eventnu
 
 
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+  japp->RootFillUnLock(this); //RELEASE ROOT LOCK!!
 
   return NOERROR;
 }

--- a/src/plugins/monitoring/CDC_roc_hits/JEventProcessor_CDC_roc_hits.cc
+++ b/src/plugins/monitoring/CDC_roc_hits/JEventProcessor_CDC_roc_hits.cc
@@ -56,8 +56,6 @@ JEventProcessor_CDC_roc_hits::~JEventProcessor_CDC_roc_hits() {
 
 jerror_t JEventProcessor_CDC_roc_hits::init(void) {
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
-
 
   TSTART = 200;
   TSTOP = 1200;
@@ -119,8 +117,6 @@ cdc_netamp_roc28   = new TH2D("cdc_netamp_roc28","CDC pulse peak amplitude minus
   
   main->cd();
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
-
 
   return NOERROR;
 }
@@ -165,7 +161,7 @@ jerror_t JEventProcessor_CDC_roc_hits::evnt(JEventLoop *eventLoop, uint64_t even
   vector<const DCDCDigiHit*> digihits;
   eventLoop->Get(digihits);
 
-  japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
   if(digihits.size() > 0) cdc_nevents->Fill(1);
 
@@ -279,7 +275,7 @@ jerror_t JEventProcessor_CDC_roc_hits::evnt(JEventLoop *eventLoop, uint64_t even
   }
 
 
-  japp->RootUnLock(); //RELEASE ROOT LOCK!!
+  japp->RootFillUnLock(this); //RELEASE ROOT LOCK!!
 
 
   return NOERROR;

--- a/src/plugins/monitoring/cpp_itrig/JEventProcessor_cpp_itrig.cc
+++ b/src/plugins/monitoring/cpp_itrig/JEventProcessor_cpp_itrig.cc
@@ -187,8 +187,10 @@ jerror_t JEventProcessor_cpp_itrig::evnt(JEventLoop *loop, uint64_t eventnumber)
 	// This is called for every event. 
 
   // Event count used by RootSpy->RSAI so it knows how many events have been seen.
+  japp->RootFillLock(this);
   hevents->Fill(0.5);
-
+  japp->RootFillUnLock(this);
+  
   ULong64_t timestamp = 0;
 
   if (MAKE_TREE) {
@@ -321,7 +323,7 @@ jerror_t JEventProcessor_cpp_itrig::evnt(JEventLoop *loop, uint64_t eventnumber)
         posdiff = posdiff>>1;
       }
 
-      japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+      japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
       // increment monitoring histo when trigger time and itrigger are both off by more than 1 bit
 
@@ -329,7 +331,7 @@ jerror_t JEventProcessor_cpp_itrig::evnt(JEventLoop *loop, uint64_t eventnumber)
 
       if (MAKE_TREE) tree->Fill();
 
-      japp->RootUnLock();
+      japp->RootFillUnLock(this);
 
     }  // for each Df125TriggerTime
 

--- a/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.cc
+++ b/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.cc
@@ -1,3 +1,4 @@
+
 // $Id$
 //
 //    File: JEventProcessor_fa125_itrig.cc
@@ -177,7 +178,10 @@ jerror_t JEventProcessor_fa125_itrig::evnt(JEventLoop *loop, uint64_t eventnumbe
 	// This is called for every event. 
 
   // Event count used by RootSpy->RSAI so it knows how many events have been seen.
+
+  japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!  
   hevents->Fill(0.5);
+  japp->RootFillUnLock(this); 
 
   ULong64_t timestamp = 0;
 
@@ -311,7 +315,7 @@ jerror_t JEventProcessor_fa125_itrig::evnt(JEventLoop *loop, uint64_t eventnumbe
         posdiff = posdiff>>1;
       }
 
-      japp->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+      japp->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
       // increment monitoring histo when trigger time and itrigger are both off by more than 1 bit
 
@@ -319,7 +323,7 @@ jerror_t JEventProcessor_fa125_itrig::evnt(JEventLoop *loop, uint64_t eventnumbe
 
       if (MAKE_TREE) tree->Fill();
 
-      japp->RootUnLock();
+      japp->RootFillUnLock(this);
 
     }  // for each Df125TriggerTime
 


### PR DESCRIPTION
I wrote a python script to check for the right kind of root locks in the right place and found a number of plugins that generated errors/warnings.  I fixed those that I am responsible for.  [This nice wiki page explains it for JANA](https://halldweb.jlab.org/wiki/index.php/Locking_in_JANA) It might seem a bit late fixing this stuff now but a bug gone is a good thing (and I wish I'd found that wiki page before today).
If you're interested, the script and its output from this afternoon are in /work/halld/njarvis/locks   The python script can run over a single plugin JEventProcessor_something.cc file, or over a whole plugin directory eg monitoring. 
The script is reasonably straightforward, it does make some unnecessary warnings, but it does also find real bugs where histograms are filled outside of root locks.   If I remember correctly, there was originally only the one kind of lock RootWriteLock, and then later the RootFillLock was introduced for filling histograms; we have a lot of code that was written before the FillLock was invented and not updated.  The wiki page says that the RootFillLock would be faster.