### PR TITLE
Fix Incorrect Handling of Tagged Factories in JANA2 Porting (hd_dump)

### DIFF
--- a/src/programs/Analysis/hd_dump/MyProcessor.cc
+++ b/src/programs/Analysis/hd_dump/MyProcessor.cc
@@ -55,7 +55,14 @@ void MyProcessor::BeginRun(const std::shared_ptr<const JEvent>& event)
 	cout << "Beginning run" << endl;
 	vector<string> factory_names;
 	for (auto factory : event->GetFactorySet()->GetAllFactories()) {
-		factory_names.push_back(factory->GetObjectName());
+		auto fac_name = factory->GetObjectName();
+		auto fac_tag = factory->GetTag();
+
+		if (!fac_tag.empty()) {
+			factory_names.push_back(fac_name + ":" + fac_tag);
+		} else {
+			factory_names.push_back(fac_name);
+		}
 	}
 
 	usleep(100000); //this just gives the Main thread a chance to finish printing the "Launching threads" message


### PR DESCRIPTION
In `hd_dump`, inside `MyProcessor::BeginRun` (JANA2) or `MyProcessor::brun` (JANA1), a vector `factory_names` is used to check user inputs. This list is expected to contain all available factories, including tagged ones.

In JANA1, this was handled using `GetFactoryNames`, which returned a list of strings where tagged factories were explicitly labeled with `fac_name:tag`:

```cpp
vector<string> factory_names;
eventLoop->GetFactoryNames(factory_names);
```

Example output:

```
{"DTAGHTDCDigiHit", "DTAGMHit", "DTAGMHit:Calib", "DTAGHHit", "DTAGHHit:Calib", "DTAGMHit:TRUTH", "DTAGHHit:TRUTH"}
```

In JANA2, there is no direct equivalent function. Instead, factory objects are retrieved using:

```cpp
event->GetFactorySet()->GetAllFactories()
```

which returns a list of `JFactory*` pointers instead of factory names:

```
{0x3cd3eb0, 0x3ca1ee0, 0x3c8f3e0, ...}
```

### **Issue**

During porting, an attempt was made to recreate `GetFactoryNames` by iterating over the factory set:

```cpp
vector<string> factory_names;
for (auto factory : event->GetFactorySet()->GetAllFactories()) {
    factory_names.push_back(factory->GetObjectName());
}
```

However, this caused the tag information to be lost, leading to the following issues:
- **Duplicate factory names caused conflicts** – for example, both `DTRDHit` and `DTRDHit:Calib` were stored as just `DTRDHit`, making it unclear which factory to use.
- **Missing factory warnings** – since tagged versions like `DTRDHit:Calib` were not included in the list, they were incorrectly being flagged as missing.
- **Objects for tagged factories were not created** – Objects are created only for the factories listed in `factory_names`, so the absence of entries like `DTRDHit:Calib`  was not only triggering warnings but was also resulting in the failure of creation of objects for those factories.
### **Fix Implemented**
To restore JANA1 behavior, the factory list now correctly includes tags when present:
```cpp
for (auto factory : event->GetFactorySet()->GetAllFactories()) {
    auto fac_name = factory->GetObjectName();
    auto fac_tag = factory->GetTag();

    if (!fac_tag.empty()) {
        factory_names.push_back(fac_name + ":" + fac_tag);
    } else {
        factory_names.push_back(fac_name);
    }
}
```

This ensures `hd_dump` correctly distinguishes between tagged and untagged factories, preventing collisions and restoring expected behavior.