### PR TITLE
Updates to locking in plugins

### DIFF
--- a/src/plugins/Alignment/FDC_InternalAlignment/JEventProcessor_FDC_InternalAlignment.cc
+++ b/src/plugins/Alignment/FDC_InternalAlignment/JEventProcessor_FDC_InternalAlignment.cc
@@ -73,6 +73,9 @@ void JEventProcessor_FDC_InternalAlignment::BeginRun(const std::shared_ptr<const
    // Get curent cathode alignment constants
 
    JCalibration * jcalib = GetJCalibration(event);
+
+   GetLockService(event)->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+   
    vector<map<string,double> >vals;
    if (jcalib->Get("FDC/cathode_alignment",vals)==false){
       for(unsigned int i=0; i<vals.size(); i++){
@@ -110,6 +113,9 @@ void JEventProcessor_FDC_InternalAlignment::BeginRun(const std::shared_ptr<const
          HistCurrentConstants->Fill(i*2+402,row["yshift"]);
       }
    }
+
+   GetLockService(event)->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
 }
 
 //------------------
@@ -124,9 +130,9 @@ void JEventProcessor_FDC_InternalAlignment::Process(const std::shared_ptr<const 
       const DFDCPseudo* thisPseudo = fdcPseudoVector[i];
       if (thisPseudo->status != 6) continue;
 
-      GetLockService(event)->RootWriteLock();
+      GetLockService(event)->RootFillLock(this);
       Hist3D[thisPseudo->wire->layer - 1]->Fill(thisPseudo->w, thisPseudo->s, thisPseudo->w_c - thisPseudo->w);
-      GetLockService(event)->RootUnLock();
+      GetLockService(event)->RootFillUnLock(this);
 
       // Plot the wire times
       char thisName[256];

--- a/src/plugins/Analysis/F250_mode10_pedestal/JEventProcessor_F250_mode10_pedestal.cc
+++ b/src/plugins/Analysis/F250_mode10_pedestal/JEventProcessor_F250_mode10_pedestal.cc
@@ -68,7 +68,6 @@ void JEventProcessor_F250_mode10_pedestal::Init()
 
 	// lock all root operations
 	auto lockSvc = GetApplication()->GetService<JLockService>();
-	lockSvc->RootWriteLock();
 
 	gStyle->SetTitleOffset(1, "Y");
   	gStyle->SetTitleSize(0.05,"xyz");
@@ -96,7 +95,6 @@ void JEventProcessor_F250_mode10_pedestal::Init()
 		}
 	}
 
-	lockSvc->RootUnLock();
 }
 
 //------------------

--- a/src/plugins/Analysis/F250_mode8_pedestal/JEventProcessor_F250_mode8_pedestal.cc
+++ b/src/plugins/Analysis/F250_mode8_pedestal/JEventProcessor_F250_mode8_pedestal.cc
@@ -61,9 +61,6 @@ void JEventProcessor_F250_mode8_pedestal::Init()
 	auto app = GetApplication();
 	app->SetDefaultParameter("F250_m8_ped:NSA_NSB", NSA_NSB, "The number of samples integrated in the signal.");
 
-	// lock all root operations
-	GetLockService(locEvent)->RootWriteLock();
-
 	gStyle->SetTitleOffset(1, "Y");
   	gStyle->SetTitleSize(0.05,"xyz");
 	gStyle->SetTitleSize(0.08,"h");
@@ -87,7 +84,6 @@ void JEventProcessor_F250_mode8_pedestal::Init()
 		}
 	}
 
-	GetLockService(locEvent)->RootUnLock();
 }
 
 //------------------

--- a/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
+++ b/src/plugins/Analysis/bcal_calib_cosmic_cdc/JEventProcessor_bcal_calib_cosmic_cdc.cc
@@ -358,7 +358,7 @@ void JEventProcessor_bcal_calib_cosmic_cdc::Process(const std::shared_ptr<const 
 	//cout << "found " << upstream.size() << " upstream and " << downstream.size() << " downstream hits for map.\n";
 
 	// Although we are only filling objects local to this plugin, TTree::Fill() periodically writes to file: Global ROOT lock
-	GetLockService(event)->RootWriteLock(); //ACQUIRE ROOT LOCK
+	GetLockService(event)->RootFillLock(this); //ACQUIRE ROOT LOCK
 	{
 		eventnum = event->GetEventNumber();
 		/// Loop over the intersected cells
@@ -390,7 +390,7 @@ void JEventProcessor_bcal_calib_cosmic_cdc::Process(const std::shared_ptr<const 
 			bcal_calib_cosmic_cdc_tree->Fill();
 		}
 	}
-	GetLockService(event)->RootUnLock(); //RELEASE ROOT LOCK
+	GetLockService(event)->RootFillUnLock(this); //RELEASE ROOT LOCK
 }
 
 //------------------

--- a/src/plugins/Analysis/compton/JEventProcessor_compton.cc
+++ b/src/plugins/Analysis/compton/JEventProcessor_compton.cc
@@ -290,10 +290,12 @@ void JEventProcessor_compton::Process(const std::shared_ptr<const JEvent>& event
 	uint32_t trigmask = trig->trig_mask;	
 	uint32_t fp_trigmask = trig->fp_trig_mask;
 	
+ 	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	for( int ibit = 0; ibit < 33; ibit++ ) {
 	  	if(trigmask & (1 << ibit)) hTrig->Fill(ibit);
 	  	if(fp_trigmask & (1 << ibit)) hfpTrig->Fill(ibit);
 	}
+ 	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	
 	if( fp_trigmask ) return;
 	

--- a/src/plugins/Analysis/imaging/JEventProcessor_imaging.cc
+++ b/src/plugins/Analysis/imaging/JEventProcessor_imaging.cc
@@ -136,7 +136,7 @@ void JEventProcessor_imaging::Process(const std::shared_ptr<const JEvent>& event
     event->Get(mcthrowns);
   }
 
-  GetLockService(event)->RootWriteLock();
+  GetLockService(event)->RootFillLock(this);
 
   if (MC_RECON_CHECK && tracks.size()==2){
     // Check estimate of vertex position relative to thrown vertex for simple
@@ -226,7 +226,7 @@ void JEventProcessor_imaging::Process(const std::shared_ptr<const JEvent>& event
     } // first track 
   } // first loop over tracks
   
-  GetLockService(event)->RootUnLock();
+  GetLockService(event)->RootFillUnLock(this);
 }
 
 //------------------

--- a/src/plugins/Analysis/pedestals/JEventProcessor_pedestals.cc
+++ b/src/plugins/Analysis/pedestals/JEventProcessor_pedestals.cc
@@ -72,7 +72,7 @@ void JEventProcessor_pedestals::Process(const std::shared_ptr<const JEvent>& eve
 	event->Get(df125pis);
 
 	// Lock ROOT mutex	
-	GetLockService(event)->RootWriteLock();
+	GetLockService(event)->RootFillLock(true);
 
 	for(unsigned int i=0; i<df250dats.size(); i++){
 		TH2D *h = GetHist(df250dats[i]);
@@ -91,7 +91,7 @@ void JEventProcessor_pedestals::Process(const std::shared_ptr<const JEvent>& eve
 	}
 	
 	// Unlock ROOT mutex	
-	GetLockService(event)->RootUnLock();
+	GetLockService(event)->RootFillLock(true);
 }
 
 //------------------

--- a/src/plugins/Calibration/BCAL_ADC_4ns/JEventProcessor_BCAL_ADC_4ns.cc
+++ b/src/plugins/Calibration/BCAL_ADC_4ns/JEventProcessor_BCAL_ADC_4ns.cc
@@ -182,7 +182,9 @@ void JEventProcessor_BCAL_ADC_4ns::Process(const std::shared_ptr<const JEvent>& 
             double Deltat = hitVector[0]->t_raw - hitVector[1]->t_raw;
             if (hitVector[0]->end==1) Deltat = -Deltat;
 
+ 			lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 			hZvsDeltat[thisPoint->module()][thisPoint->layer()][thisPoint->sector()]->Fill(Deltat, trackHitZ);
+ 			lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
          }
       }
    }

--- a/src/plugins/Calibration/BCAL_SiPM_saturation/JEventProcessor_BCAL_SiPM_saturation.cc
+++ b/src/plugins/Calibration/BCAL_SiPM_saturation/JEventProcessor_BCAL_SiPM_saturation.cc
@@ -213,7 +213,7 @@ auto lockService = DEvent::GetLockService(event);
 		locNeutralShower->Get(Points);
         uint Ncell = Points.size();
         
-    	lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    	lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
 		// Fill histogram for showers
 		dHistEthrown->Fill(Ethrown);
@@ -227,7 +227,7 @@ auto lockService = DEvent::GetLockService(event);
 	
         dHistNCell->Fill(Ncell);
 
-    	lockService->RootUnLock(); //RELEASE ROOT LOCK
+    	lockService->RootFillUnLock(this); //RELEASE ROOT LOCK
 
 
         for (unsigned int j = 0; j < Ncell; j++){
@@ -263,13 +263,13 @@ auto lockService = DEvent::GetLockService(event);
 			if (VERBOSE>=3) cout << " VERBOSE >=3" << " t=" << t << " z=" << z << endl;
 
 
-    		lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    		lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 	
 			// Fill 1D histograms
 			dHistLayer->Fill(layer);
 			dHistEpoint->Fill(Ept);
 
-	    	lockService->RootUnLock(); //RELEASE ROOT LOCK
+	    	lockService->RootFillUnLock(this); //RELEASE ROOT LOCK
 
 			// cout << " Point: Ept=" << Ept << endl;
 			float upHit=0;
@@ -305,7 +305,7 @@ auto lockService = DEvent::GetLockService(event);
 			}
 
 
-    		lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+    		lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
             // Fill 1D histograms
 			if (layer == 1) {
@@ -328,7 +328,7 @@ auto lockService = DEvent::GetLockService(event);
 			  cout << " ***Illegal layer=" << layer << endl;
 			}
 
-	    	lockService->RootUnLock(); //RELEASE ROOT LOCK
+	    	lockService->RootFillUnLock(this); //RELEASE ROOT LOCK
 
 	     }
 
@@ -343,8 +343,10 @@ auto lockService = DEvent::GetLockService(event);
                      << " lambda=" << attenuation_length << " Eup=" << upHit << " Edown=" << downHit << " Point: Ept=" 
                      << Ept << " Ecalc=" << Ecalc << " Diff=" << Ept-Ecalc <<  endl;*/
 
+    	lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 		dHistEcalc->Fill(Ecalc);
 		dHistEcalcEpt->Fill(Ecalc-Ept);
+		lockService->RootFillUnLock(this); //RELEASE ROOT LOCK
 
 	}
 

--- a/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
+++ b/src/plugins/Calibration/BCAL_attenlength_gainratio/JEventProcessor_BCAL_attenlength_gainratio.cc
@@ -349,7 +349,7 @@ void JEventProcessor_BCAL_attenlength_gainratio::Finish()
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+	//lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	// for (int module=0; module<nummodule; module++) {
 	// 	if (VERBOSE>0) printf("M%i ",module);
@@ -459,7 +459,7 @@ void JEventProcessor_BCAL_attenlength_gainratio::Finish()
 	hist2D_intattenlength->SetBinContent(0,0,1);
 	hist2D_intgainratio->SetBinContent(0,0,1);
 
-	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+	//lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     //SortDirectories();    // THIS CRASHES SOMETIMES, SHOULD FIGURE OUT WHY
 }

--- a/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.cc
+++ b/src/plugins/Calibration/BCAL_point_calib/JEventProcessor_BCAL_point_calib.cc
@@ -152,9 +152,6 @@ void JEventProcessor_BCAL_point_calib::Init()
 		return;
 	}
 	
- 	// lock all root operations
- 	lockService->RootWriteLock();
-
 	 //	TDirectory *dir = new TDirectoryFile("BCAL","BCAL");
 	 //	dir->cd();
 	// create root folder for bcal and cd to it, store main dir
@@ -306,11 +303,6 @@ void JEventProcessor_BCAL_point_calib::Init()
 	// back to main dir
 	main->cd();
 
-	// japp->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
-	
-	// unlock
-	lockService->RootUnLock();
-
 }
 
 //------------------
@@ -443,12 +435,14 @@ void JEventProcessor_BCAL_point_calib::Process(const std::shared_ptr<const JEven
 	double R4 = 0.5*(bcal_radii[3] + bcal_radii[4]); 
 
         // loop over matched showers
-        Int_t numshowers_per_event = matchedShowers.size();
+ 	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
+       Int_t numshowers_per_event = matchedShowers.size();
 	if (numshowers_per_event > 0) 
 	  h1_Num_matched_showers->Fill(numshowers_per_event);
         Int_t numtracks_per_event = matchedTracks.size();
         if (numtracks_per_event > 0) 
 	  h1trk_Num_matched_tracks->Fill(numtracks_per_event);
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	// cache points for each matched points to speed up the locked loop below
 	for(int i=0; i<numshowers_per_event; i++)  {

--- a/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.cc
+++ b/src/plugins/Calibration/BCAL_point_time/JEventProcessor_BCAL_point_time.cc
@@ -94,9 +94,6 @@ void JEventProcessor_BCAL_point_time::Init()
 
 	app->SetDefaultParameter("BCAL_point_time:VERBOSE", VERBOSE, "BCAL_point_time verbosity level");
 	if (VERBOSE>=1) printf("JEventProcessor_pedestal_online::init()\n");
-
-	// lock all root operations
-	lockService->RootWriteLock();
 		
 	gStyle->SetTitleSize(0.06,"xyz");
 	gStyle->SetTitleSize(0.07,"h");
@@ -266,9 +263,6 @@ void JEventProcessor_BCAL_point_time::Init()
 	
 	// back to main dir
 	maindir->cd();
-	
-	// unlock
-	lockService->RootUnLock();
 }
 
 //------------------

--- a/src/plugins/Calibration/BCAL_saturation/JEventProcessor_BCAL_saturation.cc
+++ b/src/plugins/Calibration/BCAL_saturation/JEventProcessor_BCAL_saturation.cc
@@ -76,7 +76,6 @@ JEventProcessor_BCAL_saturation::~JEventProcessor_BCAL_saturation() {
 void JEventProcessor_BCAL_saturation::Init() {
 
 	lockService = GetApplication()->GetService<JLockService>();
-	lockService->RootWriteLock();
 
 	// First thread to get here makes all histograms. If one pointer is
 	// already not NULL, assume all histograms are defined and return now
@@ -126,7 +125,6 @@ void JEventProcessor_BCAL_saturation::Init() {
 			waveformCounterDS[locSaturate][locLayer] = 0;
 		}
 	}
-	lockService->RootUnLock();
 }
 
 

--- a/src/plugins/Calibration/CCAL_ComptonGains/JEventProcessor_CCAL_ComptonGains.cc
+++ b/src/plugins/Calibration/CCAL_ComptonGains/JEventProcessor_CCAL_ComptonGains.cc
@@ -334,7 +334,6 @@ void JEventProcessor_CCAL_ComptonGains::Process(const std::shared_ptr<const JEve
 	if( n_fcal_showers != 1 || n_ccal_showers != 1 ) {
 		DEvent::GetLockService(locEvent)->RootFillUnLock(this);  // Release root lock
 		return;
-		
 	}
 	
 	
@@ -377,8 +376,10 @@ void JEventProcessor_CCAL_ComptonGains::Process(const std::shared_ptr<const JEve
 	
 	//----------   Apply a Coplanarity cut:
 	
-	if( fabs( deltaPhi - 180. )  >  COPL_CUT ) return; // NOERROR;
-	
+	if( fabs( deltaPhi - 180. )  >  COPL_CUT ) {
+		DEvent::GetLockService(locEvent)->RootFillUnLock(this);  // Release root lock
+		return; // NOERROR;
+	}	
 	
 	
 	

--- a/src/plugins/Calibration/FCALLEDTree/JEventProcessor_FCALLEDTree.cc
+++ b/src/plugins/Calibration/FCALLEDTree/JEventProcessor_FCALLEDTree.cc
@@ -187,6 +187,8 @@ void JEventProcessor_FCALLEDTree::EndRun()
 void JEventProcessor_FCALLEDTree::Finish()
 {
   // Called before program exit after event processing is finished.
+  lockService->RootWriteLock();
   m_tree->Write();
+  lockService->RootUnLock();
 }
 

--- a/src/plugins/Calibration/FCALLEDTree/JEventProcessor_FCALLEDTree.cc
+++ b/src/plugins/Calibration/FCALLEDTree/JEventProcessor_FCALLEDTree.cc
@@ -55,9 +55,6 @@ void JEventProcessor_FCALLEDTree::Init()
   app->SetDefaultParameter( "FCALLED:Tree", btree );
 
   lockService = app->GetService<JLockService>();
-
-  // This is called once at program startup.
-  lockService->RootWriteLock();
   
   if (btree == 1) {
   
@@ -91,8 +88,6 @@ void JEventProcessor_FCALLEDTree::Init()
   hinteg = new TH2F("m_integ", ";channel;integ;Counts", 2800, 0, 2800, 4096, 0., 4096.);
 
   main->cd();
-  
- lockService->RootUnLock();
   
   return; //NOERROR;
 }
@@ -192,8 +187,6 @@ void JEventProcessor_FCALLEDTree::EndRun()
 void JEventProcessor_FCALLEDTree::Finish()
 {
   // Called before program exit after event processing is finished.
-  lockService->RootWriteLock();
   m_tree->Write();
-  lockService->RootUnLock();
 }
 

--- a/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
+++ b/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
@@ -360,6 +360,7 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
 		}
 
 		// calculate channel shifts
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 		for (int i = 0; i < numChannels; ++i) {
 			// figure out detector location and indexing
 			int row = m_fcalGeom->row(i);
@@ -412,6 +413,7 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
 			
 			outf << (old_ADCoffsets[i] + adc_shift) << endl;
   		}
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   		
   		ref_file->Close();

--- a/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
+++ b/src/plugins/Calibration/FCAL_LED_shifts/JEventProcessor_FCAL_LED_shifts.cc
@@ -290,7 +290,8 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
   	// changed to give you a chance to clean up before processing
   	// events from the next run number.
  
-   
+	lockService->RootWriteLock(); //ACQUIRE ROOT LOCK
+ 
   	if(CALC_NEW_CONSTANTS_BEAM) {
   		// calculate time shifts
   		//cerr << "opening " << REFERENCE_FILE_NAME << endl;
@@ -360,7 +361,6 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
 		}
 
 		// calculate channel shifts
-		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 		for (int i = 0; i < numChannels; ++i) {
 			// figure out detector location and indexing
 			int row = m_fcalGeom->row(i);
@@ -413,7 +413,6 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
 			
 			outf << (old_ADCoffsets[i] + adc_shift) << endl;
   		}
-		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   		
   		ref_file->Close();
@@ -509,6 +508,8 @@ void JEventProcessor_FCAL_LED_shifts::EndRun()
   		outf.close();
 
   	}
+
+	lockService->RootUnLock(); //RELEASE ROOT LOCK
 }
 
 //------------------

--- a/src/plugins/Calibration/FCAL_TimingOffsets/JEventProcessor_FCAL_TimingOffsets.cc
+++ b/src/plugins/Calibration/FCAL_TimingOffsets/JEventProcessor_FCAL_TimingOffsets.cc
@@ -179,7 +179,7 @@ void JEventProcessor_FCAL_TimingOffsets::Process(const std::shared_ptr<const JEv
 
 
    
-  
+	DEvent::GetLockService(locEvent)->RootFillLock(); 
 
     for(unsigned int k=0; k<locFCALShowers.size(); k++)
       {
@@ -223,7 +223,7 @@ const DFCALShower *s1 = locFCALShowers[k];
     }
 	
 
-
+	DEvent::GetLockService(locEvent)->RootFillUnLock(); 
 
 
 }

--- a/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.cc
+++ b/src/plugins/Calibration/FCALgains/JEventProcessor_FCALgains.cc
@@ -41,10 +41,8 @@ void JEventProcessor_FCALgains::Init()
   // ROOT mutex like this:
   auto app = GetApplication();
   lockService = app->GetService<JLockService>();
-  lockService->RootWriteLock();
 
   if(InvMass1 && InvMass2 != NULL){
-    lockService->RootUnLock();
     return;
   }
 
@@ -109,8 +107,9 @@ void JEventProcessor_FCALgains::Init()
 			  m_event = 0;
 			  m_TotPastCuts = 0;
 
-			  lockService->RootUnLock();
 }
+
+
 int JEventProcessor_FCALgains::XYtoAbsNum(int my_x, int my_y)
 {
   return m_fcalgeom->channel( my_y/4 +29, my_x/4 +29 );

--- a/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
+++ b/src/plugins/Calibration/HLDetectorTiming/JEventProcessor_HLDetectorTiming.cc
@@ -756,7 +756,8 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     vector<const DEPICSvalue *> epicsValues;
     event->Get(epicsValues);
     
-	DEvent::GetLockService(event)->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	DEvent::GetLockService(event)->RootFillLock(this); //ACQUIRE ROOT LOCK!!
+	
     for(unsigned int j = 0; j < epicsValues.size(); j++){
         const DEPICSvalue *thisValue = epicsValues[j];
         if (strcmp((thisValue->name).c_str(), "IBCAD00CRCUR6") == 0){
@@ -772,7 +773,7 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     if (BEAM_CURRENT < 10.0) {
     	dHistBeamEvents->Fill(0);
         if (REQUIRE_BEAM){
-			DEvent::GetLockService(event)->RootUnLock(); //RELEASE ROOT LOCK!!
+			DEvent::GetLockService(event)->RootFillUnLock(this); //RELEASE ROOT LOCK!!
             return; // Skip events where we can't verify the beam current
         }
     }
@@ -780,7 +781,7 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     	dHistBeamEvents->Fill(1);
         fBeamEventCounter++;
     }
-	DEvent::GetLockService(event)->RootUnLock(); //RELEASE ROOT LOCK!!
+	DEvent::GetLockService(event)->RootFillUnLock(this); //RELEASE ROOT LOCK!!
 
     if (fBeamEventCounter >= BEAM_EVENTS_TO_KEEP) { // Able to specify beam ON events instead of just events
         cout<< "Maximum number of Beam Events reached" << endl;
@@ -867,7 +868,7 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     }
 
 
-	DEvent::GetLockService(event)->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+	DEvent::GetLockService(event)->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 	// Start by filling individual hit times
 	// 
 	// The detectors with both TDCs and ADCs need these two to be aligned
@@ -1288,7 +1289,7 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     // Certainly good enough to take a pass at the time based tracking
     // This will be the final alignment step for now
 
-    if (thisRFBunch->dNumParticleVotes < 2) { DEvent::GetLockService(event)->RootUnLock(); return; }
+    if (thisRFBunch->dNumParticleVotes < 2) { DEvent::GetLockService(event)->RootFillUnLock(this); return; }
     auto dRFTimeFactory = static_cast<DRFTime_factory*>(event->GetFactory("DRFTime", ""));
 
     // Loop over TAGM hits
@@ -1416,9 +1417,9 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
     
     // we went this far just to align the tagger with the RF time, nothing else to do without tracks
     if(NO_TRACKS) 
-	    { DEvent::GetLockService(event)->RootUnLock();  return; }
+	    { DEvent::GetLockService(event)->RootFillUnLock(this);  return; }
 
-    if (!DO_TRACK_BASED && !DO_VERIFY ) { DEvent::GetLockService(event)->RootUnLock();  return; }   // Before this stage we aren't really ready yet, so just return
+    if (!DO_TRACK_BASED && !DO_VERIFY ) { DEvent::GetLockService(event)->RootFillUnLock(this);  return; }   // Before this stage we aren't really ready yet, so just return
 
     // Try using the detector matches
     // Loop over the charged tracks
@@ -1649,7 +1650,7 @@ void JEventProcessor_HLDetectorTiming::Process(const std::shared_ptr<const JEven
 		}
     } // End of loop over time based tracks
 		
-   DEvent::GetLockService(event)->RootUnLock();
+   DEvent::GetLockService(event)->RootFillUnLock(this);
 
 
     return;

--- a/src/plugins/Calibration/SConscript
+++ b/src/plugins/Calibration/SConscript
@@ -5,8 +5,8 @@ Import('*')
 
 # update this when plugins are added
 
-subdirs = ['BCAL_SiPM_saturation','FCAL_Pi0HFA','BCAL_attenlength_gainratio','BCAL_gainmatrix','BCAL_point_time','BCAL_point_calib','BCAL_saturation','BCAL_TDC_Timing','CDC_amp','HLDetectorTiming','TAGH_timewalk','CDC_TimeToDistance','PS_timing','PSC_TW','PS_E_calib','st_tw_corr_auto','ST_Propagation_Time','ST_Tresolution','TAGM_TW','TOF_calib','FCALLEDTree','FCAL_LED_shifts', 'FCAL_Pi0TOF', 'FCAL_TimingOffsets_Primex']
+subdirs = ['BCAL_SiPM_saturation','BCAL_attenlength_gainratio','BCAL_gainmatrix','BCAL_point_time','BCAL_point_calib','BCAL_saturation','BCAL_TDC_Timing','CDC_amp','HLDetectorTiming','TAGH_timewalk','CDC_TimeToDistance','PS_timing','PSC_TW','PS_E_calib','st_tw_corr_auto','ST_Propagation_Time','ST_Tresolution','TAGM_TW','TOF_calib','FCALLEDTree','FCAL_LED_shifts','FCAL_TimingOffsets_Primex']
 
 SConscript(dirs=subdirs, exports='env osname', duplicate=0)
 
-sbms.OptionallyBuild(env, ['FCALgains','FCALpedestals','FCALpulsepeak','FCAL_TimingOffsets'])
+sbms.OptionallyBuild(env, ['FCALgains','FCALpedestals','FCALpulsepeak','FCAL_TimingOffsets','FCAL_Pi0HFA','FCAL_Pi0TOF'])

--- a/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
+++ b/src/plugins/Calibration/TOF_calib/JEventProcessor_TOF_calib.cc
@@ -249,6 +249,7 @@ void JEventProcessor_TOF_calib::Process(const std::shared_ptr<const JEvent>& eve
     float indx = bar-1 + plane*locTOFGeometry->Get_NBars()*2 + end*locTOFGeometry->Get_NBars();
     //cout<<plane<<"  "<<bar<<"  "<<end<<endl;
 
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     if (hit->pedestal){
       TOFPedestal->Fill(indx, (float)hit->pedestal);
       TOFEnergy->Fill(indx, (float)hit->pulse_integral);
@@ -261,6 +262,8 @@ void JEventProcessor_TOF_calib::Process(const std::shared_ptr<const JEvent>& eve
 
     th[plane][bar-1][end] = 1;
     TOFADCtime->Fill(time,indx);
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
+
     if (fabsf(time-ADCTLOC)<ADCTimeCut){
       // test for overflow if raw data available
       vector <const Df250PulseIntegral*> PulseIntegral;

--- a/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.cc
+++ b/src/plugins/monitoring/BCAL_Eff/JEventProcessor_BCAL_Eff.cc
@@ -418,7 +418,7 @@ void JEventProcessor_BCAL_Eff::Process(const std::shared_ptr<const JEvent> &locE
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	event_count++;
 //	if (event_count%100 == 0) printf ("Event count=%d, EventNumber=%d\n",event_count,locEventNumber);
@@ -654,7 +654,7 @@ void JEventProcessor_BCAL_Eff::Process(const std::shared_ptr<const JEvent> &locE
 
 	}   // end loop over matched showers
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	/*
 	//Optional: Save event to output REST file. Use this to create skims.
@@ -674,7 +674,7 @@ void JEventProcessor_BCAL_Eff::EndRun()
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
 	//lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
-  // h1eff_eff->Divide(h1eff_layer,h1eff_layertot);
+    // h1eff_eff->Divide(h1eff_layer,h1eff_layertot);
 	//lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
 }
 
@@ -685,14 +685,10 @@ void JEventProcessor_BCAL_Eff::Finish()
 {
   // Called before program exit after event processing is finished.  
 
-  lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
-
   h1eff_eff->Divide(h1eff_layer,h1eff_layertot,1,1,"B");
   h1eff2_eff2->Divide(h1eff2_layer,h1eff2_layertot,1,1,"B");
 
   h1eff_cellideff->Divide(h1eff_cellid,h1eff_cellidtot,1,1,"B");
   h1eff2_cellideff2->Divide(h1eff2_cellid,h1eff2_cellidtot,1,1,"B");
-
-  lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
 }
 

--- a/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/BCAL_Hadronic_Eff/JEventProcessor_BCAL_Hadronic_Eff.cc
@@ -552,7 +552,7 @@ void JEventProcessor_BCAL_Hadronic_Eff::Process(const std::shared_ptr<const JEve
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		//Fill Hit Found
 		for(auto& locLayerPair : locHitMap_HitFound)
@@ -574,7 +574,7 @@ void JEventProcessor_BCAL_Hadronic_Eff::Process(const std::shared_ptr<const JEve
 			}
 		}
 	}
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 double JEventProcessor_BCAL_Hadronic_Eff::Calc_ProjectedSector(int locLayer, const map<int, map<int, set<const DBCALPoint*> > >& locSortedPoints)

--- a/src/plugins/monitoring/BCAL_LED/JEventProcessor_BCAL_LED.cc
+++ b/src/plugins/monitoring/BCAL_LED/JEventProcessor_BCAL_LED.cc
@@ -141,10 +141,7 @@ void JEventProcessor_BCAL_LED::Init() {
     
     //REGISTER BRANCHES
      dTreeInterface->Create_Branches(locTreeBranchRegister);
-    
-    	// lock all root operations
-   	lockService->RootWriteLock();
- 
+     
  	bcal_vevent = new TProfile("bcal_vevent","Avg BCAL peak vs event;event num;peak",48,0.0,48.0);
 	
 	low_up_1 = new TProfile("low_bias_up_sector_1_peak_vchannel","Avg BCAL peak vs channel;channel ID;peak",1536,0,1536);
@@ -225,8 +222,6 @@ void JEventProcessor_BCAL_LED::Init() {
 	dHist_quad_occ_down  = new TH1F("dHist_quad_occ_down", "Quadrants triggered -  Downstream Pulser", 4, 0.5, 4.5);
 	// back to main dir
 	main->cd();
-	// unlock
-	lockService->RootUnLock();
 	
 }
 
@@ -308,9 +303,6 @@ void JEventProcessor_BCAL_LED::Process(const std::shared_ptr<const JEvent>& even
 	} else {
 		//NOtrig++;
 	}	
-	// Lock ROOT
-	lockService->RootWriteLock();
-
 	float ledup_sector = 0;
 	//int ledup_sector_int = 0;
 	float ledup_mean = 0;
@@ -328,6 +320,10 @@ void JEventProcessor_BCAL_LED::Process(const std::shared_ptr<const JEvent>& even
 		event->Get(dbcalhits);
 		event->Get(bcaldigihits);
 		event->Get(dbcalpoints);
+
+		// Lock ROOT
+		lockService->RootFillLock(this);
+
 		
       if (LED_US || LED_DS || dbcalhits.size() >= 1200.) {
 	        // float apedsubtime[1536] = { 0. };
@@ -881,7 +877,7 @@ else if (simultaneous == 1){//Pulsing all sectors simultaneously starting run 50
 		 
 	}//if LEDUP || LEDDOWN || 1200 hits   
 	// Unlock ROOT
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 	
 
     return;

--- a/src/plugins/monitoring/BCAL_LED_time/JEventProcessor_BCAL_LED_time.cc
+++ b/src/plugins/monitoring/BCAL_LED_time/JEventProcessor_BCAL_LED_time.cc
@@ -48,17 +48,7 @@ void JEventProcessor_BCAL_LED_time::Init() {
 
 	auto app = GetApplication();
 	lockService = app->GetService<JLockService>();
-	
-	// lock all root operations
-	lockService->RootWriteLock();
-	
-	// First thread to get here makes all histograms. If one pointer is
-	// already not NULL, assume all histograms are defined and return now
-	if(bcal_time_vevent != NULL){
-		lockService->RootUnLock();
-		return;
-	}
-	
+		
 	//NOtrig=0; FPtrig=0; GTPtrig=0; FPGTPtrig=0; trigUS=0; trigDS=0; trigCosmic=0;
 	//low_down_1_counter=0; low_down_2_counter=0; low_down_3_counter=0; low_down_4_counter=0; low_up_1_counter=0; low_up_2_counter=0; low_up_3_counter=0; 		low_up_4_counter=0; high_down_1_counter=0; high_down_2_counter=0; high_down_3_counter=0; high_down_4_counter=0; high_up_1_counter=0;
 	//high_up_2_counter=0; high_up_3_counter=0; high_up_4_counter=0;
@@ -249,10 +239,7 @@ void JEventProcessor_BCAL_LED_time::Init() {
 
 	// back to main dir
 	main->cd();
-	
-	// unlock
-	lockService->RootUnLock();
-	
+		
 }
 
 
@@ -328,7 +315,7 @@ void JEventProcessor_BCAL_LED_time::Process(const std::shared_ptr<const JEvent>&
 		//NOtrig++;
 	}	
 	// Lock ROOT
-	lockService->RootWriteLock();
+	lockService->RootFillLock(this);
 
 	float ledup_sector = 0;
 	int ledup_sector_int = 0;
@@ -779,7 +766,7 @@ void JEventProcessor_BCAL_LED_time::Process(const std::shared_ptr<const JEvent>&
 
 	}//if LEDUP || LEDDOWN    
 	// Unlock ROOT
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 	
 }
 

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
@@ -402,7 +402,7 @@ void JEventProcessor_BCAL_LEDonline::Process(const std::shared_ptr<const JEvent>
 	
 		// FILL HISTOGRAMS
 		// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 		if( (dbcaldigihits.size() > 0) || (dbcaltdcdigihits.size() > 0) )
 			bcal_num_events->Fill(1);
@@ -603,7 +603,7 @@ void JEventProcessor_BCAL_LEDonline::Process(const std::shared_ptr<const JEvent>
 			}
 		}
 
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
     }
 	
 	return;

--- a/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
+++ b/src/plugins/monitoring/BCAL_LEDonline/JEventProcessor_BCAL_LEDonline.cc
@@ -618,6 +618,7 @@ void JEventProcessor_BCAL_LEDonline::EndRun() {
 	// changed to give you a chance to clean up before processing
 	// events from the next run number.
 
+	lockService->RootWriteLock(); //GRAB ROOT LOCK
 	printf("\nTrigger statistics");
 	printf("------------------------\n");
 	printf("%20s: %10i\n","no triggers",NOtrig);
@@ -636,6 +637,7 @@ void JEventProcessor_BCAL_LEDonline::EndRun() {
 	bcal_fadc_digi_pedestal_vchannel->SetMinimum(bcal_fadc_digi_pedestal_vchannel->GetMinimum(0.1));
 	bcal_fadc_digi_integral_vchannel->SetMinimum(bcal_fadc_digi_integral_vchannel->GetMinimum(0.1));	
 	bcal_fadc_digi_peak_vchannel->SetMinimum(bcal_fadc_digi_peak_vchannel->GetMinimum(0.1));	
+	lockService->RootUnLock(); //RELEASE ROOT LOCK
 
 	return;
 }

--- a/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
+++ b/src/plugins/monitoring/BCAL_inv_mass/JEventProcessor_BCAL_inv_mass.cc
@@ -262,7 +262,7 @@ void JEventProcessor_BCAL_inv_mass::Process(const std::shared_ptr<const JEvent> 
 	
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	for(unsigned int i=0; i<locBCALShowers.size(); i++)
 	{
@@ -323,7 +323,7 @@ void JEventProcessor_BCAL_inv_mass::Process(const std::shared_ptr<const JEvent> 
 	}   
 
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 
 	/*

--- a/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
+++ b/src/plugins/monitoring/BCAL_online/JEventProcessor_BCAL_online.cc
@@ -558,7 +558,7 @@ void JEventProcessor_BCAL_online::Process(const std::shared_ptr<const JEvent>& e
 	
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	if( (dbcaldigihits.size() > 0) || (dbcaltdcdigihits.size() > 0) )
 		bcal_num_events->Fill(1);
@@ -843,7 +843,7 @@ void JEventProcessor_BCAL_online::Process(const std::shared_ptr<const JEvent>& e
 		bcal_shower_plane->Fill(shower->x,shower->y);
 	}
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/BEAM_online/JEventProcessor_BEAM_online.cc
+++ b/src/plugins/monitoring/BEAM_online/JEventProcessor_BEAM_online.cc
@@ -7,10 +7,13 @@
 
 #include "JEventProcessor_BEAM_online.h"
 
+#include "DANA/DEvent.h"
+
 
 // Routine used to create our JEventProcessor
 #include <JANA/JApplication.h>
 #include <JANA/JFactoryT.h>
+
 extern "C"{
   void InitPlugin(JApplication *app){
     InitJANAPlugin(app);
@@ -169,6 +172,8 @@ void JEventProcessor_BEAM_online::Process(const std::shared_ptr<const JEvent>& e
     double tpair = (PSPairs[0]->ee.first->t + PSPairs[0]->ee.second->t) / 2.;
     double epair = (PSPairs[0]->ee.first->E + PSPairs[0]->ee.second->E);
 
+    DEvent::GetLockService(event)->RootFillLock(this); 
+
     // loop over beam photons
     for (int k=0; k<NBeamPhotons; k++){
       float dt = Beam[k]->time() - tpair;
@@ -182,6 +187,7 @@ void JEventProcessor_BEAM_online::Process(const std::shared_ptr<const JEvent>& e
 	  OutOfTimeBeamH.push_back(Beam[k]);
 	}
       }
+      
       
       if (Beam[k]->dSystem == SYS_TAGM){
 	
@@ -380,6 +386,8 @@ void JEventProcessor_BEAM_online::Process(const std::shared_ptr<const JEvent>& e
 	
       }
     }
+    
+    DEvent::GetLockService(event)->RootFillUnLock(this); 
   }
 
 
@@ -411,6 +419,8 @@ void JEventProcessor_BEAM_online::Process(const std::shared_ptr<const JEvent>& e
 	double Ncnts = 0;
 	double NcntsA = 0;
 	
+	DEvent::GetLockService(event)->RootFillLock(this); 
+
 	for (int k=0 ;k<NBeamPhotons; k++){
 	  const DBeamPhoton* g = Beam[k];
 	  if (g->dSystem == SYS_TAGM){
@@ -435,6 +445,8 @@ void JEventProcessor_BEAM_online::Process(const std::shared_ptr<const JEvent>& e
 	}
       }	
     }
+    
+    DEvent::GetLockService(event)->RootFillUnLock(this); 
   }
 }
 

--- a/src/plugins/monitoring/CCAL_online/JEventProcessor_CCAL_online.cc
+++ b/src/plugins/monitoring/CCAL_online/JEventProcessor_CCAL_online.cc
@@ -343,7 +343,7 @@ void JEventProcessor_CCAL_online::Process(const std::shared_ptr<const JEvent>& e
 	//----------   Fill Histograms   ----------//
 	
 	
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	
 	
 	//-----   DigiHit Plots   -----//
@@ -639,7 +639,7 @@ void JEventProcessor_CCAL_online::Process(const std::shared_ptr<const JEvent>& e
 	
 	
 	
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
+++ b/src/plugins/monitoring/CDC_Efficiency/JEventProcessor_CDC_Efficiency.cc
@@ -394,9 +394,9 @@ void JEventProcessor_CDC_Efficiency::Process(const std::shared_ptr<const JEvent>
    for (unsigned int iTrack = 0; iTrack < bestTimeBasedTracks.size(); iTrack++){
       auto thisTimeBasedTrack = bestTimeBasedTracks[iTrack];
 
-      lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+      lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
       hChi2OverNDF->Fill(thisTimeBasedTrack->FOM);
-      lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+      lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
       if (thisTimeBasedTrack->FOM < dMinTrackingFOM)
          continue;
@@ -708,7 +708,7 @@ void JEventProcessor_CDC_Efficiency::Fill_MeasuredHit(bool withdEdx, int ringNum
    if (distanceToWire < DOCACUT)
    {
       //printf("Matching Hit!!!!!\n");
-      lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+      lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
       {
          Double_t v = cdc_measured_ring[ringNum]->GetBinContent(wireNum, 1) + 1.0;
          cdc_measured_ring[ringNum]->SetBinContent(wireNum, 1, v);
@@ -725,28 +725,28 @@ void JEventProcessor_CDC_Efficiency::Fill_MeasuredHit(bool withdEdx, int ringNum
          // ?	Double_t w = cdc_expected_ring[ringNum]->GetBinContent(wireNum, 1) + 1.0;
          // ?    cdc_measured_ring[ringNum]->SetBinContent(wireNum, 1, w);
       }
-      lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+      lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
    }
 
    int locDOCABin = (int) (distanceToWire * 10) % 8;
    TH2D* locHistToFill = cdc_measured_ringmap[locDOCABin][ringNum];
-   lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+   lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
    {
       Double_t w = locHistToFill->GetBinContent(wireNum, 1) + 1.0;
       locHistToFill->SetBinContent(wireNum, 1, w);
    }
-   lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+   lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
    if (FILL_DEDX_HISTOS) {
      if (withdEdx) {
 
        TH2D* locHistToFill = cdc_measured_with_dedx_ringmap[locDOCABin][ringNum];
-       lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+       lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
        {
 	 Double_t w = locHistToFill->GetBinContent(wireNum, 1) + 1.0;
 	 locHistToFill->SetBinContent(wireNum, 1, w);
        }
-       lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+       lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
      }
    }

--- a/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.cc
+++ b/src/plugins/monitoring/CDC_dedx/JEventProcessor_CDC_dedx.cc
@@ -167,7 +167,7 @@ void JEventProcessor_CDC_dedx::Process(const std::shared_ptr<const JEvent>& even
 
     if (dedx > 0) {
 
-      lockService->RootWriteLock();
+      lockService->RootFillLock(this);
 
       dedx_p->Fill(p,dedx);
     
@@ -177,7 +177,7 @@ void JEventProcessor_CDC_dedx::Process(const std::shared_ptr<const JEvent>& even
         dedx_p_neg->Fill(p,dedx);
       } 
 
-      lockService->RootUnLock();
+      lockService->RootFillUnLock(this);
 
     }
 
@@ -187,7 +187,7 @@ void JEventProcessor_CDC_dedx::Process(const std::shared_ptr<const JEvent>& even
 
     if (dedx > 0) {
 
-      lockService->RootWriteLock();
+      lockService->RootFillLock(this);
 
       intdedx_p->Fill(p,dedx);
     
@@ -197,7 +197,7 @@ void JEventProcessor_CDC_dedx::Process(const std::shared_ptr<const JEvent>& even
         intdedx_p_neg->Fill(p,dedx);
       } 
 
-      lockService->RootUnLock();
+      lockService->RootFillUnLock(this);
 
     }
 

--- a/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.cc
+++ b/src/plugins/monitoring/CDC_expert/JEventProcessor_CDC_expert.cc
@@ -421,7 +421,7 @@ void JEventProcessor_CDC_expert::Process(const std::shared_ptr<const JEvent>& ev
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   for(uint32_t i=0; i<hits.size(); i++) {
 
@@ -594,7 +594,7 @@ void JEventProcessor_CDC_expert::Process(const std::shared_ptr<const JEvent>& ev
   }
 
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.cc
+++ b/src/plugins/monitoring/CDC_expert_2/JEventProcessor_CDC_expert_2.cc
@@ -345,7 +345,7 @@ void JEventProcessor_CDC_expert_2::Process(const std::shared_ptr<const JEvent>& 
   event->Get(digihits);
 
 
-  lockService->RootWriteLock(); //ACQUIRE ROOT LOCK!!
+  lockService->RootFillLock(this); //ACQUIRE ROOT LOCK!!
 
 
 
@@ -531,7 +531,7 @@ void JEventProcessor_CDC_expert_2::Process(const std::shared_ptr<const JEvent>& 
   } //end for each digihit
 
 
-  lockService->RootUnLock(); //RELEASE ROOT LOCK!!
+  lockService->RootFillUnLock(this); //RELEASE ROOT LOCK!!
 
 }
 

--- a/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
+++ b/src/plugins/monitoring/CDC_online/JEventProcessor_CDC_online.cc
@@ -323,7 +323,7 @@ void JEventProcessor_CDC_online::Process(const std::shared_ptr<const JEvent>& ev
 
   // FILL HISTOGRAMS
   // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-  lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+  lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if(digihits.size() > 0)
 	  cdc_num_events->Fill(1);
@@ -466,7 +466,7 @@ void JEventProcessor_CDC_online::Process(const std::shared_ptr<const JEvent>& ev
 
   } //end of loop through digihits
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.cc
+++ b/src/plugins/monitoring/DIRC_online/JEventProcessor_DIRC_online.cc
@@ -289,7 +289,7 @@ void JEventProcessor_DIRC_online::Process(const std::shared_ptr<const JEvent>& e
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     if (digihits.size() > 0) dirc_num_events->Fill(1);
 
@@ -387,7 +387,7 @@ void JEventProcessor_DIRC_online::Process(const std::shared_ptr<const JEvent>& e
     hHit_NHits[loc_itrig]->Fill(NHits[0]+NHits[1]);
     hHit_NHitsVsBox[loc_itrig]->Fill(0.,NHits[0]); hHit_NHitsVsBox[loc_itrig]->Fill(1.,NHits[1]);
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/EVNT_online/JEventProcessor_EVNT_online.cc
+++ b/src/plugins/monitoring/EVNT_online/JEventProcessor_EVNT_online.cc
@@ -123,7 +123,7 @@ void JEventProcessor_EVNT_online::Process(const std::shared_ptr<const JEvent>& e
     // loop over data banks and hist bank sizes, etc.
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     ntot=0;
     for(auto bank : *bankList.get()) {
       nword=bank->getSize();
@@ -131,7 +131,7 @@ void JEventProcessor_EVNT_online::Process(const std::shared_ptr<const JEvent>& e
       ntot+=nword;
     }
     evntdata->Fill(ntot);
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
   }
   
   

--- a/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
+++ b/src/plugins/monitoring/FCAL_Hadronic_Eff/JEventProcessor_FCAL_Hadronic_Eff.cc
@@ -220,7 +220,7 @@ void JEventProcessor_FCAL_Hadronic_Eff::Process(const std::shared_ptr<const JEve
 
 		// FILL HISTOGRAMS
 		// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 		{
 			//TOFPoint
 			dHist_TrackFCALYVsX_TotalHit->Fill(locProjectedFCALIntersection.X(), locProjectedFCALIntersection.Y());
@@ -233,7 +233,7 @@ void JEventProcessor_FCAL_Hadronic_Eff::Process(const std::shared_ptr<const JEve
 				dHist_TrackFCALRowVsColumn_HasHit->Fill(locProjectedFCALColumn, locProjectedFCALRow);
 			}
 		}
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 		//TRACK
 		Particle_t locPID = (locChargedTrackHypothesis->t1_detector() == SYS_TOF) ? locChargedTrackHypothesis->PID() : UnknownParticle;

--- a/src/plugins/monitoring/FCAL_invmass/JEventProcessor_FCAL_invmass.cc
+++ b/src/plugins/monitoring/FCAL_invmass/JEventProcessor_FCAL_invmass.cc
@@ -55,10 +55,6 @@ void JEventProcessor_FCAL_invmass::Init()
 {
 	auto app = GetApplication();
 	lockService = app->GetService<JLockService>();
-	if(InvMass1 && InvMass2 != NULL){
-		lockService->RootUnLock();
-		return;
-	}
 
 	TDirectory *main = gDirectory;
 	gDirectory->mkdir("FCAL_invmass")->cd();
@@ -183,7 +179,7 @@ void JEventProcessor_FCAL_invmass::Process(const std::shared_ptr<const JEvent> &
 	}
 
 	// lockService->RootWriteLock();
-	lockService->RootWriteLock(); 
+	lockService->RootFillLock(this); 
 	if (locFCALShowers.size() >=2) {
 
 		for(unsigned int i=0; i<locFCALShowers.size(); i++)
@@ -295,7 +291,7 @@ void JEventProcessor_FCAL_invmass::Process(const std::shared_ptr<const JEvent> &
 	}
 	//lockService->RootUnLock();
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.cc
+++ b/src/plugins/monitoring/FCAL_online/JEventProcessor_FCAL_online.cc
@@ -303,7 +303,7 @@ void JEventProcessor_FCAL_online::Process(const std::shared_ptr<const JEvent>& e
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if( digiHits.size() > 0 )
 	  fcal_num_events->Fill(1);
@@ -592,7 +592,7 @@ void JEventProcessor_FCAL_online::Process(const std::shared_ptr<const JEvent>& e
     
 
   }
-  lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+  lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
+++ b/src/plugins/monitoring/FDC_Efficiency/JEventProcessor_FDC_Efficiency.cc
@@ -256,9 +256,9 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
     const DFDCHit * locHit = locFDCHitVector[hitNum];
     if (locHit->plane != 2) continue; // only wires!
     
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hWireTime[locHit->gLayer]->Fill(locHit->t);
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     // cut on timing of hits
     //if (-100 > locHit->t || locHit->t > 300) continue;
@@ -274,11 +274,11 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
     const DFDCPseudo * locPseudo = locFDCPseudoVector[hitNum];
     locSortedFDCPseudos[locPseudo->wire->layer].insert(locPseudo);
 
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hPseudoTime[locPseudo->wire->layer]->Fill(locPseudo->time);
     hCathodeTime[locPseudo->wire->layer]->Fill(locPseudo->t_u);
     hCathodeTime[locPseudo->wire->layer]->Fill(locPseudo->t_v);
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   }
   
@@ -333,14 +333,14 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
     double tmom = thisTimeBasedTrack->pmag();
     
     // Fill Histograms for all Tracks    
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hCellsHit->Fill(cells);
     hRingsHit->Fill(rings);
     hChi2OverNDF->Fill(thisTimeBasedTrack->FOM);
     hMom->Fill(tmom);
     hTheta->Fill(theta_deg);
     hPhi->Fill(phi_deg);
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
     // All Cuts on Track Quality:
     
@@ -386,7 +386,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
     if (packageHit[0] < minCells && packageHit[1] < minCells && packageHit[2] < minCells && packageHit[3] < minCells) continue;
     
     // Fill Histograms for accepted Tracks
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     hCellsHit_accepted->Fill(cells);
     //if (tmom < 2)
     hRingsHit_accepted->Fill(rings);
@@ -395,7 +395,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
     hTheta_accepted->Fill(theta_deg);
     hPhi_accepted->Fill(phi_deg);
     hRingsHit_vs_P->Fill(rings, tmom);
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
     
     // Start efficiency computation with these tracks
     
@@ -474,10 +474,10 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	  Double_t w, v;
 	  if(fdc_wire_expected_cell[cellNum] != NULL && cellNum < 25){
 	    // FILL HISTOGRAMS
-	    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	    w = fdc_wire_expected_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
 	    fdc_wire_expected_cell[cellNum]->SetBinContent(wireNum, 1, w);
-	    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	  }
 	  
 	  // look in the presorted FDC Hits for a match
@@ -490,10 +490,10 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	      // Loop over multiple hits in the wire
 	      for(set<const DFDCHit*>::iterator locIterator = locSortedFDCHits[cellNum][wireNum].begin();  locIterator !=  locSortedFDCHits[cellNum][wireNum].end(); ++locIterator){
 	      	const DFDCHit* locHit = * locIterator;
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 		hWireTime_accepted[cellNum]->Fill(locHit->t);
 		hResVsT[cellNum]->Fill(distanceToWire, locHit->t);
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	      }
 	    }
 
@@ -512,10 +512,10 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	    // hMeasuredHitsVsHitCells->Fill(cells);
 	    // lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
-	    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	    v = fdc_wire_measured_cell[cellNum]->GetBinContent(wireNum, 1) + 1.0;
 	    fdc_wire_measured_cell[cellNum]->SetBinContent(wireNum, 1, v);
-	    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	  }
 
 	  break; // break if 1 expected hit was found, 2 are geometrically not possible (speedup!)
@@ -532,9 +532,9 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
       
       if(fdc_pseudo_expected_cell[cellNum] != NULL && cellNum < 25){
 	// FILL HISTOGRAMS
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	fdc_pseudo_expected_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
       }
 
       bool foundPseudo = false;
@@ -561,7 +561,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	    double residualV = -1*(residual2D.Rotate(wire->angle)).Y();
 
 	    // these can be used for background studies/correction
-	    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	    hPseudoRes->Fill(residualR);
 	    // hPseudoResX[cellNum]->Fill(residualX);
 	    // hPseudoResY[cellNum]->Fill(residualY);
@@ -570,7 +570,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	    unsigned int radius = interPosition2D.Mod()/(45/rad);
 	    if (radius<rad)
 	      hPseudoResUvsV[cellNum][radius]->Fill(residualU, residualV);
-	    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	    
 	    if (foundPseudo) continue; 
 	    // to avoid double conting
@@ -581,7 +581,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 	      
 	      if(fdc_pseudo_measured_cell[cellNum] != NULL && cellNum < 25){
 		// fill histogramms with the predicted, not with the measured position
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 		fdc_pseudo_measured_cell[cellNum]->Fill(interPosition.X(), interPosition.Y());
 		hPseudoTime_accepted[cellNum]->Fill(locPseudo->time);
 		hCathodeTime_accepted[cellNum]->Fill(locPseudo->t_u);
@@ -589,7 +589,7 @@ void JEventProcessor_FDC_Efficiency::Process(const std::shared_ptr<const JEvent>
 		hDeltaTime[cellNum]->Fill(locPseudo->time - locPseudo->t_u);
 		hDeltaTime[cellNum]->Fill(locPseudo->time - locPseudo->t_v);
 		hPseudoResVsT[cellNum]->Fill(residualU, locPseudo->time);
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 	      }
 	    }
 	    

--- a/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.cc
+++ b/src/plugins/monitoring/FDC_online/JEventProcessor_FDC_online.cc
@@ -216,7 +216,7 @@ void JEventProcessor_FDC_online::Process(const std::shared_ptr<const JEvent>& ev
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     if( (anodedigis.size()>0) || (cathodedigis.size()>0) )
         fdc_num_events->Fill(1);
@@ -313,7 +313,7 @@ void JEventProcessor_FDC_online::Process(const std::shared_ptr<const JEvent>& ev
         } //end cell loop
     } //end package loop
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/L1_online/JEventProcessor_L1_online.cc
+++ b/src/plugins/monitoring/L1_online/JEventProcessor_L1_online.cc
@@ -421,7 +421,7 @@ void JEventProcessor_L1_online::Process(const std::shared_ptr<const JEvent>& eve
 
 
       // FILL HISTOGRAMS
-      lockService->RootWriteLock();    //ACQUIRE ROOT FILL LOCK
+      lockService->RootFillLock(this);    //ACQUIRE ROOT FILL LOCK
 
 
       if( l1trig.size() > 0 ){
@@ -525,7 +525,7 @@ void JEventProcessor_L1_online::Process(const std::shared_ptr<const JEvent>& eve
 
 
 
-      lockService->RootUnLock();   //RELEASE ROOT FILL LOCK
+      lockService->RootFillUnLock(this);   //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.cc
+++ b/src/plugins/monitoring/PSC_online/JEventProcessor_PSC_online.cc
@@ -233,7 +233,7 @@ void JEventProcessor_PSC_online::Process(const std::shared_ptr<const JEvent>& ev
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     if (digihits.size() > 0 || tdcdigihits.size() > 0) psc_num_events->Fill(1);
 
@@ -338,7 +338,7 @@ void JEventProcessor_PSC_online::Process(const std::shared_ptr<const JEvent>& ev
     hHit_NHits->Fill(NHits[0]+NHits[1]);
     hHit_NHitsVsArm->Fill(0.,NHits[0]); hHit_NHitsVsArm->Fill(1.,NHits[1]);
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
+++ b/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
@@ -424,7 +424,7 @@ void JEventProcessor_PSPair_online::Process(const std::shared_ptr<const JEvent>&
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     hPSC_NHitPairs->Fill(cpairs.size());
     hPS_NHitPairs->Fill(fpairs.size());
@@ -535,7 +535,7 @@ void JEventProcessor_PSPair_online::Process(const std::shared_ptr<const JEvent>&
         }
     }
     //
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
+++ b/src/plugins/monitoring/PSPair_online/JEventProcessor_PSPair_online.cc
@@ -510,16 +510,16 @@ void JEventProcessor_PSPair_online::Process(const std::shared_ptr<const JEvent>&
                 hPSTAGM_timeVsE->Fill(E_pair,clhit->t-tag->t);
             }
             // PSC,PS,TPOL coincidences
-            if (fabs(PS_Ediff) > 1.75) {lockService->RootUnLock(); return;}
-            if (fabs(PSC_tdiff) > 1.3) {lockService->RootUnLock(); return;}
-            if (E_pair < 8.4 || E_pair > 9.0) {lockService->RootUnLock(); return;}
+            if (fabs(PS_Ediff) > 1.75) {lockService->RootFillUnLock(this); return;}
+            if (fabs(PSC_tdiff) > 1.3) {lockService->RootFillUnLock(this); return;}
+            if (E_pair < 8.4 || E_pair > 9.0) {lockService->RootFillUnLock(this); return;}
             double ph_cut = 100.0;
             int N_TPOL = 0;
             for(unsigned int i=0; i<tpolhits.size(); i++) {
                 if (tpolhits[i]->pulse_peak>=ph_cut) N_TPOL++;
             }
             hPSTPOL_NHits->Fill(N_TPOL);
-            if (N_TPOL>1) {lockService->RootUnLock(); return;}
+            if (N_TPOL>1) {lockService->RootFillUnLock(this); return;}
             for(unsigned int i=0; i<tpolhits.size(); i++) {
                 const DTPOLHit* hit = tpolhits[i];
                 hPSTPOL_peak->Fill(hit->pulse_peak);

--- a/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
+++ b/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
@@ -318,7 +318,7 @@ void JEventProcessor_PS_flux::Process(const std::shared_ptr<const JEvent>& event
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     psflux_num_events->Fill(1);
     if(!beamCurrent.empty()) {
 	    hBeamCurrentTime->Fill(beamCurrent[0]->t);
@@ -451,7 +451,7 @@ void JEventProcessor_PS_flux::Process(const std::shared_ptr<const JEvent>& event
         }
     }
     //
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
+++ b/src/plugins/monitoring/PS_flux/JEventProcessor_PS_flux.cc
@@ -335,7 +335,7 @@ void JEventProcessor_PS_flux::Process(const std::shared_ptr<const JEvent>& event
         const DPSCHit* clhit = cpairs[0]->ee.first; // left hit in coarse PS
         const DPSCHit* crhit = cpairs[0]->ee.second;// right hit in coarse PS
         double PSC_tdiff = clhit->t-crhit->t;
-	if (fabs(PSC_tdiff) > 6.) {lockService->RootUnLock(); return;}
+	if (fabs(PSC_tdiff) > 6.) {lockService->RootFillUnLock(this); return;}
 	psflux_num_events->Fill(2);
 
         // PSC,PS coincidences
@@ -346,8 +346,8 @@ void JEventProcessor_PS_flux::Process(const std::shared_ptr<const JEvent>& event
             const DPSPair::PSClust* frhit = fpairs[0]->ee.second; // right hit in fine PS
 
 	    // geometry check for PS/PSC matching
-	    if(flhit->column < geomModuleColumn[clhit->module-1][0] || flhit->column > geomModuleColumn[clhit->module-1][1]) {lockService->RootUnLock(); return;}
-	    if(frhit->column < geomModuleColumn[crhit->module-1][0] || frhit->column > geomModuleColumn[crhit->module-1][1]) {lockService->RootUnLock(); return;}
+	    if(flhit->column < geomModuleColumn[clhit->module-1][0] || flhit->column > geomModuleColumn[clhit->module-1][1]) {lockService->RootFillUnLock(this); return;}
+	    if(frhit->column < geomModuleColumn[crhit->module-1][0] || frhit->column > geomModuleColumn[crhit->module-1][1]) {lockService->RootFillUnLock(this); return;}
 
 	    // energy variables with random spread in energy bite
 	    // left  - arm 0

--- a/src/plugins/monitoring/PS_online/JEventProcessor_PS_online.cc
+++ b/src/plugins/monitoring/PS_online/JEventProcessor_PS_online.cc
@@ -228,7 +228,7 @@ void JEventProcessor_PS_online::Process(const std::shared_ptr<const JEvent>& eve
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     if (digihits.size() > 0) ps_num_events->Fill(1);
 
@@ -292,7 +292,7 @@ void JEventProcessor_PS_online::Process(const std::shared_ptr<const JEvent>& eve
     }
     hHit_NHitsVsArm->Fill(0.,NHits[0]); hHit_NHitsVsArm->Fill(1.,NHits[1]);
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
+++ b/src/plugins/monitoring/RF_online/JEventProcessor_RF_online.cc
@@ -375,7 +375,7 @@ void JEventProcessor_RF_online::Process(const std::shared_ptr<const JEvent> &loc
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		// Event count used by RootSpy->RSAI so it knows how many events have been seen.
 		rf_itself_num_events->Fill(0.5);
@@ -560,7 +560,7 @@ void JEventProcessor_RF_online::Process(const std::shared_ptr<const JEvent> &loc
 			}
 		}
 	}
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 void JEventProcessor_RF_online::EndRun()

--- a/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.cc
+++ b/src/plugins/monitoring/SC_Eff/JEventProcessor_SC_Eff.cc
@@ -242,7 +242,7 @@ void JEventProcessor_SC_Eff::Process(const std::shared_ptr<const JEvent> &locEve
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	{
 		//Fill Found
 		for(auto& locHitPair : locHitMap_HitFound)
@@ -252,7 +252,7 @@ void JEventProcessor_SC_Eff::Process(const std::shared_ptr<const JEvent> &locEve
 		for(auto& locHitPair : locHitMap_HitTotal)
 			dHist_HitTotal->Fill(locHitPair.second, locHitPair.first);
 	}
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 bool JEventProcessor_SC_Eff::Cut_PIDDeltaT(const DChargedTrackHypothesis* locChargedTrackHypothesis)

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -170,7 +170,7 @@ void JEventProcessor_ST_online_Tresolution::Process(const std::shared_ptr<const 
   
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
     {   
@@ -265,7 +265,7 @@ void JEventProcessor_ST_online_Tresolution::Process(const std::shared_ptr<const 
 	}
     } // sc charged tracks
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
+++ b/src/plugins/monitoring/ST_online_Tresolution/JEventProcessor_ST_online_Tresolution.cc
@@ -50,6 +50,10 @@ void JEventProcessor_ST_online_Tresolution::Init()
 	//  ... fill historgrams or trees ...
 	// lockService->RootUnLock();
 	//
+
+  auto app = GetApplication();
+  lockService = app->GetService<JLockService>();
+
   // **************** define histograms *************************
 
   TDirectory *main = gDirectory;

--- a/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
+++ b/src/plugins/monitoring/ST_online_efficiency/JEventProcessor_ST_online_efficiency.cc
@@ -163,7 +163,7 @@ void JEventProcessor_ST_online_efficiency::Process(const std::shared_ptr<const J
   
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
   
   // Loop over charged tracks
   for (uint32_t i = 0; i < chargedTrackVector.size(); i++)
@@ -282,7 +282,7 @@ void JEventProcessor_ST_online_efficiency::Process(const std::shared_ptr<const J
 	} // end if (st_pred_id != 0) 
     }// end of charged track loop
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
+++ b/src/plugins/monitoring/ST_online_lowlevel/JEventProcessor_ST_online_lowlevel.cc
@@ -208,7 +208,7 @@ void JEventProcessor_ST_online_lowlevel::Process(const std::shared_ptr<const JEv
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if( (dscdigihits.size()>0) || (dsctdcdigihits.size()>0) || (dschits.size()>0) )
     st_num_events->Fill(1);
@@ -396,7 +396,7 @@ void JEventProcessor_ST_online_lowlevel::Process(const std::shared_ptr<const JEv
       
     }// End Hit loop
   // Lock ROOT mutex so other threads won't interfere 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
   return;
 }

--- a/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.cc
+++ b/src/plugins/monitoring/ST_online_multi/JEventProcessor_ST_online_multi.cc
@@ -155,7 +155,7 @@ void JEventProcessor_ST_online_multi::Process(const std::shared_ptr<const JEvent
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
  //reset the counters to zero
   memset(counter_adc, 0, sizeof(counter_adc));
@@ -263,7 +263,7 @@ void JEventProcessor_ST_online_multi::Process(const std::shared_ptr<const JEvent
 	}
     }
   
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
+++ b/src/plugins/monitoring/ST_online_tracking/JEventProcessor_ST_online_tracking.cc
@@ -165,7 +165,7 @@ void JEventProcessor_ST_online_tracking::Process(const std::shared_ptr<const JEv
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   sc_track_position.clear();
  
@@ -265,7 +265,7 @@ void JEventProcessor_ST_online_tracking::Process(const std::shared_ptr<const JEv
       h2_y_vs_x->Fill(sc_track_position[i].x(),sc_track_position[i].y());
     }
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/TAGGER_online/JEventProcessor_TAGGER_online.cc
+++ b/src/plugins/monitoring/TAGGER_online/JEventProcessor_TAGGER_online.cc
@@ -77,10 +77,10 @@ void JEventProcessor_TAGGER_online::Process(const std::shared_ptr<const JEvent>&
 	  if(locTAGMHit != NULL) { 
 		// FILL HISTOGRAMS
 		// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this);//ACQUIRE ROOT FILL LOCK
 		dTAGMPulsePeak_Column->Fill(locTAGMHit->column, locTAGMHit->pulse_peak);
 		dTAGMIntegral_Column->Fill(locTAGMHit->column, locTAGMHit->integral);
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 		
 		// add threshold on TAGM hits
 		if(locTAGMHit->integral < 500.) continue;
@@ -90,9 +90,9 @@ void JEventProcessor_TAGGER_online::Process(const std::shared_ptr<const JEvent>&
 	    Double_t locDeltaT = locBeamPhotons[loc_i]->time() - locSCHits[loc_j]->t;
 		// FILL HISTOGRAMS
 		// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-		lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+		lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	    dTaggerEnergy_DeltaTSC->Fill(locDeltaT, locBeamPhotons[loc_i]->momentum().Mag());
-		lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+		lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 	  }
 	}

--- a/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
+++ b/src/plugins/monitoring/TAGH_doubles/JEventProcessor_TAGH_doubles.cc
@@ -131,7 +131,7 @@ void JEventProcessor_TAGH_doubles::Process(const std::shared_ptr<const JEvent>& 
 
     const DTAGHGeometry& taghGeom = *(taghGeomVect[0]);
 
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
     // Before merging doubles
     int BM_NHits = 0;
     for (const auto& hit : hits_c) {
@@ -181,7 +181,7 @@ void JEventProcessor_TAGH_doubles::Process(const std::shared_ptr<const JEvent>& 
             hAM_tdiffVsIDdiff->Fill(abs(hit1->counter_id-hit2->counter_id),hit1->t-hit2->t);
         }
     }
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
+++ b/src/plugins/monitoring/TAGH_online/JEventProcessor_TAGH_online.cc
@@ -299,7 +299,7 @@ void JEventProcessor_TAGH_online::Process(const std::shared_ptr<const JEvent>& e
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
     hBeamCurrent->Fill(beam_current);
     if (digihits.size() > 0 || tdcdigihits.size() > 0)
@@ -443,7 +443,7 @@ void JEventProcessor_TAGH_online::Process(const std::shared_ptr<const JEvent>& e
     hHit_NHits_us->Fill(NHits_hasADC_us);
     hHit_NHits_ds->Fill(NHits_hasADC_ds);
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
+++ b/src/plugins/monitoring/TAGM_clusters/JEventProcessor_TAGM_clusters.cc
@@ -126,7 +126,7 @@ void JEventProcessor_TAGM_clusters::Process(const std::shared_ptr<const JEvent>&
    vector<const DTAGMHit*>	tagm_merged_hits;
    event->Get(tagm_merged_hits);
 
-   lockService->RootWriteLock();
+   lockService->RootFillLock(this);
 
    // Get occupancies and multiplicities before merging
    int mult_b = 0;
@@ -215,7 +215,7 @@ void JEventProcessor_TAGM_clusters::Process(const std::shared_ptr<const JEvent>&
       }
    }
 
-   lockService->RootUnLock();
+   lockService->RootFillUnLock(this);
 }
 
 //------------------

--- a/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.cc
+++ b/src/plugins/monitoring/TOF_TDC_shift/JEventProcessor_TOF_TDC_shift.cc
@@ -94,7 +94,7 @@ void JEventProcessor_TOF_TDC_shift::Process(const std::shared_ptr<const JEvent>&
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   // Fill histogram of TI % 6 vs (ADC time - TDC time)
   for(UInt_t tof = 0;tof<dtofdigihits.size();tof++){
@@ -118,7 +118,7 @@ void JEventProcessor_TOF_TDC_shift::Process(const std::shared_ptr<const JEvent>&
       hrocTimeRemainder_AdcTdcTimeDiff_corrected->Fill(diff, TriggerBIT);
   }
 
-  lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+  lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 //----------------------------------------------------------------------------------
 void JEventProcessor_TOF_TDC_shift::EndRun() {

--- a/src/plugins/monitoring/TOF_online/JEventProcessor_TOF_online.cc
+++ b/src/plugins/monitoring/TOF_online/JEventProcessor_TOF_online.cc
@@ -258,7 +258,7 @@ void JEventProcessor_TOF_online::Process(const std::shared_ptr<const JEvent>& ev
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
   if(dtofhits.size() > 0)
 	  tof_num_events->Fill(1);
@@ -451,7 +451,7 @@ void JEventProcessor_TOF_online::Process(const std::shared_ptr<const JEvent>& ev
 
     }
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 

--- a/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
+++ b/src/plugins/monitoring/TPOL_online/JEventProcessor_TPOL_online.cc
@@ -193,7 +193,7 @@ void JEventProcessor_TPOL_online::Process(const std::shared_ptr<const JEvent>& e
 
     // FILL HISTOGRAMS
     // Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-    lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+    lockService->RootFillLock(this);//ACQUIRE ROOT FILL LOCK
 
     int NHits = 0;
     for (const auto& wrd : windowrawdata) {
@@ -253,7 +253,7 @@ void JEventProcessor_TPOL_online::Process(const std::shared_ptr<const JEvent>& e
         hHit_TimeVsPeak->Fill(hit->pulse_peak,hit->t);
     }
 
-    lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+    lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 
 }
 //----------------------------------------------------------------------------------

--- a/src/plugins/monitoring/TRIG_online/JEventProcessor_TRIG_online.cc
+++ b/src/plugins/monitoring/TRIG_online/JEventProcessor_TRIG_online.cc
@@ -207,7 +207,7 @@ void JEventProcessor_TRIG_online::Process(const std::shared_ptr<const JEvent> &l
 
 	// FILL HISTOGRAMS
 	// Since we are filling histograms local to this plugin, it will not interfere with other ROOT operations: can use plugin-wide ROOT fill lock
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	h1trig_trgbits->Fill(trig_bits);
         h2trig_fcalVSbcal->Fill(bcal_energy,fcal_energy);
@@ -229,7 +229,7 @@ void JEventProcessor_TRIG_online::Process(const std::shared_ptr<const JEvent> &l
 		}
 	}
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 

--- a/src/plugins/monitoring/TS_scaler/JEventProcessor_TS_scaler.cc
+++ b/src/plugins/monitoring/TS_scaler/JEventProcessor_TS_scaler.cc
@@ -210,9 +210,9 @@ void JEventProcessor_TS_scaler::Process(const std::shared_ptr<const JEvent>& loc
 	}
 		
 	int trig_bits = fp_trig_mask > 0? 128 + fp_trig_mask/256: trig_mask;
-	lockService->RootWriteLock();
+	lockService->RootFillLock(this);
 	dHistTS_trgbits->Fill(trig_bits);
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 
 	// check if scalers are filled to identify SYNC events
 	//if(locL1Trigger->gtp_sc.size() <= 0)
@@ -247,13 +247,13 @@ void JEventProcessor_TS_scaler::Process(const std::shared_ptr<const JEvent>& loc
 	//printf ("Event=%d int_count=%d livetime=%d busytime=%d time=%d live_inst=%d\n",(int)locEventNumber,int_count,livetime,busytime,(int)timestamp,live_inst);
 	
 	double livetime_integrated = (double)livetime/(livetime+busytime);
-	lockService->RootWriteLock();
+	lockService->RootFillLock(this);
 	dHistTS_livetime_tot->Fill(livetime_integrated);
 	dHistTS_liveinst_tot->Fill((float)live_inst/1000.);
 	dHistTS_livetimeEvents->Fill(locEventNumber, livetime_integrated);
 	dHistTS_SyncEvents->Fill(locEventNumber);
 	dHistTS_Current->Fill(dEventNumber, dCurrent);
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 	
 	//STAGE DATA FOR TREE FILL
 	dTreeFillData.Fill_Single<bool>("IsFirstInterval", dIsFirstInterval);
@@ -274,7 +274,7 @@ void JEventProcessor_TS_scaler::Process(const std::shared_ptr<const JEvent>& loc
 	dSyncEventUnixTime = timestamp;
 
 	// set info for each trigger bit and fill histograms
-	lockService->RootWriteLock();
+	lockService->RootFillLock(this);
 	for (int j=0; j<kScalers; j++) {
 		gtp_rec[j] = dTrigCount[j] - dRecordedTriggerBitPrevious[j];
 		gtp_sc[j] = locL1Info->gtp_sc[j] - dScalerTriggerBitPrevious[j];
@@ -317,7 +317,7 @@ void JEventProcessor_TS_scaler::Process(const std::shared_ptr<const JEvent>& loc
 			}
 		}
 	}
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 
 	//FILL TTREE
 	dTreeInterface->Fill(dTreeFillData);

--- a/src/plugins/monitoring/TrackingPulls/JEventProcessor_TrackingPulls.cc
+++ b/src/plugins/monitoring/TrackingPulls/JEventProcessor_TrackingPulls.cc
@@ -299,7 +299,7 @@ void JEventProcessor_TrackingPulls::Process(const std::shared_ptr<const JEvent> 
 
   vector<const DChargedTrack *> chargedTrackVector;
   event->Get(chargedTrackVector);
-  DEvent::GetLockService(event)->RootWriteLock();
+  DEvent::GetLockService(event)->RootFillLock(this);
 
   for (size_t i = 0; i < chargedTrackVector.size(); i++) {
     // TODO: Should be changed to use PID FOM when ready
@@ -601,7 +601,7 @@ void JEventProcessor_TrackingPulls::Process(const std::shared_ptr<const JEvent> 
     if (MAKE_TREE)
       dTreeInterface->Fill(dTreeFillData);
   }
-  DEvent::GetLockService(event)->RootUnLock(); //RELEASE ROOT LOCK!!
+  DEvent::GetLockService(event)->RootFillUnLock(this); //RELEASE ROOT LOCK!!
 }
 
 void JEventProcessor_TrackingPulls::EndRun() {

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -180,8 +180,6 @@ void JEventProcessor_highlevel_online::Init()
 	dTimingCutMap[Positron][SYS_BCAL] = 2.5;
 	dTimingCutMap[Positron][SYS_FCAL] = 3.0;
 
-	lockService->RootWriteLock();
-
 	// All histograms go in the "highlevel" directory
 	TDirectory *main = gDirectory;
 
@@ -351,8 +349,6 @@ void JEventProcessor_highlevel_online::Init()
 
 	// back to main dir
 	main->cd();
-  
-	lockService->RootUnLock();
 }
 
 //------------------
@@ -726,7 +722,7 @@ void JEventProcessor_highlevel_online::Process(const std::shared_ptr<const JEven
 
 
 	/*************************************************************** F1 TDC - fADC time ***************************************************************/
-	lockService->RootWriteLock(); //ACQUIRE ROOT FILL LOCK
+	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 
 	// The following fills the dF1TDC_fADC_tdiff histo for
 	// all detectors that use F1TDC modules. See the templates
@@ -874,7 +870,7 @@ void JEventProcessor_highlevel_online::Process(const std::shared_ptr<const JEven
        dHist_L1bits_fp_twelvehundhits->Fill(pseudo_triggerbit);
 	// DON'T DO HIGHER LEVEL PROCESSING FOR FRONT PANEL TRIGGER EVENTS, OR NON-TRIGGER EVENTS
     if(!locL1Trigger || (locL1Trigger && (locL1Trigger->fp_trig_mask>0))) {
-        lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+        lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
         return;
     }
 
@@ -1141,7 +1137,7 @@ void JEventProcessor_highlevel_online::Process(const std::shared_ptr<const JEven
 	}
 
 
-	lockService->RootUnLock(); //RELEASE ROOT FILL LOCK
+	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK
 }
 
 //------------------

--- a/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
+++ b/src/plugins/monitoring/occupancy_online/JEventProcessor_occupancy_online.cc
@@ -97,7 +97,6 @@ void JEventProcessor_occupancy_online::Init()
 {
 	auto app = GetApplication();
 	lockService = app->GetService<JLockService>();
-	lockService->RootWriteLock();
 
 	// All histograms go in the "occupancy" directory
 	TDirectory *main = gDirectory;
@@ -292,8 +291,6 @@ void JEventProcessor_occupancy_online::Init()
 
 	// back to main dir
 	main->cd();
-  
-	lockService->RootUnLock();
 }
 
 //------------------

--- a/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.cc
+++ b/src/plugins/monitoring/pedestal_online/JEventProcessor_pedestal_online.cc
@@ -144,7 +144,7 @@ void JEventProcessor_pedestal_online::Process(const std::shared_ptr<const JEvent
 	event->Get(f125PIs);
 	
 	// Although we are only filling objects local to this plugin, the directory changes: Global ROOT lock
-	lockService->RootWriteLock();
+	lockService->RootFillLock(this);
 
 	if (peddir!=NULL) peddir->cd();
 	
@@ -336,7 +336,7 @@ void JEventProcessor_pedestal_online::Process(const std::shared_ptr<const JEvent
 
 	maindir->cd();
 	// Unlock ROOT
-	lockService->RootUnLock();
+	lockService->RootFillUnLock(this);
 }
 
 


### PR DESCRIPTION
Address issues pointed out in #845 but post-JANA2 port.  Mostly removes unneeded locks and uses finer grained ones.

More analysis is needed to hunt down remaining lock-related performance issues.