### PR TITLE
updates for CPP low level hits

### DIFF
--- a/src/libraries/FMWPC/DFMWPCHit_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.cc
@@ -271,11 +271,12 @@ jerror_t DFMWPCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     
     maxamp = maxamp - scaled_ped;
     */
-    
+
+    // apply different thresholds to the amplitude and the integral
     if (maxamp < hit_amp_threshold) {
       continue;
     }
-    if (digihit->pulse_integral < hit_int_threshold) {   /// ???
+    if (digihit->pulse_integral < hit_int_threshold) {  
       continue;
     }
 

--- a/src/libraries/FMWPC/DFMWPCHit_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.cc
@@ -24,7 +24,8 @@ using namespace jana;
 jerror_t DFMWPCHit_factory::init(void)
 {
   
-  hit_threshold = 0.;
+  hit_amp_threshold = 0.;
+  hit_int_threshold = 0.;
 
   t_raw_min = -10000.;
   t_raw_max = 10000.;
@@ -70,15 +71,22 @@ jerror_t DFMWPCHit_factory::brun(jana::JEventLoop *eventLoop, int32_t runnumber)
 
   if(print_messages) jout << "In DFMWPCHit_factory, loading constants..." << std::endl;
 
-  if (eventLoop->GetCalib("/FMWPC/hit_threshold", hit_threshold)){
-    hit_threshold = 0.;
+  vector<double> fmwpc_hit_thresholds;
+
+  if (eventLoop->GetCalib("/FMWPC/hit_threshold", hit_amp_threshold)){
+    hit_amp_threshold = 0.;
+    hit_int_threshold = 0.;
     jout << "Error loading /FMWPC/hit_threshold ! set default value to 0." << endl;
   } else {
-    jout << "FMWPC Hit Threshold: " << hit_threshold << endl;
+    hit_amp_threshold = fmwpc_hit_thresholds[0];
+    hit_int_threshold = fmwpc_hit_thresholds[1];
+    jout << "FMWPC Hit Thresholds:  Amplitude = " << hit_amp_threshold << "  Integral = " << hit_int_threshold << endl;
   }
 
-  gPARMS->SetDefaultParameter("FMWPC:FMWPC_HIT_THRESHOLD", hit_threshold,
-                              "Remove FMWPC Hits with peak amplitudes smaller than FMWPC_HIT_THRESHOLD");
+  gPARMS->SetDefaultParameter("FMWPC:FMWPC_hit_amp_threshold", hit_amp_threshold,
+                              "Remove FMWPC Hits with peak amplitudes smaller than FMWPC_hit_amp_threshold");
+  gPARMS->SetDefaultParameter("FMWPC:FMWPC_hit_int_threshold", hit_amp_threshold,
+                              "Remove FMWPC Hits with total integral smaller than FMWPC_hit_int_threshold");
 
   vector<double> fmwpc_timing_cuts;
 
@@ -264,7 +272,10 @@ jerror_t DFMWPCHit_factory::evnt(JEventLoop *loop, uint64_t eventnumber)
     maxamp = maxamp - scaled_ped;
     */
     
-    if (maxamp<hit_threshold) {
+    if (maxamp < hit_amp_threshold) {
+      continue;
+    }
+    if (digihit->pulse_integral < hit_int_threshold) {   /// ???
       continue;
     }
 

--- a/src/libraries/FMWPC/DFMWPCHit_factory.h
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.h
@@ -29,7 +29,8 @@ class DFMWPCHit_factory:public jana::JFactory<DFMWPCHit>{
 //  const char* Tag(void){return "";}
 
   // hit threshold
-  double hit_threshold;
+  double hit_amp_threshold;
+  double hit_int_threshold;
 
   // timing cut limits
   double t_raw_min;

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -2987,7 +2987,10 @@ jerror_t DEventSourceHDDM::Extract_DFMWPCHit(hddm_s::HDDM *record,  JFactory<DFM
       hit->t     = iter->getT();
       const hddm_s::FmwpcHitQList &charges=iter->getFmwpcHitQs();
       hit->q     = (charges.size()) ? charges.begin()->getQ() : 0.;
-      hit->amp   = (charges.size()) ? hit->q/28.8 : 0.; // copied from CDC
+      const hddm_s::FmwpcDigiHitList &digis=iter->getFmwpcDigiHits();
+      hit->amp   = (digis.size()) ? digis.begin()->getAmp()  : 0.; 
+      hit->QF   = (digis.size()) ? digis.begin()->getQf()  : 0.; 
+      hit->ped   = (digis.size()) ? digis.begin()->getPed()  : 0.; 
       data.push_back(hit);
    }
 

--- a/src/libraries/HDDM/DEventWriterHDDM.cc
+++ b/src/libraries/HDDM/DEventWriterHDDM.cc
@@ -843,32 +843,32 @@ bool DEventWriterHDDM::Write_HDDMEvent(JEventLoop* locEventLoop, string locOutpu
 	    hddm_s::FmwpcChamberList::iterator FMWPC_ChamberIterator = FMWPC_ChamberList->begin();
 	    for(FMWPC_ChamberIterator = FMWPC_ChamberList->begin(); FMWPC_ChamberIterator != FMWPC_ChamberList->end(); FMWPC_ChamberIterator++)
 	    {
-			if(FMWPCHits[i]->layer == FMWPC_ChamberIterator->getLayer() &&
-		   		FMWPCHits[i]->wire == FMWPC_ChamberIterator->getWire())
-		    {
-		    	foundChamber = true;
-		    	break;
-		    }
+	      if(FMWPCHits[i]->layer == FMWPC_ChamberIterator->getLayer() &&
+		 FMWPCHits[i]->wire == FMWPC_ChamberIterator->getWire())
+		{
+		  foundChamber = true;
+		  break;
+		}
 	    }
 	    if(foundChamber == false)
-	    {
-			hitv->getForwardMWPC().addFmwpcChambers();
-			FMWPC_ChamberIterator = FMWPC_ChamberList->end()-1;
-			FMWPC_ChamberIterator->setLayer(FMWPCHits[i]->layer);
-			FMWPC_ChamberIterator->setWire(FMWPCHits[i]->wire);
-	    }
+	      {
+		hitv->getForwardMWPC().addFmwpcChambers();
+		FMWPC_ChamberIterator = FMWPC_ChamberList->end()-1;
+		FMWPC_ChamberIterator->setLayer(FMWPCHits[i]->layer);
+		FMWPC_ChamberIterator->setWire(FMWPCHits[i]->wire);
+	      }
 	    FMWPC_ChamberIterator->addFmwpcHits();
 	    hddm_s::FmwpcHitList* fmwpchitl=&FMWPC_ChamberIterator->getFmwpcHits();
 	    hddm_s::FmwpcHitList::iterator fmwpchitit=fmwpchitl->end()-1;
 	    fmwpchitit->setT(FMWPCHits[i]->t);
 	    fmwpchitit->addFmwpcHitQs();
-        fmwpchitit->getFmwpcHitQs().begin()->setQ(FMWPCHits[i]->q);	    
+	    fmwpchitit->getFmwpcHitQs().begin()->setQ(FMWPCHits[i]->q);
 	    fmwpchitit->addFmwpcDigiHits();
-        fmwpchitit->getFmwpcDigiHits().begin()->setAmp(FMWPCHits[i]->amp);
-        fmwpchitit->getFmwpcDigiHits().begin()->setPed(FMWPCHits[i]->ped);
-        fmwpchitit->getFmwpcDigiHits().begin()->setQf(FMWPCHits[i]->QF);
+	    fmwpchitit->getFmwpcDigiHits().begin()->setAmp(FMWPCHits[i]->amp);
+	    fmwpchitit->getFmwpcDigiHits().begin()->setPed(FMWPCHits[i]->ped);
+	    fmwpchitit->getFmwpcDigiHits().begin()->setQf(FMWPCHits[i]->QF);
     
-	  }
+	}
 	
 
 	//*fout << *record; //stream the new record into the file

--- a/src/libraries/HDDM/DEventWriterHDDM.cc
+++ b/src/libraries/HDDM/DEventWriterHDDM.cc
@@ -833,34 +833,41 @@ bool DEventWriterHDDM::Write_HDDMEvent(JEventLoop* locEventLoop, string locOutpu
 	  }
 	//=============================================FMWPC================================================
 	for(uint i=0;i<FMWPCHits.size();++i)
-	  {
+	{
 	    if(i==0)
-	      {
+	    {
 	      hitv->addForwardMWPCs();
-	      }
+	    }
 	    bool foundChamber=false;
 	    hddm_s::FmwpcChamberList* FMWPC_ChamberList = &hitv->getForwardMWPC().getFmwpcChambers();
 	    hddm_s::FmwpcChamberList::iterator FMWPC_ChamberIterator = FMWPC_ChamberList->begin();
 	    for(FMWPC_ChamberIterator = FMWPC_ChamberList->begin(); FMWPC_ChamberIterator != FMWPC_ChamberList->end(); FMWPC_ChamberIterator++)
-	      {
-		if(FMWPCHits[i]->layer == FMWPC_ChamberIterator->getLayer() &&
-		   FMWPCHits[i]->wire == FMWPC_ChamberIterator->getWire())
-		  {
-		    foundChamber = true;
-		    break;
-		  }
-	      }
+	    {
+			if(FMWPCHits[i]->layer == FMWPC_ChamberIterator->getLayer() &&
+		   		FMWPCHits[i]->wire == FMWPC_ChamberIterator->getWire())
+		    {
+		    	foundChamber = true;
+		    	break;
+		    }
+	    }
 	    if(foundChamber == false)
-	      {
-		hitv->getForwardMWPC().addFmwpcChambers();
-		FMWPC_ChamberIterator = FMWPC_ChamberList->end()-1;
-		FMWPC_ChamberIterator->setLayer(FMWPCHits[i]->layer);
-		FMWPC_ChamberIterator->setWire(FMWPCHits[i]->wire);
-	      }
+	    {
+			hitv->getForwardMWPC().addFmwpcChambers();
+			FMWPC_ChamberIterator = FMWPC_ChamberList->end()-1;
+			FMWPC_ChamberIterator->setLayer(FMWPCHits[i]->layer);
+			FMWPC_ChamberIterator->setWire(FMWPCHits[i]->wire);
+	    }
 	    FMWPC_ChamberIterator->addFmwpcHits();
 	    hddm_s::FmwpcHitList* fmwpchitl=&FMWPC_ChamberIterator->getFmwpcHits();
 	    hddm_s::FmwpcHitList::iterator fmwpchitit=fmwpchitl->end()-1;
 	    fmwpchitit->setT(FMWPCHits[i]->t);
+	    fmwpchitit->addFmwpcHitQs();
+        fmwpchitit->addFmwpcHitQs().begin()->setQ(FMWPCHits[i]->q);	    
+	    fmwpchitit->addFmwpcDigiHits();
+        fmwpchitit->addFmwpcDigiHits().begin()->setAmp(FMWPCHits[i]->amp);
+        fmwpchitit->addFmwpcDigiHits().begin()->setPed(FMWPCHits[i]->ped);
+        fmwpchitit->addFmwpcDigiHits().begin()->setQf(FMWPCHits[i]->QF);
+    
 	  }
 	
 

--- a/src/libraries/HDDM/DEventWriterHDDM.cc
+++ b/src/libraries/HDDM/DEventWriterHDDM.cc
@@ -862,11 +862,11 @@ bool DEventWriterHDDM::Write_HDDMEvent(JEventLoop* locEventLoop, string locOutpu
 	    hddm_s::FmwpcHitList::iterator fmwpchitit=fmwpchitl->end()-1;
 	    fmwpchitit->setT(FMWPCHits[i]->t);
 	    fmwpchitit->addFmwpcHitQs();
-        fmwpchitit->addFmwpcHitQs().begin()->setQ(FMWPCHits[i]->q);	    
+        fmwpchitit->getFmwpcHitQs().begin()->setQ(FMWPCHits[i]->q);	    
 	    fmwpchitit->addFmwpcDigiHits();
-        fmwpchitit->addFmwpcDigiHits().begin()->setAmp(FMWPCHits[i]->amp);
-        fmwpchitit->addFmwpcDigiHits().begin()->setPed(FMWPCHits[i]->ped);
-        fmwpchitit->addFmwpcDigiHits().begin()->setQf(FMWPCHits[i]->QF);
+        fmwpchitit->getFmwpcDigiHits().begin()->setAmp(FMWPCHits[i]->amp);
+        fmwpchitit->getFmwpcDigiHits().begin()->setPed(FMWPCHits[i]->ped);
+        fmwpchitit->getFmwpcDigiHits().begin()->setQf(FMWPCHits[i]->QF);
     
 	  }
 	

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -227,11 +227,12 @@
       <forwardMWPC minOccurs="0">
         <fmwpcChamber layer="int" maxOccurs="unbounded" minOccurs="0" wire="int">
           <fmwpcTruthHit dE="float" dx="float" maxOccurs="unbounded" t="float">
-	    <fmwpcTruthHitQ q="float" d="float" maxOccurs="unbounded"/>
-	  </fmwpcTruthHit>
+	        <fmwpcTruthHitQ q="float" d="float" maxOccurs="unbounded"/>
+	      </fmwpcTruthHit>
           <fmwpcHit dE="float" maxOccurs="unbounded" t="float">
-	    <fmwpcHitQ q="float" maxOccurs="unbounded"/>
-	  </fmwpcHit>
+	        <fmwpcHitQ q="float" maxOccurs="unbounded"/>
+	        <fmwpcDigiHit minOccurs="0" amp="float" qf="int" ped="float" />
+	      </fmwpcHit>
         </fmwpcChamber>
         <fmwpcTruthPoint E="float" maxOccurs="unbounded" minOccurs="0" primary="boolean" ptype="int" px="float" py="float" pz="float" t="float" track="int" x="float" y="float" z="float">
           <trackID minOccurs="0" itrack="int"/>


### PR DESCRIPTION
* add handling of writing out all the appropriate fields for FMWPC hits to HDDM event format
* add ability to apply thresholds to both the digit hit amplitude and integral. we can implement the appropriate CCDB table after this