### PR TITLE
Tracking update feb2025

### DIFF
--- a/src/libraries/HDGEOMETRY/DMagneticFieldMap.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMap.h
@@ -11,39 +11,45 @@
 #include <DVector3.h>
 
 class DMagneticFieldMap{
-	public:
+public:
 	
-		DMagneticFieldMap(){}
-		virtual ~DMagneticFieldMap(){}
+  DMagneticFieldMap(){}
+  virtual ~DMagneticFieldMap(){}
 
-		virtual void GetField(const DVector3 &pos,DVector3 &Bout) const=0;
-		virtual void GetField(double x, double y, double z, double &Bx, double &By, double &Bz, int method=0) const = 0;
-		virtual double GetBz(double x, double y, double z) const=0;
+  typedef struct{
+    double Bx,By,Bz,Bmag;
+    double dBxdx, dBxdy, dBxdz;
+    double dBydx, dBydy, dBydz;
+    double dBzdx, dBzdy, dBzdz;
+  }DBfieldCartesian_t;
 
-		virtual void GetFieldGradient(double x, double y, double z,
-                                      double &dBxdx, double &dBxdy,
-                                      double &dBxdz,
-                                      double &dBydx, double &dBydy,
-                                      double &dBydz,
-                                      double &dBzdx, double &dBzdy,
-				      double &dBzdz) const = 0;
-		virtual	void GetFieldBicubic(double x,double y,double z,
-				     double &Bx,double &By,double &Bz) const=0;
+  virtual void GetField(const DVector3 &pos,DVector3 &Bout) const=0;
+  virtual void GetField(double x, double y, double z, double &Bx, double &By, double &Bz, int method=0) const = 0;
+  virtual double GetBz(double x, double y, double z) const=0;
 
-		virtual void GetFieldAndGradient(double x,double y,double z,
-						 double &Bx,double &By,
-						 double &Bz,
-					         double &dBxdx, 
-						 double &dBxdy,
-						 double &dBxdz,
-						 double &dBydx, 
-						 double &dBydy,
-						 double &dBydz,
-						 double &dBzdx, 
-						 double &dBzdy,
-						 double &dBzdz) const = 0;
-
-
+  virtual void GetFieldGradient(double x, double y, double z,
+				double &dBxdx, double &dBxdy,
+				double &dBxdz,
+				double &dBydx, double &dBydy,
+				double &dBydz,
+				double &dBzdx, double &dBzdy,
+				double &dBzdz) const = 0;
+  virtual void GetFieldBicubic(double x,double y,double z,
+			       double &Bx,double &By,double &Bz) const=0;
+  virtual void GetFieldAndGradient(double x,double y,double z,
+				   double &Bx,double &By,
+				   double &Bz,
+				   double &dBxdx,
+				   double &dBxdy,
+				   double &dBxdz,
+				   double &dBydx,
+				   double &dBydy,
+				   double &dBydz,
+				   double &dBzdx,
+				   double &dBzdy,
+				   double &dBzdz) const = 0;
+  virtual void GetFieldAndGradient(double x,double y,double z,
+				   DBfieldCartesian_t &Bdata) const = 0;
 };
 
 #endif // _DMagneticFieldMap_

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapCalibDB.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapCalibDB.h
@@ -47,6 +47,15 @@ class DMagneticFieldMapCalibDB:public DMagneticFieldMap{
 					 double &dBydz,
 					 double &dBzdx, double &dBzdy,
 					 double &dBzdz) const;
+		void GetFieldAndGradient(double x,double y,double z,
+					 DBfieldCartesian_t &Bdata) const{
+		   GetFieldAndGradient(x,y,z, Bdata.Bx,Bdata.By,Bdata.Bz,
+				       Bdata.dBxdx, Bdata.dBxdy,Bdata.dBxdz,
+				       Bdata.dBydx, Bdata.dBydy,Bdata.dBydz,
+				       Bdata.dBzdx, Bdata.dBzdy,Bdata.dBzdz);
+		   Bdata.Bmag=sqrt(Bdata.Bx*Bdata.Bx+Bdata.By*Bdata.By
+				   +Bdata.Bz*Bdata.Bz);
+		};
 
 		typedef struct{
 			float x,y,z,Bx,By,Bz;

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapConst.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapConst.h
@@ -49,6 +49,15 @@ class DMagneticFieldMapConst:public DMagneticFieldMap{
 					 double &dBydz,
 					 double &dBzdx, double &dBzdy,
 					 double &dBzdz) const;
+		void GetFieldAndGradient(double x,double y,double z,
+					 DBfieldCartesian_t &Bdata) const {
+		  GetFieldAndGradient(x,y,z, Bdata.Bx,Bdata.By,Bdata.Bz,
+				      Bdata.dBxdx, Bdata.dBxdy,Bdata.dBxdz,
+				      Bdata.dBydx, Bdata.dBydy,Bdata.dBydz,
+				      Bdata.dBzdx, Bdata.dBzdy,Bdata.dBzdz);
+		  Bdata.Bmag=sqrt(Bdata.Bx*Bdata.Bx+Bdata.By*Bdata.By
+				  +Bdata.Bz*Bdata.Bz);
+		}  
 
 	protected:
 		

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.cc
@@ -182,6 +182,7 @@ int DMagneticFieldMapFineMesh::ReadMap(string namepath, int32_t runnumber, strin
     b->Bx = a[3];
     b->By = a[4];
     b->Bz = a[5];
+    b->Bmag=sqrt(b->Bx*b->Bx + b->By*b->By + b->Bz*b->Bz);
   }
   
   // Calculate gradient at every point in the map.
@@ -374,8 +375,8 @@ void DMagneticFieldMapFineMesh::GetFieldBicubic(double x,double y,double z,
     }
   }
   else{ // otherwise do a simple lookup in the fine-mesh table
-    unsigned int indr=(unsigned int)floor((r-rminFine)*rscale);
-    unsigned int indz=(unsigned int)floor((z-zminFine)*zscale);
+    unsigned int indr=static_cast<unsigned int>((r-rminFine)*rscale);
+    unsigned int indz=static_cast<unsigned int>((z-zminFine)*zscale);
     
     Bz_=mBfine[indr][indz].Bz;
     Br_=mBfine[indr][indz].Br;
@@ -520,6 +521,90 @@ void DMagneticFieldMapFineMesh::InterpolateField(double r,double z,double &Br,
     }
   dBzdr/=dx;
   dBzdz/=dz;
+}
+
+// Find the field and field gradient at the point (x,y,z).
+void DMagneticFieldMapFineMesh::GetFieldAndGradient(double x,double y,double z,
+						    DBfieldCartesian_t &Bdata) const{
+  // radial distance
+  double rsq = x*x + y*y;
+  if (rsq>xmax*xmax || z>zmax || z<zmin){
+    Bdata.Bx=0.0,Bdata.By=0.0,Bdata.Bz=0.;
+    Bdata.Bmag=0.0;
+    Bdata.dBxdx=0.0,Bdata.dBxdy=0.0,Bdata.dBxdz=0.0;
+    Bdata.dBydx=0.0,Bdata.dBydy=0.0,Bdata.dBydz=0.0;
+    Bdata.dBzdx=0.0,Bdata.dBzdy=0.0,Bdata.dBzdz=0.0;
+    return;
+  }
+
+  // radial component of B and gradient
+  double Br_=0.,dBrdr_=0.,dBrdz_=0.,dBzdr_=0.;
+
+  // If the point (x,y,z) is outside the fine-mesh grid, interpolate
+  // on the coarse grid
+  //if (true){
+  double r=sqrt(rsq);
+  if (z<zminFine || z>=zmaxFine || r>=rmaxFine){
+    // Get closest indices for this point
+    int index_x = static_cast<int>(r*one_over_dx);
+    int index_z = static_cast<int>((z-zmin)*one_over_dz);
+    int index_y = 0;
+
+    if(index_x>=0 && index_x<Nx && index_z>=0 && index_z<Nz){
+      const DBfieldPoint_t *B = &Btable[index_x][index_y][index_z];
+
+      // Fractional distance between map points.
+      double ur = (r - B->x)*one_over_dx;
+      double uz = (z - B->z)*one_over_dz;
+
+      // Use gradient to project grid point to requested position
+      Br_ = B->Bx+B->dBxdx*ur+B->dBxdz*uz;
+      Bdata.Bz = B->Bz+B->dBzdx*ur+B->dBzdz*uz;
+      Bdata.Bmag=B->Bmag; // approximation, at grid point edge
+
+      dBrdr_=B->dBxdx;
+      dBrdz_=B->dBxdz;
+      dBzdr_=B->dBzdx;
+      Bdata.dBzdz=B->dBzdz;
+    }
+  }
+  else{ // otherwise do a simple lookup in the fine-mesh table
+    unsigned int indr=static_cast<unsigned int>(r*rscale);
+    unsigned int indz=static_cast<unsigned int>((z-zminFine)*zscale);
+    const DBfieldCylindrical_t *field=&mBfine[indr][indz];
+
+    Bdata.Bmag=field->Bmag;
+    Bdata.Bz=field->Bz;
+    Br_=field->Br;
+
+    dBrdr_=field->dBrdr;
+    dBrdz_=field->dBrdz;
+    Bdata.dBzdz=field->dBzdz;
+    dBzdr_=field->dBzdr;
+
+    //	  printf("Bz Br %f %f\n",Bz,Br);
+  }
+
+  // Convert r back to x,y components
+  double cos_theta = 1.;
+  double sin_theta = 0.;
+  if(r>0.){
+    cos_theta=x/r;
+    sin_theta=y/r;
+  }
+  // Rotate back into phi direction
+  Bdata.Bx=Br_*cos_theta;
+  Bdata.By=Br_*sin_theta;
+
+  Bdata.dBxdx =dBrdr_*cos_theta*cos_theta;
+  Bdata.dBxdy =dBrdr_*cos_theta*sin_theta;
+  Bdata.dBxdz =dBrdz_*cos_theta;
+  Bdata.dBydx =Bdata.dBxdy;
+  Bdata.dBydy = dBrdr_*sin_theta*sin_theta;
+  Bdata.dBydz = dBrdz_*sin_theta;
+  Bdata.dBzdx = dBzdr_*cos_theta;
+  Bdata.dBzdy = dBzdr_*sin_theta;
+
 }
 
 // Find the field and field gradient at the point (x,y,z).  
@@ -903,8 +988,8 @@ void DMagneticFieldMapFineMesh::GenerateFineMesh(void){
   dzFine=0.1;
   zscale=1./dzFine;
   rscale=1./drFine;
-  NrFine=(unsigned int)floor((rmaxFine-rminFine)/drFine+0.5);
-  NzFine=(unsigned int)floor((zmaxFine-zminFine)/dzFine+0.5);
+  NrFine=static_cast<unsigned int>((rmaxFine-rminFine)/drFine+0.5);
+  NzFine=static_cast<unsigned int>((zmaxFine-zminFine)/dzFine+0.5);
 
   vector<DBfieldCylindrical_t>zrow;
   for (unsigned int i=0;i<NrFine;i++){
@@ -1087,8 +1172,8 @@ void DMagneticFieldMapFineMesh::ReadEvioFile(string evioFileName){
 	zscale=1./dzFine;
 	rscale=1./drFine;
 
-	NrFine=(unsigned int)floor((rmaxFine-rminFine)/drFine+0.5);
-	NzFine=(unsigned int)floor((zmaxFine-zminFine)/dzFine+0.5);
+	NrFine=static_cast<unsigned int>((rmaxFine-rminFine)/drFine+0.5);
+	NzFine=static_cast<unsigned int>((zmaxFine-zminFine)/dzFine+0.5);
 	mBfine.resize(NrFine);
 	for(auto &m : mBfine) m.resize(NzFine);
 
@@ -1116,6 +1201,13 @@ void DMagneticFieldMapFineMesh::ReadEvioFile(string evioFileName){
 				case 5: mBfine[indr][indz].dBzdz = *fptr++;  break;  // dBzdz
 			}
 		}
+	}
+
+	for (unsigned int i=0;i<NrFine;i++){
+	  for (unsigned int k=0;k<NzFine;k++){
+	    mBfine[i][k].Bmag=sqrt(mBfine[i][k].Bz*mBfine[i][k].Bz
+				   +mBfine[i][k].Br*mBfine[i][k].Br);
+	  }
 	}
 	
 	delete[] buff;

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapFineMesh.h
@@ -46,6 +46,8 @@ class DMagneticFieldMapFineMesh:public DMagneticFieldMap{
 			   double &dBydz,
 			   double &dBzdx, double &dBzdy,
 			   double &dBzdz) const;
+  void GetFieldAndGradient(double x,double y,double z,
+			   DBfieldCartesian_t &Bdata) const;
   void GetFineMeshMap(string namepath,int32_t runnumber);
   void WriteEvioFile(string evioFileName);	
   void ReadEvioFile(string evioFileName);
@@ -59,10 +61,11 @@ class DMagneticFieldMapFineMesh:public DMagneticFieldMap{
     double dBxdxdy,dBxdxdz,dBxdydz;
     double dBydxdy,dBydxdz,dBydydz;
     double dBzdxdy,dBzdxdz,dBzdydz;
+    double Bmag;
   }DBfieldPoint_t;
   
   typedef struct{
-    double Br,Bz;
+    double Br,Bz,Bmag;
     double dBrdr,dBrdz,dBzdr,dBzdz;
   }DBfieldCylindrical_t;
   

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapNoField.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapNoField.h
@@ -82,6 +82,14 @@ class DMagneticFieldMapNoField:public DMagneticFieldMap{
     By=0.;
     Bz=0.;
   };
+  void GetFieldAndGradient(double x,double y,double z,
+			   DBfieldCartesian_t &Bdata) const {
+    Bdata.Bmag=0.;
+    GetFieldAndGradient(x,y,z, Bdata.Bx,Bdata.By,Bdata.Bz,
+			Bdata.dBxdx, Bdata.dBxdy,Bdata.dBxdz,
+			Bdata.dBydx, Bdata.dBydy,Bdata.dBydz,
+			Bdata.dBzdx, Bdata.dBzdy,Bdata.dBzdz);
+  };
 };
 
 #endif // _DMagneticFieldMapNoField_

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapParameterized.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapParameterized.h
@@ -47,6 +47,16 @@ class DMagneticFieldMapParameterized:public DMagneticFieldMap{
 						 double &dBzdx, 
 						 double &dBzdy,
 						 double &dBzdz) const;
+		void GetFieldAndGradient(double x,double y,double z,
+					 DBfieldCartesian_t &Bdata) const{
+		  GetFieldAndGradient(x,y,z, Bdata.Bx,Bdata.By,Bdata.Bz,
+				      Bdata.dBxdx, Bdata.dBxdy,Bdata.dBxdz,
+				      Bdata.dBydx, Bdata.dBydy,Bdata.dBydz,
+				      Bdata.dBzdx, Bdata.dBzdy,Bdata.dBzdz);
+		  Bdata.Bmag=sqrt(Bdata.Bx*Bdata.Bx+Bdata.By*Bdata.By
+				 +Bdata.Bz*Bdata.Bz);
+		};
+
 	protected:
 		JCalibration *jcalib;
 		

--- a/src/libraries/HDGEOMETRY/DMagneticFieldMapSpoiled.h
+++ b/src/libraries/HDGEOMETRY/DMagneticFieldMapSpoiled.h
@@ -44,6 +44,15 @@ class DMagneticFieldMapSpoiled:public DMagneticFieldMap{
 					 double &dBydz,
 					 double &dBzdx, double &dBzdy,
 					 double &dBzdz) const;
+		void GetFieldAndGradient(double x,double y,double z,
+					 DBfieldCartesian_t &Bdata) const{
+		  GetFieldAndGradient(x,y,z, Bdata.Bx,Bdata.By,Bdata.Bz,
+				       Bdata.dBxdx, Bdata.dBxdy,Bdata.dBxdz,
+				      Bdata.dBydx, Bdata.dBydy,Bdata.dBydz,
+				      Bdata.dBzdx, Bdata.dBzdy,Bdata.dBzdz);
+		  Bdata.Bmag=sqrt(Bdata.Bx*Bdata.Bx+Bdata.By*Bdata.By
+				  +Bdata.Bz*Bdata.Bz);
+		}
 		
 	protected:
 		

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -2568,8 +2568,8 @@ jerror_t DTrackFitterKalmanSIMD::StepStateAndCovariance(DVector2 &xy,
 
    // New covariance matrix
    // C=J C J^T
-   //C=C.SandwichMultiply(J);
-   C=J*C*J.Transpose();
+   C=C.SandwichMultiply(J);
+   //C=J*C*J.Transpose();
 
    return NOERROR;
 }
@@ -3983,8 +3983,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
       // Update the actual state vector and covariance matrix
       Sc=S0+J*(Sc-S0_);
       // Cc=J*(Cc*JT)+Q;   
-      // Cc=Q.AddSym(Cc.SandwichMultiply(J));
-      Cc=Q.AddSym(J*Cc*J.Transpose());
+      Cc=Q.AddSym(Cc.SandwichMultiply(J));
+      //Cc=Q.AddSym(J*Cc*J.Transpose());
 
       // Save the current state and covariance matrix in the deque
       if (fit_type==kTimeBased){
@@ -4151,8 +4151,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanCentral(double anneal_factor,
 
             // Difference and inverse of variance
             //InvV=1./(V+H*(Cc*H_T));
-            //double Vproj=Cc.SandwichMultiply(H_T);
-	    double Vproj=H*Cc*H_T;
+            double Vproj=Cc.SandwichMultiply(H_T);
+	    //double Vproj=H*Cc*H_T;
             InvV=1./(V+Vproj);
             double dm=measurement-prediction;
 
@@ -4421,8 +4421,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForward(double fdc_anneal_factor,
     
 
     //C=J*(C*J_T)+Q;   
-    //C=Q.AddSym(C.SandwichMultiply(J));
-    C=Q.AddSym(J*C*J.Transpose());
+    C=Q.AddSym(C.SandwichMultiply(J));
+    //C=Q.AddSym(J*C*J.Transpose());
     
     // Save the current state and covariance matrix in the deque
     forward_traj[k].Skk=S;
@@ -4681,8 +4681,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForward(double fdc_anneal_factor,
 	  
 	  // inverse variance including prediction
 	  //double InvV1=1./(Vc+H*(C*H_T));
-	  //double Vproj=C.SandwichMultiply(Hc_T);
-	  double Vproj=Hc*C*Hc_T;
+	  double Vproj=C.SandwichMultiply(Hc_T);
+	  //double Vproj=Hc*C*Hc_T;
 	  double InvV1=1./(Vc+Vproj);
 	  if (InvV1<0.){
 	    if (DEBUG_LEVEL>0)
@@ -4809,8 +4809,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForward(double fdc_anneal_factor,
       double newz=z_+my_dz;
       // Step C along z
       StepJacobian(z_,newz,S,0.,J);
-      C=J*C*J.Transpose();
-      //C=C.SandwichMultiply(J);
+      //C=J*C*J.Transpose();
+      C=C.SandwichMultiply(J);
       
       // Step S along z
       Step(z_,newz,0.,S);
@@ -4820,8 +4820,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForward(double fdc_anneal_factor,
     
     // Step C along z
     StepJacobian(z_,TARGET_Z,S,0.,J);
-    C=J*C*J.Transpose();
-    //C=C.SandwichMultiply(J);
+    //C=J*C*J.Transpose();
+    C=C.SandwichMultiply(J);
     
     // Step S along z
     Step(z_,TARGET_Z,0.,S);
@@ -5062,8 +5062,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanForwardCDC(double anneal,
     }
    
     //C=J*(C*J_T)+Q;   
-    C=Q.AddSym(J*C*J.Transpose());
-    //C=Q.AddSym(C.SandwichMultiply(J));
+    //C=Q.AddSym(J*C*J.Transpose());
+    C=Q.AddSym(C.SandwichMultiply(J));
     
     // Save the current state of the reference trajectory
     S0_=S0;
@@ -5419,8 +5419,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DMatrix5x1 &S,
          StepJacobian(z,z_,S,dEdx,J);  
 
          // Propagate the covariance matrix
-         C=J*C*J.Transpose();
-         //C=C.SandwichMultiply(J);
+         //C=J*C*J.Transpose();
+         C=C.SandwichMultiply(J);
 
          // Step to the position of the doca
          Step(z,z_,dEdx,S);
@@ -5440,8 +5440,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DMatrix5x1 &S,
          StepJacobian(z,newz,S,dEdx,J);  
 
          // Propagate the covariance matrix
-         C=J*C*J.Transpose();
-         //C=C.SandwichMultiply(J);
+         //C=J*C*J.Transpose();
+         C=C.SandwichMultiply(J);
 
          S2=S;
          S=S1;
@@ -5459,8 +5459,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DMatrix5x1 &S,
          StepJacobian(z,newz,S,dEdx,J);  
 
          // Propagate the covariance matrix
-         C=J*C*J.Transpose();
-         //C=C.SandwichMultiply(J);
+         //C=J*C*J.Transpose();
+         C=C.SandwichMultiply(J);
 
          S1=S;
          S=S2;
@@ -5546,8 +5546,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DMatrix5x1 &S,
       StepJacobian(z,newz,S,dEdx,J);  
 
       // Propagate the covariance matrix
-      C=Q.AddSym(J*C*J.Transpose());
-      //C=Q.AddSym(C.SandwichMultiply(J));
+      //C=Q.AddSym(J*C*J.Transpose());
+      C=Q.AddSym(C.SandwichMultiply(J));
 
       // Step through field
       Step(z,newz,dEdx,S);
@@ -5574,8 +5574,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DMatrix5x1 &S,
          // Propagate the covariance matrix
          //C=J*C*J.Transpose()+(dz/(newz-z))*Q;
          //C=((dz/newz-z)*Q).AddSym(C.SandwichMultiply(J));
-         //C=C.SandwichMultiply(J);
-	 C=J*C*J.Transpose();
+         C=C.SandwichMultiply(J);
+	 //C=J*C*J.Transpose();
 
          // update internal variables
          x_=S(state_x);
@@ -5834,8 +5834,8 @@ jerror_t DTrackFitterKalmanSIMD::ExtrapolateToVertex(DVector2 &xy,
 
          // Propagate the covariance matrix
          //Cc=Jc*Cc*Jc.Transpose()+(my_ds/ds_old)*Q;
-         //Cc=((my_ds/ds_old)*Q).AddSym(Cc.SandwichMultiply(Jc));
-	 Cc=((my_ds/ds_old)*Q).AddSym(Jc*Cc*Jc.Transpose());
+         Cc=((my_ds/ds_old)*Q).AddSym(Cc.SandwichMultiply(Jc));
+	 //Cc=((my_ds/ds_old)*Q).AddSym(Jc*Cc*Jc.Transpose());
 
          break;
       }
@@ -6627,7 +6627,8 @@ kalman_error_t DTrackFitterKalmanSIMD::ForwardFit(const DMatrix5x1 &S0,const DMa
 	   StepJacobian(z,newz,SReverse,dEdx,J);
 	   Step(z,newz,dEdx,SReverse);
 	   
-	   CReverse=forward_traj[k].Q.AddSym(J*CReverse*J.Transpose());
+	   //CReverse=forward_traj[k].Q.AddSym(J*CReverse*J.Transpose());
+	   CReverse=forward_traj[k].Q.AddSym(CReverse.SandwichMultiply(J));
 	 }
 
 	 double reduced_chisq=reverse_chisq/double(reverse_ndf);
@@ -6946,7 +6947,8 @@ kalman_error_t DTrackFitterKalmanSIMD::ForwardCDCFit(const DMatrix5x1 &S0,const 
 	   StepJacobian(z,newz,SReverse,dEdx,J);
 	   Step(z,newz,dEdx,SReverse);
 	   
-	   CReverse=forward_traj[k].Q.AddSym(J*CReverse*J.Transpose());
+	   //CReverse=forward_traj[k].Q.AddSym(J*CReverse*J.Transpose());
+	   CReverse=forward_traj[k].Q.AddSym(CReverse.SandwichMultiply(J));
 	 }
 	 
 	 double reduced_chisq=reverse_chisq/double(reverse_ndf);
@@ -7252,8 +7254,8 @@ kalman_error_t DTrackFitterKalmanSIMD::CentralFit(const DVector2 &startpos,
    // lab 
    DMatrix5x5 Jc=I5x5;
    Jc(state_D,state_D)=(dy*cosphi-dx*sinphi)/D_;
-   //Cclast=Cclast.SandwichMultiply(Jc);
-   Cclast=Jc*Cclast*Jc.Transpose();
+   Cclast=Cclast.SandwichMultiply(Jc);
+   //Cclast=Jc*Cclast*Jc.Transpose();
 
    if (!isfinite(x_) || !isfinite(y_) || !isfinite(z_) || !isfinite(phi_) 
          || !isfinite(q_over_pt_) || !isfinite(tanl_)){
@@ -7424,12 +7426,12 @@ jerror_t DTrackFitterKalmanSIMD::SmoothForward(vector<pull_t>&forward_pulls){
 
                if (my_fdchits[id]->hit!=NULL 
 		   && my_fdchits[id]->hit->wire->layer==PLANE_TO_SKIP){
-                  //V+=Cs.SandwichMultiply(H_T);
-                  V=V+H*Cs*H_T;
+		 //V+=Cs.SandwichMultiply(H_T);
+		 V=V+H*Cs*H_T;
                }
                else{
-                  //V-=dC.SandwichMultiply(H_T);
-                  V=V-H*dC*H_T;
+		 //V-=dC.SandwichMultiply(H_T);
+		 V=V-H*dC*H_T;
                }
 
 
@@ -9454,7 +9456,9 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanReverse(double fdc_anneal_factor,
      }
      // Update the actual state vector and covariance matrix
      S=S0+J*(S-S0_);
-     C=Q.AddSym(J*C*J.Transpose());
+     //C=Q.AddSym(J*C*J.Transpose());
+     C=Q.AddSym(C.SandwichMultiply(J));
+
      //C.Print();
      
      // Save the current state of the reference trajectory
@@ -9541,7 +9545,8 @@ kalman_error_t DTrackFitterKalmanSIMD::KalmanReverse(double fdc_anneal_factor,
 	   double res=dmeas-d;
 	   
 	   // inverse variance including prediction
-	   double Vproj=Hc*C*Hc_T;	   
+	   //double Vproj=Hc*C*Hc_T;
+	   double Vproj=C.SandwichMultiply(Hc_T);
 	   double InvV1=1./(Vc+Vproj);
 
 	   // Check if this hit is an outlier
@@ -9777,8 +9782,8 @@ DTrackFitterKalmanSIMD::FindDoca(const DKalmanSIMDCDCHit_t *hit,
 
 	// propagate error matrix to z-position of hit
 	StepJacobian(my_z,newz,S0,dedx,J);
-	C=J*C*J.Transpose();
-	//C=C.SandwichMultiply(J);
+	//C=J*C*J.Transpose();
+	C=C.SandwichMultiply(J);
 	
 	// Step reference trajectory by my_dz
 	Step(my_z,newz,dedx,S0); 
@@ -9789,8 +9794,8 @@ DTrackFitterKalmanSIMD::FindDoca(const DKalmanSIMDCDCHit_t *hit,
       newz=my_z+dz3;
       // propagate error matrix to z-position of hit
       StepJacobian(my_z,newz,S0,dedx,J);
-      C=J*C*J.Transpose();
-      //C=C.SandwichMultiply(J);
+      //C=J*C*J.Transpose();
+      C=C.SandwichMultiply(J);
 
       // Step reference trajectory by dz3
       Step(my_z,newz,dedx,S0); 	    
@@ -9800,8 +9805,8 @@ DTrackFitterKalmanSIMD::FindDoca(const DKalmanSIMDCDCHit_t *hit,
       
       // propagate error matrix to z-position of hit
       StepJacobian(z,newz,S0,dedx,J);
-      C=J*C*J.Transpose();
-      //C=C.SandwichMultiply(J);
+      //C=J*C*J.Transpose();
+      C=C.SandwichMultiply(J);
       
       // Step reference trajectory by dz
       Step(z,newz,dedx,S0); 
@@ -9843,8 +9848,8 @@ void DTrackFitterKalmanSIMD::StepBack(double dedx,double newz,double z,
   if (num_steps==0){
     // Step C back to the z-position on the reference trajectory
     StepJacobian(newz,z,S0,dedx,J);
-    C=J*C*J.Transpose();
-    //C=C.SandwichMultiply(J);
+    //C=J*C*J.Transpose();
+    C=C.SandwichMultiply(J);
 
     // Step S to current position on the reference trajectory
     Step(newz,z,dedx,S);
@@ -9861,8 +9866,8 @@ void DTrackFitterKalmanSIMD::StepBack(double dedx,double newz,double z,
       
       // Step C along z
       StepJacobian(my_z,z,S0,dedx,J);
-      C=J*C*J.Transpose();
-      //C=C.SandwichMultiply(J);
+      //C=J*C*J.Transpose();
+      C=C.SandwichMultiply(J);
       
       // Step S along z
       Step(my_z,z,dedx,S); 
@@ -9876,8 +9881,8 @@ void DTrackFitterKalmanSIMD::StepBack(double dedx,double newz,double z,
     
     // Step C back to the z-position on the reference trajectory
     StepJacobian(my_z,z,S0,dedx,J);
-    C=J*C*J.Transpose();
-    //C=C.SandwichMultiply(J);
+    //C=J*C*J.Transpose();
+    C=C.SandwichMultiply(J);
 
     // Step S to current position on the reference trajectory
     Step(my_z,z,dedx,S);

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -490,7 +490,7 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
   vector<double>dTRDz_vec;
 
   // Mass hypothesis
-  double MASS,mass2;
+  double MASS,INV_MASS,mass2;
   double m_ratio; // electron mass/MASS
   double m_ratio_sq; // .. and its square
   double two_m_e; // twice the electron mass

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.h
@@ -473,9 +473,7 @@ class DTrackFitterKalmanSIMD: public DTrackFitter{
   double ftime, len, var_ftime;
 
   // B-field and gradient
-  double Bx,By,Bz;
-  double dBxdx,dBxdy,dBxdz,dBydx,dBydy,dBydz,dBzdx,dBzdy,dBzdz;
-  bool get_field;
+  DMagneticFieldMap::DBfieldCartesian_t myField;
   double FactorForSenseOfRotation;
 
   // endplate dimensions and location

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -169,7 +169,7 @@ void DTrackTimeBased_factory::Init()
   SAVE_TRUNCATED_DEDX = false;
   app->SetDefaultParameter("TRK:SAVE_TRUNCATED_DEDX",SAVE_TRUNCATED_DEDX);
 
-  COUNT_POTENTIAL_HITS = false;
+  COUNT_POTENTIAL_HITS = true;
   app->SetDefaultParameter("TRK:COUNT_POTENTIAL_HITS",COUNT_POTENTIAL_HITS);
 
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -169,6 +169,10 @@ void DTrackTimeBased_factory::Init()
   SAVE_TRUNCATED_DEDX = false;
   app->SetDefaultParameter("TRK:SAVE_TRUNCATED_DEDX",SAVE_TRUNCATED_DEDX);
 
+  COUNT_POTENTIAL_HITS = false;
+  app->SetDefaultParameter("TRK:COUNT_POTENTIAL_HITS",COUNT_POTENTIAL_HITS);
+
+
 	return;
 }
 
@@ -247,8 +251,9 @@ void DTrackTimeBased_factory::BeginRun(const std::shared_ptr<const JEvent>& even
   // extract the "mean" radius of each ring from the wire data
   cdc_rmid.clear();
   for(uint ring=0; ring<cdcwires.size(); ring++)
-    cdc_rmid.push_back( cdcwires[ring][0]->origin.Perp() );
-  
+    if (COUNT_POTENTIAL_HITS){ 
+      cdc_rmid.push_back( cdcwires[ring][0]->origin.Perp() );
+    }
   
 	if(DEBUG_HISTS){
 		root_lock->RootWriteLock();
@@ -389,69 +394,71 @@ void DTrackTimeBased_factory::Process(const std::shared_ptr<const JEvent>& event
     }
   }
 
-  // figure out the number of expected hits for this track based on the final fit
-  for (size_t j=0; j<mData.size();j++){
-    set<const DCDCWire *> expected_hit_straws;
-    set<int> expected_hit_fdc_planes;
+  if (COUNT_POTENTIAL_HITS){
+    // figure out the number of expected hits for this track based on the final fit
+    for (size_t j=0; j<mData.size();j++){
+      set<const DCDCWire *> expected_hit_straws;
+      set<int> expected_hit_fdc_planes;
     
-    vector<DTrackFitter::Extrapolation_t>cdc_extraps=mData[j]->extrapolations.at(SYS_CDC);
-    for(uint i=0; i<cdc_extraps.size(); i++) {
-      // figure out the radial position of the point to see which ring it's in
-      DVector3 track_pos=cdc_extraps[i].position;
-      double r = track_pos.Perp();
-      uint ring=0;
-      for(; ring<cdc_rmid.size(); ring++) {
-	//_DBG_ << "Rs = " << r << " " << cdc_rmid[ring] << endl;
-	if( (r<cdc_rmid[ring]-0.78) || (fabs(r-cdc_rmid[ring])<0.78) )
-	  break;
-      }
-      if(ring == cdc_rmid.size()) ring--;
-      //_DBG_ << "ring = " << ring << endl;
-      //_DBG_ << "ring = " << ring << "  stereo = " << cdcwires[ring][0]->stereo << endl;
-      int best_straw=0;
-      double best_dist_diff2=(track_pos - cdcwires[ring][0]->origin).Mag2();
-      // match based on straw center
-      for(uint straw=1; straw<cdcwires[ring].size(); straw++) {
-	const DCDCWire *wire=cdcwires[ring][straw];
-	DVector3 wire_position = wire->origin;  // start with the nominal wire center
-	// now take into account the z dependence due to the stereo angle
-	double dz = track_pos.Z() - wire_position.Z();
-	double ds = dz*tan(wire->stereo);
-	double phi=wire_position.Phi();
-	wire_position += DVector3(-ds*sin(phi), ds*cos(phi), dz);
-	double diff2 = (track_pos - wire_position).Mag2();
-	if( diff2 < best_dist_diff2 ){
-	  best_straw = straw;
-	  best_dist_diff2=diff2;
+      vector<DTrackFitter::Extrapolation_t>cdc_extraps=mData[j]->extrapolations.at(SYS_CDC);
+      for(uint i=0; i<cdc_extraps.size(); i++) {
+	// figure out the radial position of the point to see which ring it's in
+	DVector3 track_pos=cdc_extraps[i].position;
+	double r = track_pos.Perp();
+	uint ring=0;
+	for(; ring<cdc_rmid.size(); ring++) {
+	  //_DBG_ << "Rs = " << r << " " << cdc_rmid[ring] << endl;
+	  if( (r<cdc_rmid[ring]-0.78) || (fabs(r-cdc_rmid[ring])<0.78) )
+	    break;
 	}
-      }
-      
-      expected_hit_straws.insert(cdcwires[ring][best_straw]);
-    }
-    
-    vector<DTrackFitter::Extrapolation_t>fdc_extraps=mData[j]->extrapolations.at(SYS_FDC);
-    for(uint i=0; i<fdc_extraps.size(); i++) {
-      // check to make sure that the track goes through the sensitive region of the FDC
-      // assume one hit per plane
-      double z = fdc_extraps[i].position.Z();
-      double r = fdc_extraps[i].position.Perp();
-      
-      // see if we're in the "sensitive area" of a package
-      for(uint plane=0; plane<fdc_z_wires.size(); plane++) {
-	int package = plane/6;
-	if(fabs(z-fdc_z_wires[plane]) < fdc_package_size) {
-	  if( r<fdc_rmax && r>fdc_rmin_packages[package]) {
-	    expected_hit_fdc_planes.insert(plane);
+	if(ring == cdc_rmid.size()) ring--;
+	//_DBG_ << "ring = " << ring << endl;
+	//_DBG_ << "ring = " << ring << "  stereo = " << cdcwires[ring][0]->stereo << endl;
+	int best_straw=0;
+	double best_dist_diff2=(track_pos - cdcwires[ring][0]->origin).Mag2();
+	// match based on straw center
+	for(uint straw=1; straw<cdcwires[ring].size(); straw++) {
+	  const DCDCWire *wire=cdcwires[ring][straw];
+	  DVector3 wire_position = wire->origin;  // start with the nominal wire center
+	  // now take into account the z dependence due to the stereo angle
+	  double dz = track_pos.Z() - wire_position.Z();
+	  double ds = dz*tan(wire->stereo);
+	  double phi=wire_position.Phi();
+	  wire_position += DVector3(-ds*sin(phi), ds*cos(phi), dz);
+	  double diff2 = (track_pos - wire_position).Mag2();
+	  if( diff2 < best_dist_diff2 ){
+	    best_straw = straw;
+	    best_dist_diff2=diff2;
 	  }
+	}
+	
+	expected_hit_straws.insert(cdcwires[ring][best_straw]);
+      }
+    
+      vector<DTrackFitter::Extrapolation_t>fdc_extraps=mData[j]->extrapolations.at(SYS_FDC);
+      for(uint i=0; i<fdc_extraps.size(); i++) {
+	// check to make sure that the track goes through the sensitive region of the FDC
+	// assume one hit per plane
+	double z = fdc_extraps[i].position.Z();
+	double r = fdc_extraps[i].position.Perp();
+	
+	// see if we're in the "sensitive area" of a package
+	for(uint plane=0; plane<fdc_z_wires.size(); plane++) {
+	  int package = plane/6;
+	  if(fabs(z-fdc_z_wires[plane]) < fdc_package_size) {
+	    if( r<fdc_rmax && r>fdc_rmin_packages[package]) {
+	      expected_hit_fdc_planes.insert(plane);
+	    }
 	  break; // found the right plane
+	  }
 	}
       }
+      
+      mData[j]->potential_cdc_hits_on_track = expected_hit_straws.size();
+      mData[j]->potential_fdc_hits_on_track = expected_hit_fdc_planes.size();
     }
-    
-    mData[j]->potential_cdc_hits_on_track = expected_hit_straws.size();
-    mData[j]->potential_fdc_hits_on_track = expected_hit_fdc_planes.size();
-  }
-
+  } // if COUNT_POTENTIAL_HITS
+  
   return;
 }
 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -46,7 +46,7 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
 
   bool DEBUG_HISTS;
   int DEBUG_LEVEL;
-  bool PID_FORCE_TRUTH;
+  bool PID_FORCE_TRUTH,COUNT_POTENTIAL_HITS;
   bool USE_HITS_FROM_WIREBASED_FIT;
 
   bool SAVE_TRUNCATED_DEDX;       // store extra dEdx information in time based tracks


### PR DESCRIPTION
Various changes to speed up track reconstruction.  On ifarm2402 I ran hd_ana -PAUTOACTIVATE=DTrackTimeBased on one of the evio files for run 30300 with a single processing thread.  With the new version a I got a rate of 18.4 Hz after 25000 events, compared to 14.4 Hz.  The rate increases to 20.5 Hz if I set the new command line parameter  TRK:COUNT_POTENTIAL_HITS to false.  These numbers need to be verified with further tests but look encouraging.