### PR TITLE
Fix JANA2-related deprecation warnings

### DIFF
--- a/src/jana-upgrade.py
+++ b/src/jana-upgrade.py
@@ -72,7 +72,7 @@ def main():
 
     r.add(re.compile(r'using namespace jana;\n'), ''),
 
-    r.add(re.compile(r'#include <JANA/jerror\.h>'), r'#include <JANA/Compatibility/jerror.h>'),
+    r.add(re.compile(r'#include <JANA/jerror\.h>'), r'#include <DANA/jerror.h>'),
 
     r.add(re.compile(r'gPARMS'), 'app'),
     r.add(re.compile(r'JObject::oid'), 'oid'),

--- a/src/libraries/ANALYSIS/DTreeInterface.cc
+++ b/src/libraries/ANALYSIS/DTreeInterface.cc
@@ -1,5 +1,5 @@
 #include "DTreeInterface.h"
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 /************************************************* STATIC-VARIABLE-ACCESSING PRIVATE MEMBER FUNCTIONS *************************************************/
 

--- a/src/libraries/BCAL/DBCALShower_factory_IU.cc
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.cc
@@ -11,7 +11,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "DANA/DGeometryManager.h"
 #include "HDGEOMETRY/DGeometry.h"

--- a/src/libraries/BCAL/DBCALShower_factory_IU.h
+++ b/src/libraries/BCAL/DBCALShower_factory_IU.h
@@ -14,7 +14,7 @@
 
 #include "BCAL/DBCALShower.h"
 #include "BCAL/DBCALGeometry.h"
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 
 #include "TH2F.h"
 #include <DMatrixDSym.h>

--- a/src/libraries/CCAL/DCCALShower_factory.cc
+++ b/src/libraries/CCAL/DCCALShower_factory.cc
@@ -128,8 +128,8 @@ void DCCALShower_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 	} else if( profile_file_name.find("map_name") != profile_file_name.end() 
 		&& profile_file_name["map_name"] != "None" ) 
 	{
-	  JLargeCalibration *jresman = calib_man->GetLargeCalibration(runnumber);
-	  ccal_profile_file = jresman->GetResource(profile_file_name["map_name"]);
+	  JResource *res = calib_man->GetResource(runnumber);
+	  ccal_profile_file = res->GetResource(profile_file_name["map_name"]);
 	}
 	
 	if(print_messages)

--- a/src/libraries/DANA/DApplication.cc
+++ b/src/libraries/DANA/DApplication.cc
@@ -28,7 +28,7 @@ using std::string;
 
 #include <DANA/DApplication.h>
 #include <DANA/DGeometryManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
 #include <JANA/Calibrations/JCalibrationGeneratorCCDB.h>
 #include <JANA/Compatibility/JGeometryManager.h>

--- a/src/libraries/DANA/DApplication.cc
+++ b/src/libraries/DANA/DApplication.cc
@@ -31,7 +31,7 @@ using std::string;
 #include <JANA/Services/JLockService.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
 #include <JANA/Calibrations/JCalibrationGeneratorCCDB.h>
-#include <JANA/Compatibility/JGeometryManager.h>
+#include <JANA/Geometry/JGeometryManager.h>
 #include <JANA/CLI/JMain.h>
 
 /// The DApplication class adds HALL-D specific event source and factory generators to a JApplication

--- a/src/libraries/DANA/DApplication.h
+++ b/src/libraries/DANA/DApplication.h
@@ -8,7 +8,7 @@
 #ifndef _DApplication_
 #define _DApplication_
 
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <JANA/CLI/JMain.h>
 
 class JApplication;

--- a/src/libraries/DANA/DEvent.h
+++ b/src/libraries/DANA/DEvent.h
@@ -8,7 +8,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "DANA/DStatusBits.h"
 #include "DANA/DGeometryManager.h"

--- a/src/libraries/DANA/DEvent.h
+++ b/src/libraries/DANA/DEvent.h
@@ -42,9 +42,8 @@ namespace DEvent {
 		return event->GetJApplication()->GetService<JCalibrationManager>()->GetJCalibration(event->GetRunNumber());
 	}
 
-// TODO: NWB: Not so happy with naming of "JResourceManager" or "JLargeCalibration"
-	inline JLargeCalibration* GetJLargeCalibration(const std::shared_ptr<const JEvent>& event) {
-		return event->GetJApplication()->GetService<JCalibrationManager>()->GetLargeCalibration(event->GetRunNumber());
+	inline JResource* GetJResource(const std::shared_ptr<const JEvent>& event) {
+		return event->GetJApplication()->GetService<JCalibrationManager>()->GetResource(event->GetRunNumber());
 	}
 
 	inline DGeometry* GetDGeometry(const std::shared_ptr<const JEvent>& event) {

--- a/src/libraries/DANA/DGeometryManager.cc
+++ b/src/libraries/DANA/DGeometryManager.cc
@@ -17,7 +17,7 @@
 #include <DIRC/DDIRCLutReader.h>
 
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JGeometryManager.h>
+#include <JANA/Geometry/JGeometryManager.h>
 
 
 DGeometryManager::DGeometryManager(JApplication* app) : m_app(app) {}

--- a/src/libraries/DANA/DStatusBits.h
+++ b/src/libraries/DANA/DStatusBits.h
@@ -21,7 +21,7 @@
 #ifndef _DStatusBits_
 #define _DStatusBits_
 
-#include <JANA/Compatibility/JStatusBits.h>
+#include <JANA/Utils/JStatusBits.h>
 
 // Used for status flags set for each event
 enum StatusBitType{

--- a/src/libraries/DANA/JExceptionDataFormat.h
+++ b/src/libraries/DANA/JExceptionDataFormat.h
@@ -8,7 +8,7 @@
 #ifndef _JExceptionDataFormat_
 #define _JExceptionDataFormat_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JException.h>
 
 /// This is a subclass of JException that is used to indicate a

--- a/src/libraries/DANA/cint.h
+++ b/src/libraries/DANA/cint.h
@@ -1,0 +1,31 @@
+
+// This stuff is needed by rootcint to generate the dictionary files
+#if defined(__CINT__) || defined(__CLING__)
+
+namespace jana{}
+using namespace jana;
+
+class pthread_t;
+class pthread_cond_t;
+class pthread_mutex_t;
+
+class exception;
+class __signed;
+class timespec;
+class timeval;
+
+#endif // __CINT__  __CLING__
+
+
+// This stuff is needed when actually compiling the dictionary files with g++
+#ifdef G__DICTIONARY
+
+namespace jana{}
+using namespace jana;
+
+#ifndef _root_cint_seen_
+#define _root_cint_seen_
+
+#endif // _root_cint_seen_
+
+#endif

--- a/src/libraries/DANA/jerror.h
+++ b/src/libraries/DANA/jerror.h
@@ -1,0 +1,36 @@
+//
+/// jerror.h
+/// 
+/// This file contains error codes for errors specific to the
+/// analysis code. Many functions return values
+/// of type jerror_t. This header should be included in all
+/// files which must deal with this type.
+
+#ifndef _JERROR_H_
+#define _JERROR_H_
+
+enum jerror_t {
+    NOERROR = 0,
+    UNKNOWN_ERROR = -1000,
+    MAX_EVENT_PROCESSORS_EXCEEDED,
+    ERROR_OPENING_EVENT_SOURCE,
+    ERROR_CLOSING_EVENT_SOURCE,
+    NO_MORE_EVENTS_IN_SOURCE,
+    NO_MORE_EVENT_SOURCES,
+    EVENT_NOT_IN_MEMORY,
+    EVENT_SOURCE_NOT_OPEN,
+    OBJECT_NOT_AVAILABLE,
+    DEVENT_OBJECT_DOES_NOT_EXIST,
+    MEMORY_ALLOCATION_ERROR,
+    RESOURCE_UNAVAILABLE,
+    VALUE_OUT_OF_RANGE,
+    INFINITE_RECURSION,
+    UNRECOVERABLE_ERROR,
+    FILTER_EVENT_OUT
+};
+
+// The following is here just so we can use ROOT's THtml class to generate documentation.
+#include "cint.h"
+
+#endif
+

--- a/src/libraries/DAQ/DBORptrs.h
+++ b/src/libraries/DAQ/DBORptrs.h
@@ -27,7 +27,7 @@
 	X(DTSGBORConfig)
 
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 
 #include <DAQ/LinkAssociations.h>
 

--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -776,7 +776,7 @@ void DEVIOWorkerThread::ParseCDAQBank(uint32_t* &iptr, uint32_t *iend)
 		iptr += 2;
 		try{
 			ParseBORbank(iptr, iend);
-		}catch(JException &e){
+		}catch(const JException &e){
 			cerr << e.what();
 		}
 		return;

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -18,7 +18,7 @@
 #include <iterator>
 using namespace std;
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <DAQ/HDEVIO.h>
 #include <DAQ/DParsedEvent.h>
 #include <DAQ/DModuleType.h>

--- a/src/libraries/DAQ/DParsedEvent.h
+++ b/src/libraries/DAQ/DParsedEvent.h
@@ -13,16 +13,13 @@
 using std::string;
 using std::map;
 
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/JObject.h>
 #include <JANA/JEvent.h>
 
-
+#include <DANA/jerror.h>
 #include <DANA/DStatusBits.h>
 #include <DAQ/daq_param_type.h>
 #include <DAQ/DModuleType.h>
-
-
 #include <DAQ/Df250Config.h>
 #include <DAQ/Df250PulseIntegral.h>
 #include <DAQ/Df250StreamingRawData.h>

--- a/src/libraries/DAQ/JEventSourceGenerator_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSourceGenerator_EVIOpp.h
@@ -8,9 +8,9 @@
 #ifndef _JEventSourceGenerator_EVIOpp_
 #define _JEventSourceGenerator_EVIOpp_
 
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/JEventSourceGenerator.h>
 
+#include <DANA/jerror.h>
 #include <DAQ/HDEVIO.h>
 
 #include "JEventSource_EVIOpp.h"

--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -97,10 +97,10 @@ JEventSource_EVIO::JEventSource_EVIO(std::string source_name, JApplication* app)
 	source_type = kNoSource;
 	quit_on_next_ET_timeout = false;
 
-	// Initialize dedicated JStreamLog used for debugging messages
-	evioout.SetTag("--- EVIO ---: ");
-	evioout.SetTimestampFlag();
-	evioout.SetThreadstampFlag();
+	// Initialize dedicated logger
+	evioout.SetGroup("EVIO");
+	evioout.ShowTimestamp(true);
+	evioout.ShowThreadstamp(true);
 	
 	// Define base set of status bits
 	DStatusBits::SetStatusBitDescriptions();

--- a/src/libraries/DAQ/JEventSource_EVIO.cc
+++ b/src/libraries/DAQ/JEventSource_EVIO.cc
@@ -891,7 +891,7 @@ jerror_t JEventSource_EVIO::ParseEvents(ObjList *objs_ptr)
 					double tstart = GetTime();
 					ParseEVIOEvent(evt, my_full_events);
 					time_evio_parse = GetTime() - tstart;
-				}catch(JException &jexception){
+				}catch(const JException &jexception){
 					jerr << "Exception thrown from ParseEVIOEvent!" << endl;
 					jerr << jexception.what() << endl;
 				}

--- a/src/libraries/DAQ/JEventSource_EVIO.h
+++ b/src/libraries/DAQ/JEventSource_EVIO.h
@@ -26,7 +26,6 @@ using std::set;
 #include <JANA/JEventSource.h>
 #include <JANA/JEvent.h>
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/JStreamLog.h>
 
 #include "HDEVIO.h"
 
@@ -84,10 +83,10 @@ typedef pair<int,int> tagNum;
 
 #include "Df125EmulatorAlgorithm.h"
 #include "Df250EmulatorAlgorithm.h"
-#include <JANA/Compatibility/jerror.h>
 
 #include <PID/DVertex.h>
 #include <DANA/DStatusBits.h>
+#include <DANA/jerror.h>
 
 extern set<uint32_t> ROCIDS_TO_PARSE;
 

--- a/src/libraries/DAQ/JEventSource_EVIO.h
+++ b/src/libraries/DAQ/JEventSource_EVIO.h
@@ -223,7 +223,7 @@ class JEventSource_EVIO: public JEventSource {
 		map<tagNum, MODULE_TYPE> module_type;
 		map<MODULE_TYPE, MODULE_TYPE> modtype_translate;
 
-		JStreamLog evioout;
+		JLogger evioout;
 
 		bool  AUTODETECT_MODULE_TYPES;
 		bool  DUMP_MODULE_MAP;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -58,10 +58,10 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(std::string source_name):JEventSource(s
 	NEVENTBUFF_STALLED   = 0;
 	NPARSER_STALLED      = 0;
 
-	// Initialize dedicated JStreamLog used for debugging messages
-	evioout.SetTag("--- EVIO ---: ");
-	evioout.SetTimestampFlag();
-	evioout.SetThreadstampFlag();
+	// Initialize dedicated logger
+	evioout.SetGroup("EVIO");
+	evioout.ShowTimestamp(true);
+	evioout.ShowThreadstamp(true);
 	
 	// Define base set of status bits
 	DStatusBits::SetStatusBitDescriptions();

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -15,8 +15,7 @@
 #include <JANA/JApplication.h>
 #include <JANA/JEventSource.h>
 #include <JANA/JEvent.h>
-#include <JANA/Compatibility/JStreamLog.h>
-#include <JANA/Compatibility/jerror.h>
+#include <JANA/JLogger.h>
 
 #include <DAQ/HDEVIO.h>
 #include <DAQ/HDET.h>
@@ -30,6 +29,7 @@
 
 #include <DANA/DApplication.h>
 #include <DANA/DStatusBits.h>
+#include <DANA/jerror.h>
 
 /// How this Event Source Works
 /// ===================================================================

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -174,7 +174,7 @@ class JEventSource_EVIOpp: public JEventSource{
 		vector<DEVIOWorkerThread*> worker_threads;
 		thread *dispatcher_thread;
 
-		JStreamLog evioout;
+		JLogger evioout;
 		
 		uint32_t F250_EMULATION_MODE; // (EmulationModeType)
 		uint32_t F125_EMULATION_MODE; // (EmulationModeType)

--- a/src/libraries/DIRC/DDIRCGeometry.cc
+++ b/src/libraries/DIRC/DDIRCGeometry.cc
@@ -7,7 +7,7 @@
 #include <TString.h>
 
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JGeometryManager.h>
+#include <JANA/Geometry/JGeometryManager.h>
 
 #include "DDIRCGeometry.h"
 

--- a/src/libraries/DIRC/DDIRCLut.h
+++ b/src/libraries/DIRC/DDIRCLut.h
@@ -7,7 +7,7 @@
 #define _DDIRCLut_
 
 #include <JANA/JObject.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <DANA/DGeometryManager.h>
 #include <PID/DDetectorMatches.h>

--- a/src/libraries/DIRC/DDIRCLutReader.cc
+++ b/src/libraries/DIRC/DDIRCLutReader.cc
@@ -34,7 +34,7 @@ DDIRCLutReader::DDIRCLutReader(JApplication *app, unsigned int run_number)
 	if(jcalib->GetCalib("/DIRC/LUT/lut_map", lut_map_name)) 
 		jout << "Can't find requested /DIRC/LUT/lut_map in CCDB for this run!" << jendl;
 	else if(lut_map_name.find("map_name") != lut_map_name.end() && lut_map_name["map_name"] != "None" && lut_file.empty()) {
-		jresman = japp->GetService<JCalibrationManager>()->GetLargeCalibration(run_number);
+		jresman = japp->GetService<JCalibrationManager>()->GetResource(run_number);
 		lut_file = jresman->GetResource(lut_map_name["map_name"]);
 	}
 	
@@ -99,7 +99,7 @@ DDIRCLutReader::DDIRCLutReader(JApplication *app, unsigned int run_number)
 		if(jcalib->GetCalib("/DIRC/LUT/lutcorr_map", lutcorr_map_name)) 
 		  jout << "Can't find requested /DIRC/LUT/lutcorr_map in CCDB for this run!" << endl;
 		else if(lutcorr_map_name.find("map_name") != lutcorr_map_name.end() && lutcorr_map_name["map_name"] != "None" && lutcorr_file.empty()) {
-                  jresman = japp->GetService<JCalibrationManager>()->GetLargeCalibration(run_number);
+                  jresman = japp->GetService<JCalibrationManager>()->GetResource(run_number);
 		  lutcorr_file = jresman->GetResource(lutcorr_map_name["map_name"]);
 		}
 		if(!lutcorr_file.empty()) {

--- a/src/libraries/DIRC/DDIRCLutReader.h
+++ b/src/libraries/DIRC/DDIRCLutReader.h
@@ -9,7 +9,7 @@
 #include <JANA/Compatibility/jerror.h>
 #include <JANA/JApplication.h>
 #include <JANA/Calibrations/JCalibration.h>
-#include <JANA/Calibrations/JLargeCalibration.h>
+#include <JANA/Calibrations/JResource.h>
 
 #include <DIRC/DDIRCGeometry.h>
 
@@ -57,7 +57,7 @@ private:
 
 protected:
 	JCalibration *jcalib;
-	JLargeCalibration *jresman;
+	JResource *jresman;
 };
 
 #endif // _DDIRCLutReader_

--- a/src/libraries/DIRC/DDIRCLutReader.h
+++ b/src/libraries/DIRC/DDIRCLutReader.h
@@ -6,11 +6,11 @@
 #ifndef _DDIRCLutReader_
 #define _DDIRCLutReader_
 
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/JApplication.h>
 #include <JANA/Calibrations/JCalibration.h>
 #include <JANA/Calibrations/JResource.h>
 
+#include <DANA/jerror.h>
 #include <DIRC/DDIRCGeometry.h>
 
 #include "TROOT.h"

--- a/src/libraries/EVENTSTORE/DESDBProviderMySQL.cc
+++ b/src/libraries/EVENTSTORE/DESDBProviderMySQL.cc
@@ -10,7 +10,7 @@
 #include <cstdlib>
 
 #include <JANA/JException.h>
-#include <JANA/Compatibility/JStreamLog.h>
+#include <JANA/JLogger.h>
 
 #include "DESDBProviderMySQL.h"
 

--- a/src/libraries/EVENTSTORE/DEventSourceEventStore.h
+++ b/src/libraries/EVENTSTORE/DEventSourceEventStore.h
@@ -7,7 +7,7 @@
 #ifndef _DEventSourceEventStore_
 #define _DEventSourceEventStore_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JEventSource.h>
 #include <JANA/JEvent.h>
 

--- a/src/libraries/FCAL/DFCALShower_factory.cc
+++ b/src/libraries/FCAL/DFCALShower_factory.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <DANA/DEvent.h>
 
 

--- a/src/libraries/FCAL/DFCALShower_factory.h
+++ b/src/libraries/FCAL/DFCALShower_factory.h
@@ -9,8 +9,8 @@
 #define _DFCALShower_factory_
 
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/jerror.h>
 
+#include <DANA/jerror.h>
 #include <FCAL/DFCALShower.h>
 #include <FCAL/DFCALCluster.h>
 

--- a/src/libraries/FDC/DFDCCathodeCluster_factory.cc
+++ b/src/libraries/FDC/DFDCCathodeCluster_factory.cc
@@ -191,7 +191,7 @@ void DFDCCathodeCluster_factory::Process(const std::shared_ptr<const JEvent>& ev
       std::sort(mData.begin(), mData.end(), DFDCCathodeCluster_gPlane_cmp);
     }
   }
-  catch (JException d) {
+  catch (const JException& d) {
     cout << d << endl;
   }	
   catch (...) {

--- a/src/libraries/FDC/DFDCCathodeCluster_factory.cc
+++ b/src/libraries/FDC/DFDCCathodeCluster_factory.cc
@@ -63,18 +63,16 @@ bool DFDCCathodeCluster_gPlane_cmp(	const DFDCCathodeCluster* a,
 
 ///
 /// DFDCCathodeCluster_factory::DFDCCathodeCluster_factory():
-///	default constructor--initializes log file
+///	default constructor
 ///
 DFDCCathodeCluster_factory::DFDCCathodeCluster_factory() {
-	_log = new JStreamLog(std::cout, "DFDCCathodeCluster >>");
 }
 
 ///
 /// DFDCCathodeCluster_factory::~DFDCCathodeCluster_factory():
-/// default destructor--closes log file.
+/// default destructor
 ///
 DFDCCathodeCluster_factory::~DFDCCathodeCluster_factory() {
-	delete _log;
 }
 
 ///

--- a/src/libraries/FDC/DFDCCathodeCluster_factory.h
+++ b/src/libraries/FDC/DFDCCathodeCluster_factory.h
@@ -9,7 +9,6 @@
 
 #include <JANA/JFactoryT.h>
 #include <JANA/JException.h>
-#include <JANA/Compatibility/JStreamLog.h>
 
 
 #include "DFDCCathodeCluster.h"

--- a/src/libraries/FDC/DFDCCathodeCluster_factory.h
+++ b/src/libraries/FDC/DFDCCathodeCluster_factory.h
@@ -55,7 +55,6 @@ class DFDCCathodeCluster_factory : public JFactoryT<DFDCCathodeCluster> {
 		void Process(const std::shared_ptr<const JEvent>& event) override;
 		void Init() override;
 	private:
-		JStreamLog* _log;
 		double TIME_SLICE;
 };
 

--- a/src/libraries/FDC/DFDCPseudo.h
+++ b/src/libraries/FDC/DFDCPseudo.h
@@ -9,7 +9,7 @@
 #define DFDCPSEUDO_H
 
 #include <JANA/JObject.h>
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 
 #include "DFDCWire.h"
 #include "DFDCCathodeCluster.h"

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -10,7 +10,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "DANA/DGeometryManager.h"
 #include "HDGEOMETRY/DGeometry.h"
 

--- a/src/libraries/FDC/DFDCPseudo_factory.cc
+++ b/src/libraries/FDC/DFDCPseudo_factory.cc
@@ -64,16 +64,14 @@ bool DFDCPseudo_cmp(const DFDCPseudo* a, const DFDCPseudo *b){
 
 ///
 /// DFDCPseudo_factory::DFDCPseudo_factory():
-/// default constructor -- initializes log file
+/// default constructor
 ///
 DFDCPseudo_factory::DFDCPseudo_factory() {
-  //_log = new JStreamLog(std::cout, "FDC PSEUDO >>");
-  //*_log << "File initialized." << endMsg;
 }
 
 ///
 /// DFDCPseudo_factory::~DFDCPseudo_factory():
-/// default destructor -- closes log file
+/// default destructor
 ///
 DFDCPseudo_factory::~DFDCPseudo_factory() {
   if (fdcwires.size()){
@@ -90,7 +88,6 @@ DFDCPseudo_factory::~DFDCPseudo_factory() {
       }
     }    
   }
-  //delete _log;
 }
 
 //------------------

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -137,7 +137,6 @@ class DFDCPseudo_factory : public JFactoryT<DFDCPseudo> {
 		TH1F *u_cl_size, *v_cl_size, *u_cl_n, *v_cl_n, *x_dist_2, *x_dist_3, *x_dist_23, *x_dist_33;
 		TH1F *d_uv;
 
-//		JStreamLog* _log;
 };
 
 #endif // DFACTORY_DFDCPSEUDO_H

--- a/src/libraries/FDC/DFDCPseudo_factory.h
+++ b/src/libraries/FDC/DFDCPseudo_factory.h
@@ -9,7 +9,6 @@
 #define DFACTORY_DFDCPSEUDO_H
 
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/JStreamLog.h>
 
 #include "DFDCPseudo.h"
 #include "DFDCCathodeCluster.h"

--- a/src/libraries/FDC/DFDCSegment_factory.cc
+++ b/src/libraries/FDC/DFDCSegment_factory.cc
@@ -51,18 +51,16 @@ bool DFDCSegment_package_cmp(const DFDCPseudo* a, const DFDCPseudo* b) {
 
 
 DFDCSegment_factory::DFDCSegment_factory() {
-        _log = new JStreamLog(std::cout, "FDCSEGMENT >>");
-        *_log << "File initialized." << endMsg;
 }
 
 
 ///
 /// DFDCSegment_factory::~DFDCSegment_factory():
-/// default destructor -- closes log file
+/// default destructor
 ///
 DFDCSegment_factory::~DFDCSegment_factory() {
-        delete _log;	
 }
+
 ///
 /// DFDCSegment_factory::brun():
 /// Initialization: read in deflection map, get magnetic field map
@@ -82,7 +80,7 @@ void DFDCSegment_factory::BeginRun(const std::shared_ptr<const JEvent>& event) {
   bfield = dapp->GetBfield();
   lorentz_def=dapp->GetLorentzDeflections();
 
-  *_log << "Table of Lorentz deflections initialized." << endMsg;
+  GetLogger() << "Table of Lorentz deflections initialized.";
   */
   DEBUG_LEVEL=0;
   app->SetDefaultParameter("FDC:DEBUG_LEVEL", DEBUG_LEVEL);

--- a/src/libraries/FDC/DFDCSegment_factory.h
+++ b/src/libraries/FDC/DFDCSegment_factory.h
@@ -7,7 +7,7 @@
 
 #include <JANA/JFactoryT.h>
 #include <JANA/JException.h>
-#include <JANA/Compatibility/JStreamLog.h>
+#include <JANA/JLogger.h>
 
 #include "DFDCSegment.h"
 #include "DFDCPseudo.h"

--- a/src/libraries/FDC/DFDCSegment_factory.h
+++ b/src/libraries/FDC/DFDCSegment_factory.h
@@ -87,8 +87,6 @@ class DFDCSegment_factory : public JFactoryT<DFDCSegment> {
 		void Process(const std::shared_ptr<const JEvent>& event) override;
 
 	private:
-		JStreamLog* _log;
-
 		double N[3];
 	        double varN[3][3];
 	 	double dist_to_origin,xc,yc,rc;

--- a/src/libraries/FMWPC/DFMWPCCluster_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCCluster_factory.cc
@@ -122,7 +122,7 @@ void DFMWPCCluster_factory::Process(const std::shared_ptr<const JEvent> &event)
       }
     }
   }
-  catch (JException& d) {
+  catch (const JException& d) {
     cout << d << endl;
   }	
   catch (...) {

--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -28,13 +28,14 @@ using namespace std;
 
 #include <JANA/JFactoryT.h>
 #include <JANA/JEvent.h>
-#include <DANA/DStatusBits.h>
-#include <DANA/DEvent.h>
+#include <JANA/Geometry/JGeometryXML.h>
 
-#include <JANA/Compatibility/JGeometryXML.h>
 #include "BCAL/DBCALGeometry.h"
 #include "PAIR_SPECTROMETER/DPSGeometry.h"
-#include "DANA/DObjectID.h"
+
+#include <DANA/DObjectID.h>
+#include <DANA/DStatusBits.h>
+#include <DANA/DEvent.h>
 
 
 #include <DVector2.h>

--- a/src/libraries/HDDM/DEventSourceHDDM.h
+++ b/src/libraries/HDDM/DEventSourceHDDM.h
@@ -22,9 +22,9 @@ using namespace std;
 #include <pthread.h>
 
 #include <JANA/JEventSource.h>
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/Calibrations/JCalibration.h>
 
+#include <DANA/jerror.h>
 #include <HDDM/hddm_s.hpp>
 
 #include "TRACKING/DMCTrackHit.h"

--- a/src/libraries/HDDM/DEventWriterHDDM.h
+++ b/src/libraries/HDDM/DEventWriterHDDM.h
@@ -9,7 +9,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/JObject.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <CDC/DCDCHit.h>
 #include <TOF/DTOFHit.h>

--- a/src/libraries/HDDM/DEventWriterREST.h
+++ b/src/libraries/HDDM/DEventWriterREST.h
@@ -9,7 +9,7 @@
 
 #include <JANA/JObject.h>
 #include <JANA/JEvent.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <DVector3.h>
 #include <DMatrix.h>

--- a/src/libraries/HDGEOMETRY/DGeometry.cc
+++ b/src/libraries/HDGEOMETRY/DGeometry.cc
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JGeometryXML.h>
+#include <JANA/Geometry/JGeometryXML.h>
 
 #include "DGeometry.h"
 #include "FDC/DFDCWire.h"

--- a/src/libraries/HDGEOMETRY/DGeometry.h
+++ b/src/libraries/HDGEOMETRY/DGeometry.h
@@ -12,9 +12,9 @@
 #include <map>
 
 #include <JANA/JApplication.h>
-#include <JANA/Compatibility/jerror.h>
-#include <JANA/Compatibility/JGeometry.h>
+#include <JANA/Geometry/JGeometry.h>
 
+#include <DANA/jerror.h>
 #include <DANA/DGeometryManager.h>
 #include "FDC/DFDCGeometry.h"
 #include "FDC/DFDCWire.h"

--- a/src/libraries/HDGEOMETRY/DLorentzDeflections.h
+++ b/src/libraries/HDGEOMETRY/DLorentzDeflections.h
@@ -2,7 +2,7 @@
 #ifndef _DLorentzDeflections_
 #define _DLorentzDeflections_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 /* The folowing are for interpreting grid of Lorentz deflection data */
 #define PACKAGE_Z_POINTS 10
 #define LORENTZ_X_POINTS 21

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
@@ -862,7 +862,7 @@ void DMagneticFieldMapFineMesh::GetFineMeshMap(string namepath,int32_t runnumber
     // see if we can get the EVIO file as a resource
     try {
         evioFileName = jresman->GetResource(finemesh_namepath);
-    } catch ( JException e ) {
+    } catch ( const JException& e ) {
         // if we can't get it as a resource, try to get it from a local file
         size_t ipos=namepath.find("/");
         size_t ipos2=namepath.find("/",ipos+1);

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
@@ -27,7 +27,7 @@ DMagneticFieldMapFineMesh::DMagneticFieldMapFineMesh(JApplication *app, int32_t 
 {
 	auto calib_svc = app->GetService<JCalibrationManager>();
 	jcalib = calib_svc->GetJCalibration(runnumber);
-	jresman = calib_svc->GetLargeCalibration(runnumber);
+	jresman = calib_svc->GetResource(runnumber);
 
 	japp->SetDefaultParameter("BFIELD_MAP", namepath);
 	

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.h
@@ -15,7 +15,7 @@ using std::string;
 
 #include <JANA/JApplication.h>
 #include <JANA/Calibrations/JCalibration.h>
-#include <JANA/Calibrations/JLargeCalibration.h>
+#include <JANA/Calibrations/JResource.h>
 
 class DMagneticFieldMapFineMesh:public DMagneticFieldMap{
  public:
@@ -69,7 +69,7 @@ class DMagneticFieldMapFineMesh:public DMagneticFieldMap{
  protected:
   
   JCalibration *jcalib;
-  JLargeCalibration *jresman;
+  JResource *jresman;
 
   vector< vector< vector<DBfieldPoint_t> > > Btable;
   

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapPS2DMap.cc
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapPS2DMap.cc
@@ -15,7 +15,7 @@ using namespace evio;
 
 #include <HDGEOMETRY/DGeometry.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Calibrations/JLargeCalibration.h>
+#include <JANA/Calibrations/JResource.h>
 
 //---------------------------------
 // DMagneticFieldMapPS2DMap    (Constructor)
@@ -25,7 +25,7 @@ DMagneticFieldMapPS2DMap::DMagneticFieldMapPS2DMap(JApplication *app, int32_t ru
 
 	auto calib_svc = app->GetService<JCalibrationManager>();
 	jcalib = calib_svc->GetJCalibration(runnumber);
-	jresman = calib_svc->GetLargeCalibration(runnumber);
+	jresman = calib_svc->GetResource(runnumber);
 	geom = app->GetService<DGeometryManager>()->GetDGeometry(runnumber);
 	
 	app->SetDefaultParameter("PSBFIELD_MAP", namepath);

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapPS2DMap.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapPS2DMap.h
@@ -15,7 +15,7 @@ using std::string;
 
 #include <JANA/JApplication.h>
 #include <JANA/Calibrations/JCalibration.h>
-#include <JANA/Calibrations/JLargeCalibration.h>
+#include <JANA/Calibrations/JResource.h>
 
 class DGeometry;
 
@@ -63,7 +63,7 @@ class DMagneticFieldMapPS2DMap:public DMagneticFieldMapPS {
  protected:
   
   JCalibration *jcalib;
-  JLargeCalibration *jresman;
+  JResource *jresman;
   DGeometry* geom;
 
   vector< vector< vector<DBfieldPoint_t> > > Btable;

--- a/src/libraries/HDGEOMETRY/DMaterialMap.h
+++ b/src/libraries/HDGEOMETRY/DMaterialMap.h
@@ -3,7 +3,7 @@
 #ifndef _DMaterialMap_
 #define _DMaterialMap_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/Calibrations/JCalibration.h>
 #include <JANA/Services/JParameterManager.h>
 

--- a/src/libraries/HDGEOMETRY/DRootGeom.h
+++ b/src/libraries/HDGEOMETRY/DRootGeom.h
@@ -10,7 +10,7 @@
 
 #include <JANA/JApplication.h>
 #include <JANA/Calibrations/JCalibration.h>
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 
 #include <DVector3.h>
 

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -61,8 +61,8 @@ void DChargedTrackHypothesis_factory::BeginRun(const std::shared_ptr<const JEven
 	  }
 	  else if( dedx_theta_file_name.find("file_name") != dedx_theta_file_name.end()
 		  && dedx_theta_file_name["file_name"] != "None" ) {
-	    auto *jlargecalib = DEvent::GetJLargeCalibration(event);
-	    dedx_theta_correction_file = jlargecalib->GetResource(dedx_theta_file_name["file_name"]);
+	    auto *jresource = DEvent::GetJResource(event);
+	    dedx_theta_correction_file = jresource->GetResource(dedx_theta_file_name["file_name"]);
 	  }
 
 	 // check to see if we actually have a filename
@@ -120,8 +120,8 @@ void DChargedTrackHypothesis_factory::BeginRun(const std::shared_ptr<const JEven
 	 }
 	 else if( dedx_i_theta_file_name.find("file_name") != dedx_i_theta_file_name.end()
 		 && dedx_i_theta_file_name["file_name"] != "None" ) {
-	   auto *jlargecalib = DEvent::GetJLargeCalibration(event);
-	   dedx_i_theta_correction_file = jlargecalib->GetResource(dedx_i_theta_file_name["file_name"]);
+	   auto *res = DEvent::GetJResource(event);
+	   dedx_i_theta_correction_file = res->GetResource(dedx_i_theta_file_name["file_name"]);
 	 }
 
 	 // check to see if we actually have a filename

--- a/src/libraries/TAC/DTACHit_factory.h
+++ b/src/libraries/TAC/DTACHit_factory.h
@@ -12,11 +12,11 @@
 using namespace std;
 
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/jerror.h>
 
+#include <DANA/jerror.h>
 #include <DANA/ReadWriteLock.h>
-#include <TTAB/DTTabUtilities.h>
 #include <DAQ/Df250PulseRawData.h>
+#include <TTAB/DTTabUtilities.h>
 
 #include "DTACDigiHit.h"
 #include "DTACTDCDigiHit.h"

--- a/src/libraries/TAC/HitRebuilderInterfaceTAC.h
+++ b/src/libraries/TAC/HitRebuilderInterfaceTAC.h
@@ -12,7 +12,7 @@
 #include <set>
 
 #include <JANA/JEvent.h>
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <DAQ/Df250WindowRawData.h>
 #include <TAC/DTACHit.h>
 

--- a/src/libraries/TAC/HitRebuilderTAC.h
+++ b/src/libraries/TAC/HitRebuilderTAC.h
@@ -12,8 +12,8 @@
 #include <set>
 #include <stdexcept>
 
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/JFactoryT.h>
+#include <DANA/jerror.h>
 #include <DAQ/Df250WindowRawData.h>
 
 #include "DTACDigiHit.h"

--- a/src/libraries/TRACKING/DHelicalFit.h
+++ b/src/libraries/TRACKING/DHelicalFit.h
@@ -71,7 +71,7 @@ using namespace std;
 #include "FDC/DFDCPseudo.h"
 #include "CDC/DCDCWire.h"
 
-#include "JANA/Compatibility/jerror.h"
+#include "DANA/jerror.h"
 
 #include <math.h>
 #ifndef atan2f

--- a/src/libraries/TRACKING/DMagneticFieldStepper.h
+++ b/src/libraries/TRACKING/DMagneticFieldStepper.h
@@ -7,7 +7,7 @@
 #include <math.h>
 
 #include <DVector3.h>
-#include "JANA/Compatibility/jerror.h"
+#include "DANA/jerror.h"
 
 #include "HDGEOMETRY/DMagneticFieldMap.h"
 

--- a/src/libraries/TRACKING/DQuickFit.h
+++ b/src/libraries/TRACKING/DQuickFit.h
@@ -51,7 +51,7 @@ using namespace std;
 
 #include <DVector3.h>
 
-#include "JANA/Compatibility/jerror.h"
+#include "DANA/jerror.h"
 
 #include <math.h>
 #ifndef atan2f

--- a/src/libraries/TRACKING/DReferenceTrajectory.h
+++ b/src/libraries/TRACKING/DReferenceTrajectory.h
@@ -14,7 +14,7 @@ using std::vector;
 #include <TMatrixFSym.h>
 #include <TMatrix.h>
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JApplication.h>
 
 #include <HDGEOMETRY/DGeometry.h>

--- a/src/libraries/TRACKING/DRiemannFit.h
+++ b/src/libraries/TRACKING/DRiemannFit.h
@@ -5,7 +5,7 @@
 using namespace std;
 
 #include <DMatrix.h>
-#include "JANA/Compatibility/jerror.h"
+#include "DANA/jerror.h"
 #include <DVector3.h>
 
 typedef struct{

--- a/src/libraries/TRACKING/DTrackCandidate_factory.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory.cc
@@ -41,7 +41,7 @@ using namespace std;
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "DANA/DGeometryManager.h"
 #include "HDGEOMETRY/DGeometry.h"
 

--- a/src/libraries/TRACKING/DTrackCandidate_factory_CDC.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_CDC.cc
@@ -153,7 +153,6 @@ void DTrackCandidate_factory_CDC::Init()
 //------------------
 void DTrackCandidate_factory_CDC::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
-	auto event_number = event->GetEventNumber();
 	auto run_number = event->GetRunNumber();
 	auto app = event->GetJApplication();
 	auto jcalib = app->GetService<JCalibrationManager>()->GetJCalibration(run_number);

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDC.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDC.cc
@@ -16,7 +16,7 @@ using namespace std;
 #include "DTrackCandidate_factory_FDC.h"
 
 #include <JANA/JEvent.h>
-#include "JANA/Compatibility/JGeometry.h"
+#include "JANA/Geometry/JGeometry.h"
 
 #include "DQuickFit.h"
 #include "HDGEOMETRY/DMagneticFieldMap.h"

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDC.h
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDC.h
@@ -13,7 +13,7 @@
 #include <TH3F.h>
 
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/JGeometry.h>
+#include <JANA/Geometry/JGeometry.h>
 
 
 #include "DQuickFit.h"

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
@@ -11,7 +11,7 @@
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "DANA/DGeometryManager.h"
 #include "HDGEOMETRY/DGeometry.h"
 

--- a/src/libraries/TRACKING/DTrackFitterALT1.cc
+++ b/src/libraries/TRACKING/DTrackFitterALT1.cc
@@ -15,7 +15,7 @@ using namespace std;
 #include <DVector3.h>
 #include <DMatrix.h>
 
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "GlueX.h"
 #include "PID/DParticleID.h"

--- a/src/libraries/TRACKING/DTrackFitterALT1.h
+++ b/src/libraries/TRACKING/DTrackFitterALT1.h
@@ -16,7 +16,7 @@
 #include <TH3.h>
 
 #include <JANA/JFactoryT.h>
-#include <JANA/Compatibility/JGeometry.h>
+#include <JANA/Geometry/JGeometry.h>
 #include "HDGEOMETRY/DMagneticFieldMap.h"
 #include "DTrackWireBased.h"
 #include "DReferenceTrajectory.h"

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD_ALT1.h
@@ -8,7 +8,7 @@
 #ifndef _DTrackFitterKalmanSIMD_ALT1_
 #define _DTrackFitterKalmanSIMD_ALT1_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <TRACKING/DTrackFitterKalmanSIMD.h>
 
 class DTrackFitterKalmanSIMD_ALT1: public DTrackFitterKalmanSIMD{

--- a/src/libraries/TRACKING/DTrackFitterStraightTrack.h
+++ b/src/libraries/TRACKING/DTrackFitterStraightTrack.h
@@ -8,10 +8,10 @@
 #ifndef _DTrackFitterStraightTrack_
 #define _DTrackFitterStraightTrack_
 
-#include <JANA/Compatibility/jerror.h>
 
 #include <TRACKING/DTrackFitter.h>
 
+#include <DANA/jerror.h>
 #include <CDC/DCDCTrackHit.h>
 #include <FDC/DFDCPseudo.h> 
 #include <DMatrixSIMD.h>

--- a/src/libraries/TRACKING/DTrackHitSelectorALT1.cc
+++ b/src/libraries/TRACKING/DTrackHitSelectorALT1.cc
@@ -10,7 +10,7 @@ using namespace std;
 
 #include <TROOT.h>
 
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <TRACKING/DReferenceTrajectory.h>
 

--- a/src/libraries/TRACKING/DTrackHitSelectorALT2.cc
+++ b/src/libraries/TRACKING/DTrackHitSelectorALT2.cc
@@ -12,7 +12,7 @@ using namespace std;
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "DANA/DGeometryManager.h"
 #include "HDGEOMETRY/DGeometry.h"

--- a/src/libraries/TRACKING/DTrackHitSelectorTHROWN.h
+++ b/src/libraries/TRACKING/DTrackHitSelectorTHROWN.h
@@ -8,7 +8,7 @@
 #ifndef _DTrackHitSelectorTHROWN_
 #define _DTrackHitSelectorTHROWN_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 
 #include <TRACKING/DTrackHitSelector.h>
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -177,7 +177,6 @@ void DTrackTimeBased_factory::Init()
 //------------------
 void DTrackTimeBased_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
-  auto event_number = event->GetEventNumber();
   auto run_number = event->GetRunNumber();
   auto app = GetApplication();
   auto geo_manager = app->GetService<DGeometryManager>();

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -169,7 +169,6 @@ void DTrackWireBased_factory::Init()
 //------------------
 void DTrackWireBased_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
-	auto event_number = event->GetEventNumber();
 	auto run_number = event->GetRunNumber();
 	auto app = GetApplication();
 

--- a/src/libraries/TRD/DTRDPoint_factory.cc
+++ b/src/libraries/TRD/DTRDPoint_factory.cc
@@ -31,7 +31,6 @@ void DTRDPoint_factory::Init()
 //------------------
 void DTRDPoint_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
-  auto event_number = event->GetEventNumber();
   auto runnumber = event->GetRunNumber();
   auto app = event->GetJApplication();
   auto geo_manager = app->GetService<DGeometryManager>();

--- a/src/libraries/TTAB/DTranslationTable.cc
+++ b/src/libraries/TTAB/DTranslationTable.cc
@@ -150,10 +150,10 @@ DTranslationTable::DTranslationTable(JApplication* app, JEvent* event)
 	// DTranslationTable.h
 	InitNsamplesOverride(app);
 
-	// Initialize dedicated JStreamLog used for debugging messages
-	ttout.SetTag("--- TT ---: ");
-	ttout.SetTimestampFlag();
-	ttout.SetThreadstampFlag();
+	// Initialize dedicated JLogger used for debugging messages
+	ttout.SetGroup("TT");
+	ttout.ShowTimestamp(true);
+	ttout.ShowThreadstamp(true);
 
 	// Look for and read in an optional rocid <-> rocid translation table
 	ReadOptionalROCidTranslation();

--- a/src/libraries/TTAB/DTranslationTable.h
+++ b/src/libraries/TTAB/DTranslationTable.h
@@ -662,7 +662,7 @@ class DTranslationTable:public JObject{
 		string ROCID_MAP_FILENAME;
 		bool CALL_STACK;
 
-		mutable JStreamLog ttout;
+		mutable JLogger ttout;
 
 		string Channel2Str(const DChannelInfo &in_channel) const;
 

--- a/src/plugins/Analysis/F250_mode10_pedestal/JEventProcessor_F250_mode10_pedestal.cc
+++ b/src/plugins/Analysis/F250_mode10_pedestal/JEventProcessor_F250_mode10_pedestal.cc
@@ -18,7 +18,7 @@
 
 
 // Routine used to create our JEventProcessor
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 extern "C"{
 void InitPlugin(JApplication *app){

--- a/src/plugins/Analysis/bcal_calib/DEventProcessor_bcal_calib.h
+++ b/src/plugins/Analysis/bcal_calib/DEventProcessor_bcal_calib.h
@@ -23,11 +23,11 @@ using std::map;
 #include <JANA/JEventProcessor.h>
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibration.h>
-#include <JANA/Compatibility/jerror.h>
 
 #include <PID/DKinematicData.h>
 #include <CDC/DCDCTrackHit.h>
 #include <BCAL/DBCALShower.h>
+#include <DANA/jerror.h>
 #include <DMatrixSIMD.h>
 #include <DVector2.h>
 #include <DVector3.h>

--- a/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
+++ b/src/plugins/Calibration/BCAL_TDC_Timing/JEventProcessor_BCAL_TDC_Timing.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_TDC_Timing_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <BCAL/DBCALGeometry.h>
 #include <TRACKING/DTrackFitter.h>
 

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.h
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_attenlength_gainratio_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "BCAL/DBCALGeometry.h"
 #include "TH2.h"
 

--- a/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.h
+++ b/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.h
@@ -11,7 +11,7 @@
 #include <TDirectory.h>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <BCAL/DBCALGeometry.h>
 
 class JEventProcessor_BCAL_point_time:public JEventProcessor{

--- a/src/plugins/Calibration/BCAL_saturation/JEventProcessor_BCAL_saturation.h
+++ b/src/plugins/Calibration/BCAL_saturation/JEventProcessor_BCAL_saturation.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_saturation_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_BCAL_saturation:public JEventProcessor{
  public:

--- a/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.h
+++ b/src/plugins/Calibration/CDC_TimeToDistance/JEventProcessor_CDC_TimeToDistance.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_TimeToDistance_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "TProfile2D.h"
 #include "TProfile.h"
 #include "TH1F.h"

--- a/src/plugins/Calibration/CDC_amp/JEventProcessor_CDC_amp.h
+++ b/src/plugins/Calibration/CDC_amp/JEventProcessor_CDC_amp.h
@@ -10,7 +10,7 @@
 
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TRACKING/DTrackFitter.h"
 #include "TRACKING/DTrackTimeBased.h"

--- a/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.h
+++ b/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_FCAL_LED_shifts_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <FCAL/DFCALGeometry.h>
 #include <TTAB/DTranslationTable.h>
 

--- a/src/plugins/Calibration/FCAL_Pi0TOF/JEventProcessor_FCAL_Pi0TOF.h
+++ b/src/plugins/Calibration/FCAL_Pi0TOF/JEventProcessor_FCAL_Pi0TOF.h
@@ -8,7 +8,7 @@
 #ifndef _JEventProcessor_FCAL_Pi0TOF_
 #define _JEventProcessor_FCAL_Pi0TOF_
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <PID/DNeutralParticle.h>
 #include <FCAL/DFCALShower.h>
 #include <FCAL/DFCALCluster.h>

--- a/src/plugins/Calibration/FCAL_TimingOffsets_Primex/JEventProcessor_FCAL_TimingOffsets_Primex.h
+++ b/src/plugins/Calibration/FCAL_TimingOffsets_Primex/JEventProcessor_FCAL_TimingOffsets_Primex.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_FCAL_TimingOffsets_Primex_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TTree.h"
 #include "TH1.h"

--- a/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.h
+++ b/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.h
@@ -9,7 +9,7 @@
 #define _DEventProcessor_FCAL_Shower_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DEventWriterROOT.h>
 #include <HDDM/DEventWriterREST.h>

--- a/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.h
+++ b/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PSC_TW_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <PAIR_SPECTROMETER/DPSCHit.h>
 #include <PAIR_SPECTROMETER/DPSCPair.h>

--- a/src/plugins/Calibration/PS_E_calib/JEventProcessor_PS_E_calib.h
+++ b/src/plugins/Calibration/PS_E_calib/JEventProcessor_PS_E_calib.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PS_E_calib_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_PS_E_calib:public JEventProcessor{
 	public:

--- a/src/plugins/Calibration/PS_timing/JEventProcessor_PS_timing.h
+++ b/src/plugins/Calibration/PS_timing/JEventProcessor_PS_timing.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PS_timing_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_PS_timing:public JEventProcessor{
 public:

--- a/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
+++ b/src/plugins/Calibration/ST_Propagation_Time/JEventProcessor_ST_Propagation_Time.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_Propagation_Time_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 // ROOT header files
 #include <TMath.h>
 #include <TDirectory.h>

--- a/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
+++ b/src/plugins/Calibration/ST_Tresolution/JEventProcessor_ST_Tresolution.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_Tresolution_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 // ROOT header files
 #include <TMath.h>
 #include <TDirectory.h>

--- a/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.h
+++ b/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGH_timewalk_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <RF/DRFTime_factory.h>
 
 class JEventProcessor_TAGH_timewalk:public JEventProcessor{

--- a/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.h
+++ b/src/plugins/Calibration/TAGM_TW/JEventProcessor_TAGM_TW.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGM_TW_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TAGGER/DTAGMHit.h"
 #include "TAGGER/DTAGMGeometry.h"

--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.h
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.h
@@ -9,11 +9,11 @@
 #define _JEventProcessor_TOF_calib_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/jerror.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 using namespace std;
 #include <stdint.h>
+#include <DANA/jerror.h>
 #include <DAQ/DCODAEventInfo.h>
 #include <TOF/DTOFDigiHit.h>
 

--- a/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.h
+++ b/src/plugins/Calibration/st_tw_corr_auto/JEventProcessor_st_tw_corr_auto.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_st_tw_corr_auto_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 using namespace std;
 using std::vector;

--- a/src/plugins/Utilities/cal_high_energy_skim/JEventProcessor_cal_high_energy_skim.h
+++ b/src/plugins/Utilities/cal_high_energy_skim/JEventProcessor_cal_high_energy_skim.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_cal_high_energy_skim_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include "evio_writer/DEventWriterEVIO.h"
 
 #include <TH1F.h>

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.h
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_cdc_scan_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_cdc_scan:public JEventProcessor{

--- a/src/plugins/Utilities/dedx_tree/JEventProcessor_dedx_tree.h
+++ b/src/plugins/Utilities/dedx_tree/JEventProcessor_dedx_tree.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_dedx_tree_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TRIGGER/DTrigger.h"
 #include "TRACKING/DTrackTimeBased.h"

--- a/src/plugins/Utilities/dumpcandidates/JEventProcessor_dumpcandidates.h
+++ b/src/plugins/Utilities/dumpcandidates/JEventProcessor_dumpcandidates.h
@@ -13,7 +13,7 @@
 using namespace std;
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <HDGEOMETRY/DGeometry.h>
 
 class JEventProcessor_dumpcandidates:public JEventProcessor{

--- a/src/plugins/Utilities/dumpthrowns/JEventProcessor_dumpthrowns.h
+++ b/src/plugins/Utilities/dumpthrowns/JEventProcessor_dumpthrowns.h
@@ -13,7 +13,7 @@
 using namespace std;
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <HDGEOMETRY/DGeometry.h>
 
 class JEventProcessor_dumpthrowns:public JEventProcessor{

--- a/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
+++ b/src/plugins/Utilities/evio_writer/DEventWriterEVIO.h
@@ -9,7 +9,7 @@
 #include <JANA/JEvent.h>
 #include <JANA/JEventSource.h>
 #include <JANA/JApplication.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <DAQ/JEventSource_EVIO.h>
 #include <DAQ/JEventSource_EVIOpp.h>

--- a/src/plugins/Utilities/evio_writer/DFactoryGenerator_evio_writer.h
+++ b/src/plugins/Utilities/evio_writer/DFactoryGenerator_evio_writer.h
@@ -1,7 +1,7 @@
 #ifndef _DFactoryGenerator_evio_writer_
 #define _DFactoryGenerator_evio_writer_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JFactoryGenerator.h>
 
 #include "DEventWriterEVIO_factory.h"

--- a/src/plugins/Utilities/eviodana/DEventSourceEVIO.h
+++ b/src/plugins/Utilities/eviodana/DEventSourceEVIO.h
@@ -8,10 +8,10 @@
 #ifndef _DEventSourceEVIO_
 #define _DEventSourceEVIO_
 
-#include <JANA/Compatibility/jerror.h>
 #include <JANA/JEventSource.h>
 #include <JANA/JEvent.h>
 
+#include <DANA/jerror.h>
 #include <HDGEOMETRY/DMagneticFieldMap.h>
 #include <HDGEOMETRY/DGeometry.h>
 #include <TRACKING/DTrackTimeBased.h>

--- a/src/plugins/Utilities/eviodana/DEventSourceEVIOGenerator.h
+++ b/src/plugins/Utilities/eviodana/DEventSourceEVIOGenerator.h
@@ -12,7 +12,7 @@
 using namespace std;
 
 #include <JANA/JApplication.h>
-#include <JANA/Compatibility/jerror.h>
+#include <JANA/Services/jerror.h>
 #include <JANA/JEventSourceGenerator.h>
 
 class DEventSourceEVIOGenerator:public JEventSourceGenerator{

--- a/src/plugins/Utilities/l3bdt/JEventProcessor_L3BDTtree.h
+++ b/src/plugins/Utilities/l3bdt/JEventProcessor_L3BDTtree.h
@@ -11,7 +11,7 @@
 #include <TTree.h>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <DAQ/Df250TriggerTime.h>
 #include <DAQ/Df250PulseData.h>

--- a/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.h
+++ b/src/plugins/Utilities/run_summary/DEventProcessor_run_summary.h
@@ -9,7 +9,7 @@
 #define _DEventProcessor_run_summary_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DEventWriterROOT.h>
 #include <HDDM/DEventWriterREST.h>

--- a/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
+++ b/src/plugins/Utilities/syncskim/JEventProcessor_syncskim.h
@@ -11,7 +11,7 @@
 #include <atomic>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <TFile.h>
 #include <TTree.h>

--- a/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
+++ b/src/plugins/Utilities/track_skimmer/DEventProcessor_track_skimmer.h
@@ -12,7 +12,7 @@
 #include <fstream>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DEventWriterROOT.h>
 #include <HDDM/DEventWriterREST.h>

--- a/src/plugins/Utilities/trackeff_missing/DFactoryGenerator_trackeff_missing.h
+++ b/src/plugins/Utilities/trackeff_missing/DFactoryGenerator_trackeff_missing.h
@@ -8,7 +8,7 @@
 #ifndef _DFactoryGenerator_trackeff_missing_
 #define _DFactoryGenerator_trackeff_missing_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JFactoryGenerator.h>
 
 #include "DReaction_factory_trackeff_missing.h"

--- a/src/plugins/include/HistogramTools.h
+++ b/src/plugins/include/HistogramTools.h
@@ -5,7 +5,7 @@
 #include <stdexcept>
 
 #include <JANA/JApplication.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <TH1I.h>
 #include <TH2I.h>
 #include <TH3I.h>

--- a/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.h
+++ b/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_Eff_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DHistogramActions.h>
 #include "ANALYSIS/DAnalysisUtilities.h"

--- a/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.h
+++ b/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_BCAL_Hadronic_Eff_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TH1I.h"
 #include "TH2I.h"

--- a/src/plugins/monitoring/BCAL_LED/JEventProcessor_BCAL_LED.h
+++ b/src/plugins/monitoring/BCAL_LED/JEventProcessor_BCAL_LED.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_BCAL_LED_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <stdint.h>
 #include <vector>

--- a/src/plugins/monitoring/BCAL_LED_time/JEventProcessor_BCAL_LED_time.h
+++ b/src/plugins/monitoring/BCAL_LED_time/JEventProcessor_BCAL_LED_time.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_BCAL_LED_time_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <stdint.h>
 #include <vector>

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.h
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_BCAL_LEDonline_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <BCAL/DBCALGeometry.h>
 
 class JEventProcessor_BCAL_LEDonline:public JEventProcessor{

--- a/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.h
+++ b/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.h
@@ -9,7 +9,7 @@
 #define _DEventProcessor_BCAL_Shower_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DEventWriterROOT.h>
 #include <HDDM/DEventWriterREST.h>

--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.h
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_BCAL_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <BCAL/DBCALGeometry.h>
 
 class JEventProcessor_BCAL_online:public JEventProcessor{

--- a/src/plugins/monitoring/CCAL_online/JEventProcessor_CCAL_online.h
+++ b/src/plugins/monitoring/CCAL_online/JEventProcessor_CCAL_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CCAL_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <stdint.h>
 #include <vector>

--- a/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.h
+++ b/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.h
@@ -25,7 +25,7 @@ using namespace std;
 
 #include <JANA/JFactoryT.h>
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <HDGEOMETRY/DGeometry.h>
 #include <TRACKING/DTrackCandidate_factory_StraightLine.h>

--- a/src/plugins/monitoring/CDC_PerStrawReco/JEventProcessor_CDC_PerStrawReco.h
+++ b/src/plugins/monitoring/CDC_PerStrawReco/JEventProcessor_CDC_PerStrawReco.h
@@ -12,7 +12,7 @@
 
 #include <TH1F.h>
 #include <TH2F.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 using std::vector;
 

--- a/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.h
+++ b/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_dedx_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TRIGGER/DTrigger.h"
 #include "PID/DVertex.h"

--- a/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.h
+++ b/src/plugins/monitoring/CDC_drift/JEventProcessor_CDC_drift.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_drift_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_CDC_drift:public JEventProcessor{

--- a/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.h
+++ b/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_expert_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_CDC_expert:public JEventProcessor{

--- a/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.h
+++ b/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_expert_2_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 using namespace std;

--- a/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.h
+++ b/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_CDC_online:public JEventProcessor{

--- a/src/plugins/monitoring/CDC_roc_hits/JEventProcessor_CDC_roc_hits.h
+++ b/src/plugins/monitoring/CDC_roc_hits/JEventProcessor_CDC_roc_hits.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_CDC_roc_hits_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "CDC/DCDCDigiHit.h"
 #include "DAQ/Df125PulseIntegral.h"

--- a/src/plugins/monitoring/DAQ_online/JEventProcessor_DAQ_online.h
+++ b/src/plugins/monitoring/DAQ_online/JEventProcessor_DAQ_online.h
@@ -11,7 +11,7 @@
 #include <TDirectory.h>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_DAQ_online:public JEventProcessor{
 	public:

--- a/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.h
+++ b/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_DIRC_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <DIRC/DDIRCGeometry.h>
 
 class JEventProcessor_DIRC_online:public JEventProcessor{

--- a/src/plugins/monitoring/EPICS_dump/JEventProcessor_EPICS_dump.h
+++ b/src/plugins/monitoring/EPICS_dump/JEventProcessor_EPICS_dump.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_EPICS_dump_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_EPICS_dump:public JEventProcessor{

--- a/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.h
+++ b/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_FCAL_Hadronic_Eff_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TH1I.h"
 #include "TH2I.h"

--- a/src/plugins/monitoring/FCAL_invmass/JEventProcessor_FCAL_invmass.h
+++ b/src/plugins/monitoring/FCAL_invmass/JEventProcessor_FCAL_invmass.h
@@ -9,7 +9,7 @@
 #define _DEventProcessor_FCAL_Shower_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <ANALYSIS/DEventWriterROOT.h>
 #include <HDDM/DEventWriterREST.h>

--- a/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.h
+++ b/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_FCAL_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class TH1D;
 class TH1I;

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.h
@@ -22,7 +22,7 @@ using namespace std;
 #include <TMath.h>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <JANA/Calibrations/JCalibration.h>
 
 #include <HDGEOMETRY/DGeometry.h>

--- a/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.h
+++ b/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_FDC_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_FDC_online:public JEventProcessor{

--- a/src/plugins/monitoring/FMWPC_online/JEventProcessor_FMWPC_online.h
+++ b/src/plugins/monitoring/FMWPC_online/JEventProcessor_FMWPC_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_FMWPC_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <vector>
 
 class JEventProcessor_FMWPC_online:public JEventProcessor{

--- a/src/plugins/monitoring/L1_online/JEventProcessor_L1_online.h
+++ b/src/plugins/monitoring/L1_online/JEventProcessor_L1_online.h
@@ -8,7 +8,7 @@
 #define _JEventProcessor_L1_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_L1_online:public JEventProcessor{
 public:

--- a/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.h
+++ b/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PSC_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_PSC_online:public JEventProcessor{

--- a/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.h
+++ b/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PSPair_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_PSPair_online:public JEventProcessor{
 public:

--- a/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.h
+++ b/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.h
@@ -10,7 +10,7 @@
 #include "TRandom3.h"
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "PAIR_SPECTROMETER/DPSGeometry.h"
 #include "ANALYSIS/DTreeInterface.h"

--- a/src/plugins/monitoring/PS_online/JEventProcessor_PS_online.h
+++ b/src/plugins/monitoring/PS_online/JEventProcessor_PS_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_PS_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_PS_online:public JEventProcessor{

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.h
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.h
@@ -18,7 +18,7 @@
 #include "TDirectoryFile.h"
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "GlueX.h"
 #include "DAQ/DCODAROCInfo.h"

--- a/src/plugins/monitoring/RSAI_KO/RSAI_KO.cc
+++ b/src/plugins/monitoring/RSAI_KO/RSAI_KO.cc
@@ -9,7 +9,7 @@
 #include <iostream>
 using namespace std;
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JFactoryGenerator.h>
 
 #include "JFactoryGenerator_RSAI_KO.h"

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_SC_Eff_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TH1I.h"
 #include "TH2I.h"

--- a/src/plugins/monitoring/ST_ZEff/JEventProcessor_ST_ZEff.h
+++ b/src/plugins/monitoring/ST_ZEff/JEventProcessor_ST_ZEff.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_ZEff_
 // Routine used to create our JEventProcessor
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 // ST header files
 #include "START_COUNTER/DSCHit.h"
 #include "START_COUNTER/DSCDigiHit.h"

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.h
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_online_Tresolution_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 // ROOT header files
 #include <TMath.h>
 #include <TDirectory.h>

--- a/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.h
+++ b/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_online_efficiency_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 // ST header files
 #include "START_COUNTER/DSCHit.h"
 #include "START_COUNTER/DSCDigiHit.h"

--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.h
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_online_lowlevel_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 using namespace std;
 using std::vector;

--- a/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.h
+++ b/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_online_multi_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 using namespace std;
 // ***************** C++ header files******************
 //*****************************************************

--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.h
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_ST_online_tracking_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <START_COUNTER/DSCHit.h>
 #include <RF/DRFTDCDigiTime.h>
 #include <RF/DRFTime_factory.h>

--- a/src/plugins/monitoring/TAGGER_online/JEventProcessor_TAGGER_online.h
+++ b/src/plugins/monitoring/TAGGER_online/JEventProcessor_TAGGER_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGGER_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <TAGGER/DTAGMHit.h>
 #include <START_COUNTER/DSCHit.h>

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.h
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGH_doubles_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_TAGH_doubles:public JEventProcessor{
     public:

--- a/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.h
+++ b/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGH_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_TAGH_online:public JEventProcessor{
 public:

--- a/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.h
+++ b/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGM_clusters_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <TAGGER/DTAGMHit.h>
 
 class JEventProcessor_TAGM_clusters:public JEventProcessor{

--- a/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.h
+++ b/src/plugins/monitoring/TAGM_online/JEventProcessor_TAGM_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TAGM_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_TAGM_online:public JEventProcessor{
  public:

--- a/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.h
+++ b/src/plugins/monitoring/TOF_Eff/JEventProcessor_TOF_Eff.h
@@ -7,7 +7,7 @@
 #define _JEventProcessor_TOF_Eff_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "TH1I.h"
 #include "TH2I.h"

--- a/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.h
+++ b/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TOF_TDC_shift_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <TDirectory.h>
 #include <TH2I.h>

--- a/src/plugins/monitoring/TOF_online/JEventProcessor_TOF_online.h
+++ b/src/plugins/monitoring/TOF_online/JEventProcessor_TOF_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TOF_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_TOF_online:public JEventProcessor{

--- a/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.h
+++ b/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.h
@@ -3,7 +3,7 @@
 #define _JEventProcessor_TPOL_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 class JEventProcessor_TPOL_online:public JEventProcessor{

--- a/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.h
+++ b/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.h
@@ -3,7 +3,7 @@
 #define _JEventProcessor_TRD_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_TRD_online:public JEventProcessor{
 public:

--- a/src/plugins/monitoring/TRIG_online/JEventProcessor_TRIG_online.h
+++ b/src/plugins/monitoring/TRIG_online/JEventProcessor_TRIG_online.h
@@ -16,7 +16,7 @@ using std::map;
 #include "TH2I.h"
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_TRIG_online:public JEventProcessor{
  public:

--- a/src/plugins/monitoring/TS_scaler/JEventProcessor_TS_scaler.h
+++ b/src/plugins/monitoring/TS_scaler/JEventProcessor_TS_scaler.h
@@ -16,7 +16,7 @@
 #include "TH2I.h"
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include "ANALYSIS/DTreeInterface.h"
 

--- a/src/plugins/monitoring/TrackingPulls_straight/JEventProcessor_TrackingPulls_straight.h
+++ b/src/plugins/monitoring/TrackingPulls_straight/JEventProcessor_TrackingPulls_straight.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_TrackingPulls_straight_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 #include <TTree.h>
 
 class JEventProcessor_TrackingPulls_straight : public JEventProcessor {

--- a/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.h
+++ b/src/plugins/monitoring/cppFMWPC/JEventProcessor_cppFMWPC.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_cppFMWPC_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <FMWPC/DFMWPCHit.h>
 #include <FDC/DFDCHit.h>

--- a/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.h
+++ b/src/plugins/monitoring/fa125_itrig/JEventProcessor_fa125_itrig.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_fa125_itrig_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
@@ -2,7 +2,7 @@
 #define _JEventProcessor_highlevel_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <TDirectory.h>
 #include <TH2.h>

--- a/src/plugins/monitoring/lowlevel_online/JEventProcessor_lowlevel_online.h
+++ b/src/plugins/monitoring/lowlevel_online/JEventProcessor_lowlevel_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_lowlevel_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <GlueX.h>
 #include <PAIR_SPECTROMETER/DPSGeometry.h>

--- a/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
+++ b/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_lumi_mon_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 #include <TDirectory.h>

--- a/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.h
+++ b/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_occupancy_online_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <GlueX.h>
 #include <PAIR_SPECTROMETER/DPSGeometry.h>

--- a/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.h
+++ b/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.h
@@ -11,7 +11,7 @@
 #include <TDirectory.h>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 class JEventProcessor_pedestal_online:public JEventProcessor{
 	public:

--- a/src/plugins/monitoring/scaler_primex/JEventProcessor_scaler_primex.h
+++ b/src/plugins/monitoring/scaler_primex/JEventProcessor_scaler_primex.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_scaler_primex_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 
 #include <TDirectory.h>

--- a/src/plugins/monitoring/timing_online/DFactoryGenerator_p2pi.h
+++ b/src/plugins/monitoring/timing_online/DFactoryGenerator_p2pi.h
@@ -8,7 +8,7 @@
 #ifndef _DFactoryGenerator_p2pi_
 #define _DFactoryGenerator_p2pi_
 
-#include <JANA/Compatibility/jerror.h>
+#include <DANA/jerror.h>
 #include <JANA/JFactoryGenerator.h>
 
 #include "DReaction_factory_p2pi.h"

--- a/src/plugins/monitoring/timing_online/JEventProcessor_HLDetectorTiming.h
+++ b/src/plugins/monitoring/timing_online/JEventProcessor_HLDetectorTiming.h
@@ -9,7 +9,7 @@
 #define _JEventProcessor_HLDetectorTiming_
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <DAQ/DEPICSvalue.h>
 #include <BCAL/DBCALHit.h>

--- a/src/programs/Analysis/hd_dump/hd_dump.cc
+++ b/src/programs/Analysis/hd_dump/hd_dump.cc
@@ -34,7 +34,7 @@ int main(int narg, char *argv[])
 	JApplication* app = dapp.GetJApp();
 
 	// Set tag prefix for JANA streams to empty
-	jout.SetTag("");
+	jout.SetGroup("");
 	
 	// If LIST_FACTORIES is set, print all factories and exit
 	if(LIST_FACTORIES){

--- a/src/programs/Analysis/hd_eventfilter/MyProcessor.h
+++ b/src/programs/Analysis/hd_eventfilter/MyProcessor.h
@@ -9,7 +9,7 @@
 #include <string>
 
 #include <JANA/JEventProcessor.h>
-#include <JANA/Compatibility/JLockService.h>
+#include <JANA/Services/JLockService.h>
 
 #include <HDDM/hddm_s.hpp>
 #include <fstream>

--- a/src/programs/Utilities/mkplugin/mkplugin
+++ b/src/programs/Utilities/mkplugin/mkplugin
@@ -97,7 +97,7 @@ sub PrintClass()
 \#define _JEventProcessor_${pluginname}_
 
 \#include <JANA/JEventProcessor.h>
-// \#include <JANA/Compatibility/JLockService.h> // Required for accessing services
+// \#include <JANA/Services/JLockService.h> // Required for accessing services
 
 
 class JEventProcessor_${pluginname}:public JEventProcessor{


### PR DESCRIPTION
This fixes almost all warnings that appeared because of the JANA2 port, dramatically cleaning up the compiler output.

The overwhelming majority of these result from the following deprecations:
- `JLargeCalibration` was renamed to `JResource`
- `JGeometryManager` and `JLockService` headers were moved out of `Compatibility`
- `JStreamLog` was fully replaced by `JLogger`
- `jerror_t.h` was removed from JANA2 completely, and now lives under `libraries/DANA`

In addition, the following warnings were fixed:
- Unused `event_number` variables
- Catching `JException` by value instead of (constant) reference

Future work:
- `JEventSourceEVIO{pp}` and `DTranslationTable` define their own loggers with external variables for logger verbosity.  This is no longer necessary or desired, as every JANA2 component now comes with its own logger, which is automatically configured with a unified mechanism for setting verbosity. 

- There are two warnings related to redefining `DBG` macros. This is due to `HDEVIO.h` providing one definition and `JLogger.h` providing another. The easiest fix is to add an `#ifndef` guard on the JANA2 implementation.