### PR TITLE
Nsj f125 wrd fix

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -2014,24 +2014,23 @@ void DEVIOWorkerThread::MakeDf125WindowRawData(DParsedEvent *pe, uint32_t rocid,
         // Make sure this is a data continuation word, if not, stop here
         if(((*iptr>>31) & 0x1) != 0x0)break;
 
-        bool invalid_1 = (*iptr>>29) & 0x1;
-        bool invalid_2 = (*iptr>>13) & 0x1;
-        uint16_t sample_1 = 0;
+        uint16_t sample_1 = (*iptr>>16) & 0xFFF;
+
         uint16_t sample_2 = 0;
-        if(!invalid_1)sample_1 = (*iptr>>16) & 0x1FFF;
-        if(!invalid_2)sample_2 = (*iptr>>0) & 0x1FFF;
+        bool invalid_2 = (*iptr>>13) & 0x1;
+	if(!invalid_2)sample_2 = (*iptr>>0) & 0xFFF;
 
         // Sample 1
         wrd->samples.push_back(sample_1);
-        wrd->invalid_samples |= invalid_1;
-        wrd->overflow |= (sample_1>>12) & 0x1;
+        wrd->invalid_samples = 0;
+        wrd->overflow = 0;
 
         if((isample+2) == window_width && invalid_2)break; // skip last sample if flagged as invalid
 
         // Sample 2
         wrd->samples.push_back(sample_2);
         wrd->invalid_samples |= invalid_2;
-        wrd->overflow |= (sample_2>>12) & 0x1;
+        wrd->overflow = 0;
     }
 }
 

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -123,9 +123,9 @@ class DEVIOWorkerThread{
 		void              ParseCAEN1190(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void   ParseModuleConfiguration(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void              Parsef250Bank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
-		void     MakeDf250WindowRawData(DParsedEvent *pe, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr);
+		void     MakeDf250WindowRawData(DParsedEvent *pe, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr, uint32_t* &iend);
 		void              Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
-		void     MakeDf125WindowRawData(DParsedEvent *pe, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr);
+		void     MakeDf125WindowRawData(DParsedEvent *pe, uint32_t rocid, uint32_t slot, uint32_t itrigger, uint32_t* &iptr, uint32_t* &iend);
 		void             ParseF1TDCBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void               ParseSSPBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);
 		void           ParseDGEMSRSBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend);

--- a/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
+++ b/src/plugins/Utilities/cdc_scan/JEventProcessor_cdc_scan.cc
@@ -26,7 +26,7 @@
 
 
 #include "JEventProcessor_cdc_scan.h"
-#include <JANA/JApplication.h>
+//#include <JANA/JApplication.h>
 
 
 using namespace std;
@@ -263,7 +263,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
   /* 0xN0B4 FE timing_thres_hi definitions */
   #define FA125_FE_TIMING_THRES_HI_MASK(x) (0x1FF<<((x%3)*9))
   
-  
+  /*
   // Only look at physics triggers
   
   const DTrigger* locTrigger = NULL; 
@@ -273,19 +273,15 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
   if (!locTrigger->Get_IsPhysicsEvent()){ // do not look at PS triggers
     return;
   }
-   
-  vector <const Df125CDCPulse*> cdcpulses;
-  event->Get(cdcpulses);
+  */
+  
+  auto cdcpulses = event->Get<Df125CDCPulse>();  
   uint32_t nc = (uint32_t)cdcpulses.size();
 
-  
-  vector <const Df125FDCPulse*> fdcpulses;
-  event->Get(fdcpulses);
+  auto fdcpulses = event->Get<Df125FDCPulse>();
   uint32_t nf = (uint32_t)fdcpulses.size();
 
-
-  vector<const Df125TriggerTime*> ttvector;
-  event->Get(ttvector);
+  auto ttvector = event->Get<Df125TriggerTime>();
   uint32_t ntt = (uint32_t)ttvector.size();
 
   
@@ -295,7 +291,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
   ULong64_t eventnum = (ULong64_t)event->GetEventNumber();
 
   
-  lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
+  lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
 
   t->SetBranchAddress("eventnum",&eventnum);
   t->SetBranchAddress("CDCPulsecount",&nc);
@@ -304,7 +300,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
     
   t->Fill();  
 
-  lockService->RootFillUnLock(this);
+  lockService->RootUnLock();
   
  
   
@@ -312,7 +308,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
   
   if (ntt > 0) { //   Df125TriggerTime 
 
-    lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!    
+    lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!    
 
     tt->SetBranchAddress("eventnum",&eventnum);
 
@@ -340,7 +336,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
       tt->Fill();
     }
 
-    lockService->RootFillUnLock(this);
+    lockService->RootUnLock();
 
   }
 
@@ -350,7 +346,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
 
   if (nc || (nf&&FDC)) {  // branches are almost the same for CDC & FDC - only amp differs
 
-    lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
+    lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
     
     p->SetBranchAddress("eventnum",&eventnum);
 
@@ -457,9 +453,8 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
 	
         emulated = cp->emulated;
 
-        const Df125WindowRawData *wrd;
-        cp->GetSingle(wrd);
-
+	auto wrd = cp->GetSingle<Df125WindowRawData>();
+	
         if (wrd) {
           ns = (uint32_t)wrd->samples.size();
 
@@ -518,9 +513,8 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
         cTH=0;
         cTL=0;
 
-        const Df125BORConfig *BORConfig=NULL;
-        cp->GetSingle(BORConfig);
-
+	auto BORConfig = cp->GetSingle<Df125BORConfig>();
+	
         if (BORConfig) {
 
           board_id = BORConfig->board_id;
@@ -594,8 +588,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
 	
         emulated = fp->emulated;
 
-        const Df125WindowRawData *wrd;
-        fp->GetSingle(wrd);
+	auto wrd = fp->GetSingle<Df125WindowRawData>();	
 
         if (wrd) {
           ns = (uint32_t)wrd->samples.size();
@@ -656,9 +649,8 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
         cTH=0;
         cTL=0;
 
-        const Df125BORConfig *BORConfig=NULL;
-        fp->GetSingle(BORConfig);
-
+	auto BORConfig = fp->GetSingle<Df125BORConfig>();
+	
         if (BORConfig) {
 
           board_id = BORConfig->board_id;
@@ -705,7 +697,7 @@ void JEventProcessor_cdc_scan::Process(const std::shared_ptr<const JEvent> &even
   
     }
 
-    lockService->RootFillUnLock(this);    
+    lockService->RootUnLock();    
   }
     
   return;


### PR DESCRIPTION
There are 3 commits here:

- make the cdc_scan plugin more compatible with JANA2
- fix a very old omission in the WindowRawData decoder, it was ignoring any extra Df125FDCPulses created if NPK>1 and extra peaks are found - we have NEVER used NPK>1 with CDC or FDC, so this does not affect old data, or new data with NPK=1.
- fix some misunderstandings in the Df125WindowRawData decoding; the software was inherited from the f250 WRD format and did not match the f125 exactly. The f125 does not use the overflow bits, and we only use the invalid sample bit for the 2nd sample, in the case when there are an odd number of samples in the readout window (so far we always used an even number). 