### PR TITLE
Add code to mask dead channels when reading in HDDM/REST events

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -187,6 +187,10 @@ class DEventSourceHDDM:public JEventSource
       JCalibration *jcalib;
       float uscale[192],vscale[192];
 
+	  double tagh_counter_quality[TAGH_MAX_COUNTER+1];
+	  double tagm_fiber_quality[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
+
+
 };
 
 #endif //_JEVENT_SOURCEHDDM_H_

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -15,6 +15,9 @@
 #include <JANA/JEvent.h>
 #include <DANA/DStatusBits.h>
 
+#include <TAGGER/DTAGHHit_factory_Calib.h>
+#include <TAGGER/DTAGMHit_factory_Calib.h>
+
 #include <DVector2.h>
 #include <DEventSourceREST.h>
 
@@ -307,6 +310,19 @@ jerror_t DEventSourceREST::GetObjects(JEvent &event, JFactory_base *factory)
 			     << " dx/dz=" << dBeamDirMap[locRunNumber].X() 
 			     << " dy/dz=" << dBeamDirMap[locRunNumber].Y() 
 			     << endl;
+
+			// load tagger quality tables
+// 			dTAGHCounterQualities[locRunNumber] = new double[TAGH_MAX_COUNTER+1];
+// 			dTAGMFiberQualities[locRunNumber] = new double*[TAGM_MAX_ROW+1];
+// 			for(int i; i<TAGM_MAX_ROW+1; i++)
+// 				dTAGMFiberQualities[locRunNumber][i] = new double[TAGM_MAX_COLUMN+1];
+
+			if(!DTAGHHit_factory_Calib::load_ccdb_constants(locEventLoop, "counter_quality", "code", dTAGHCounterQualities[locRunNumber])) {
+				jerr << "Error loading /PHOTON_BEAM/hodoscope/counter_quality in DEventSourceREST::GetObjects() ... " << endl;
+			}
+			if(!DTAGMHit_factory_Calib::load_ccdb_constants(locEventLoop, "fiber_quality", "code", dTAGMFiberQualities[locRunNumber])) {
+				jerr << "Error loading /PHOTON_BEAM/microscope/fiber_quality in DEventSourceREST::GetObjects() ... " << endl;
+			}
 
 			// tagger related configs for reverse mapping tagger energy to counter number
 			if( REST_JANA_CALIB_CONTEXT != "" ) {
@@ -655,7 +671,12 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 		if(column == 0) {
 			continue;
 		}
-
+     
+		// throw away hits from bad or noisy counters
+		int quality = dTAGMFiberQualities[locRunNumber][0][column];  // I think this works for the row? - we are generally not worrying about the quality of individual fibers
+		if (quality != DTAGMHit_factory_Calib::k_fiber_good )
+			continue;
+         
 		DBeamPhoton* gamma = new DBeamPhoton();
 
 		double Elo_tagm = tagmGeom->getElow(column);
@@ -716,7 +737,12 @@ jerror_t DEventSourceREST::Extract_DBeamPhoton(hddm_r::HDDM *record,
 		if(counter == 0) {
 			continue;
 		}
-
+         	
+		// throw away hits from bad or noisy counters
+		int quality = dTAGHCounterQualities[locRunNumber][counter];
+		if (quality != DTAGHHit_factory_Calib::k_counter_good )
+			continue;
+         
       	DBeamPhoton* gamma = new DBeamPhoton();
 
 		double Elo_tagh = taghGeom->getElow(counter);

--- a/src/libraries/HDDM/DEventSourceREST.h
+++ b/src/libraries/HDDM/DEventSourceREST.h
@@ -41,6 +41,8 @@
 #include <DIRC/DDIRCPmtHit.h>
 #include <DIRC/DDIRCTruthBarHit.h>
 #include <PID/DParticleID.h>
+#include <TAGGER/DTAGMHit.h>
+#include <TAGGER/DTAGHHit.h>
 #include <TAGGER/DTAGMGeometry.h>
 #include <TAGGER/DTAGHGeometry.h>
 #include <HDDM/DEventHitStatistics.h>
@@ -139,6 +141,13 @@ class DEventSourceREST:public JEventSource
    	map<unsigned int, JCalibration *> dJCalib_olds; //unsigned int is run number
    	map<unsigned int, DTAGHGeometry *> dTAGHGeoms; //unsigned int is run number
    	map<unsigned int, DTAGMGeometry *> dTAGMGeoms; //unsigned int is run number
+
+	//map<unsigned int, double *> dTAGHCounterQualities;
+	map<unsigned int, double [TAGH_MAX_COUNTER+1]> dTAGHCounterQualities;
+	//map<unsigned int, double **> dTAGMFiberQualities;
+	map<unsigned int, double [TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1]> dTAGMFiberQualities;
+	
+	
 
 };
 

--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.cc
@@ -97,15 +97,15 @@ jerror_t DTAGHHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnu
     else
         jerr << "Unable to get TAGH_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/hodoscope/base_time_offset !" << endl;
 
-    if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
-        load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
-        load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
-        load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
-        load_ccdb_constants("counter_quality", "code", counter_quality) &&
-        load_ccdb_constants("tdc_timewalk", "c0", tdc_twalk_c0) &&
-        load_ccdb_constants("tdc_timewalk", "c1", tdc_twalk_c1) &&
-        load_ccdb_constants("tdc_timewalk", "c2", tdc_twalk_c2) &&
-        load_ccdb_constants("tdc_timewalk", "c3", tdc_twalk_c3))
+    if (load_ccdb_constants(eventLoop, "fadc_gains", "gain", fadc_gains) &&
+        load_ccdb_constants(eventLoop, "fadc_pedestals", "pedestal", fadc_pedestals) &&
+        load_ccdb_constants(eventLoop, "fadc_time_offsets", "offset", fadc_time_offsets) &&
+        load_ccdb_constants(eventLoop, "tdc_time_offsets", "offset", tdc_time_offsets) &&
+        load_ccdb_constants(eventLoop, "counter_quality", "code", counter_quality) &&
+        load_ccdb_constants(eventLoop, "tdc_timewalk", "c0", tdc_twalk_c0) &&
+        load_ccdb_constants(eventLoop, "tdc_timewalk", "c1", tdc_twalk_c1) &&
+        load_ccdb_constants(eventLoop, "tdc_timewalk", "c2", tdc_twalk_c2) &&
+        load_ccdb_constants(eventLoop, "tdc_timewalk", "c3", tdc_twalk_c3))
     {
         return NOERROR;
     }
@@ -273,7 +273,7 @@ jerror_t DTAGHHit_factory_Calib::fini(void)
 //---------------------
 // load_ccdb_constants
 //---------------------
-bool DTAGHHit_factory_Calib::load_ccdb_constants(
+bool DTAGHHit_factory_Calib::load_ccdb_constants( jana::JEventLoop *eventLoop, 
     std::string table_name,
     std::string column_name,
     double result[TAGH_MAX_COUNTER+1])

--- a/src/libraries/TAGGER/DTAGHHit_factory_Calib.h
+++ b/src/libraries/TAGGER/DTAGHHit_factory_Calib.h
@@ -44,7 +44,8 @@ class DTAGHHit_factory_Calib:public jana::JFactory<DTAGHHit>{
         double tdc_twalk_c2[TAGH_MAX_COUNTER+1];
         double tdc_twalk_c3[TAGH_MAX_COUNTER+1];
 
-        bool load_ccdb_constants(std::string table_name,
+        bool static load_ccdb_constants(jana::JEventLoop *eventLoop, 
+            std::string table_name,
             std::string column_name,
             double table[TAGH_MAX_COUNTER+1]);
 

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.cc
@@ -99,17 +99,17 @@ jerror_t DTAGMHit_factory_Calib::brun(jana::JEventLoop *eventLoop, int32_t runnu
     else
         jerr << "Unable to get TAGM_TDC_BASE_TIME_OFFSET from /PHOTON_BEAM/microscope/base_time_offset !" << endl;
 
-    if (load_ccdb_constants("fadc_gains", "gain", fadc_gains) &&
-    load_ccdb_constants("fadc_pedestals", "pedestal", fadc_pedestals) &&
-    load_ccdb_constants("fadc_time_offsets", "offset", fadc_time_offsets) &&
-    load_ccdb_constants("tdc_time_offsets", "offset", tdc_time_offsets) &&
-    load_ccdb_constants("fiber_quality", "code", fiber_quality) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c0", tw_c0) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c1", tw_c1) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "c2", tw_c2) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "threshold", tw_c3) &&
-    load_ccdb_constants("tdc_timewalk_corrections", "reference", ref) &&
-    load_ccdb_constants("integral_cuts", "integral", int_cuts))
+    if (load_ccdb_constants(eventLoop, "fadc_gains", "gain", fadc_gains) &&
+    load_ccdb_constants(eventLoop, "fadc_pedestals", "pedestal", fadc_pedestals) &&
+    load_ccdb_constants(eventLoop, "fadc_time_offsets", "offset", fadc_time_offsets) &&
+    load_ccdb_constants(eventLoop, "tdc_time_offsets", "offset", tdc_time_offsets) &&
+    load_ccdb_constants(eventLoop, "fiber_quality", "code", fiber_quality) &&
+    load_ccdb_constants(eventLoop, "tdc_timewalk_corrections", "c0", tw_c0) &&
+    load_ccdb_constants(eventLoop, "tdc_timewalk_corrections", "c1", tw_c1) &&
+    load_ccdb_constants(eventLoop, "tdc_timewalk_corrections", "c2", tw_c2) &&
+    load_ccdb_constants(eventLoop, "tdc_timewalk_corrections", "threshold", tw_c3) &&
+    load_ccdb_constants(eventLoop, "tdc_timewalk_corrections", "reference", ref) &&
+    load_ccdb_constants(eventLoop, "integral_cuts", "integral", int_cuts))
     {
         return NOERROR;
     }
@@ -324,7 +324,7 @@ jerror_t DTAGMHit_factory_Calib::fini(void)
 //---------------------
 // load_ccdb_constants
 //---------------------
-bool DTAGMHit_factory_Calib::load_ccdb_constants(
+bool DTAGMHit_factory_Calib::load_ccdb_constants( jana::JEventLoop *eventLoop, 
         std::string table_name,
         std::string column_name,
         double result[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1])

--- a/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
+++ b/src/libraries/TAGGER/DTAGMHit_factory_Calib.h
@@ -52,7 +52,7 @@ class DTAGMHit_factory_Calib: public jana::JFactory<DTAGMHit> {
       double ref[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
       double int_cuts[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1];
 
-      bool load_ccdb_constants(std::string table_name,
+      bool static load_ccdb_constants(jana::JEventLoop *eventLoop, std::string table_name,
                                std::string column_name,
                                double table[TAGM_MAX_ROW+1][TAGM_MAX_COLUMN+1]);
    private:


### PR DESCRIPTION
This is mainly for random hits that are merged in, when the bad channel mask was updated after the random trigger files were created

Addresses issue #810