### PR TITLE
Fcal2 index fix

### DIFF
--- a/src/libraries/FCAL/DFCALGeometry.cc
+++ b/src/libraries/FCAL/DFCALGeometry.cc
@@ -82,19 +82,19 @@ void DFCALGeometry::GetSurveyGeometry(const DGeometry *geom){
 	double x=m_FCALdX+x0+double(col-col0)*dx;
 	double y=m_FCALdY+pos[1];//+phi*x; //use small angle approximation
 	m_positionOnFace[row][col].Set(x,y);
+	ch=row*kBlocksTall+col;
 	m_row[ch]     =  row;
 	m_column[ch]  =  col;
 	m_channelNumber[row][col]=ch;
 	m_activeBlock[row][col] = true;
-	
-	ch++;
       }
     }
   }
-  m_numFcalChannels=ch;
-  
-  // Now extract the positions of the PWO crystals 
-   for( int i = 0; i < 42; i++ ){
+  m_numFcalChannels=2800; // for backward-compatibility
+
+  // Now extract the positions of the PWO crystals
+  ch=m_numFcalChannels;
+  for( int i = 0; i < 42; i++ ){
     string my_row_string="XTrow"+to_string(i);
     string my_mpos_string="//composition[@name='"+my_row_string
       +"']/mposX[@volume='XTModule']/";

--- a/src/libraries/FCAL/DFCALHit_factory.cc
+++ b/src/libraries/FCAL/DFCALHit_factory.cc
@@ -272,9 +272,11 @@ void DFCALHit_factory::FillCalibTable( fcal_digi_constants_t &table,
 {
     for (int channel=0; channel < static_cast<int>(raw_table.size()); channel++)
     {
+      if (fcalGeom.isBlockActive(channel)){
         int row = fcalGeom.row(channel);
         int col = fcalGeom.column(channel);
         table[row][col] = raw_table[channel];
+      }
     }
 }
 

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory_DATA.cc
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory_DATA.cc
@@ -288,14 +288,13 @@ jerror_t DL1MCTrigger_factory_DATA::brun(jana::JEventLoop *eventLoop, int32_t ru
 
     if(debug){
       for(int ch = 0; ch < (int)fcal_gains_ch.size(); ch++){
-	int row = fcalGeom.row(ch);
-	int col = fcalGeom.column(ch);
-	if(fcalGeom.isBlockActive(row,col)){
+	if (fcalGeom.isBlockActive(ch)){
+	  int row = fcalGeom.row(ch);
+	  int col = fcalGeom.column(ch);
 	  hfcal_gains->Fill(fcal_gains[row][col]);
 	  DVector2 aaa = fcalGeom.positionOnFace(row,col);
 	  hfcal_gains2->Fill(float(aaa.X()), float(aaa.Y()), fcal_gains[row][col]);
-	  //	  cout << aaa.X() << "  " << aaa.Y() << endl;
-	  
+	  //cout << aaa.X() << "  " << aaa.Y() << endl;	  
 	}	
       }
     }
@@ -315,9 +314,9 @@ jerror_t DL1MCTrigger_factory_DATA::brun(jana::JEventLoop *eventLoop, int32_t ru
 
     if(debug){
       for(int ch = 0; ch < (int)fcal_gains_ch.size(); ch++){
-	int row = fcalGeom.row(ch);
-	int col = fcalGeom.column(ch);
-	if(fcalGeom.isBlockActive(row,col)){
+	if(fcalGeom.isBlockActive(ch)){
+	  int row = fcalGeom.row(ch);
+	  int col = fcalGeom.column(ch);
 	  hfcal_ped->Fill(fcal_pedestals[row][col]);
 	}
       }	
@@ -1540,36 +1539,13 @@ int DL1MCTrigger_factory_DATA::FindTriggers(DL1MCTrigger *trigger){
 // Fill fcal calibration tables similar to FCALHit factory
 void DL1MCTrigger_factory_DATA::LoadFCALConst(fcal_constants_t &table, const vector<double> &fcal_const_ch, 
 					 const DFCALGeometry  &fcalGeom){
-  
-  char str[256];
-  
-  if (fcalGeom.numChannels() != FCAL_MAX_CHANNELS) {
-    sprintf(str, "FCAL geometry is wrong size! channels=%d (should be %d)", 
-	    fcalGeom.numChannels(), FCAL_MAX_CHANNELS);
-    throw JException(str);
-  }
-  
-  
   for (int ch = 0; ch < static_cast<int>(fcal_const_ch.size()); ch++) {
-    
-    // make sure that we don't try to load info for channels that don't exist
-    if (ch == (int)fcalGeom.numChannels())
-      break;
-    
-    int row = fcalGeom.row(ch);
-    int col = fcalGeom.column(ch);
-    
-    // results from DFCALGeometry should be self consistent, but add in some
-    // sanity checking just to be sure
-    if (fcalGeom.isBlockActive(row,col) == false) {
-      sprintf(str, "DL1MCTrigger: Loading FCAL constant for inactive channel!  "
-	      "row=%d, col=%d", row, col);
-      throw JException(str);
-    }    
-    
-    table[row][col] = fcal_const_ch[ch];
+    if (fcalGeom.isBlockActive(ch)){
+      int row = fcalGeom.row(ch);
+      int col = fcalGeom.column(ch);
+      table[row][col] = fcal_const_ch[ch];
+    }
   }
-  
 }
 
 void DL1MCTrigger_factory_DATA::Digitize(double adc_amp[sample], int adc_count[sample]){


### PR DESCRIPTION
Change how the FCAL-2 geometry is loaded to handle indexing of the FCAL channels taking into account the hole in the center for the ECAL but still maintaining the meaning of the order of the 2800 entries on the ccdb calibration tables.