### PR TITLE
Fix Memory Leak Due to `NOT_OBJECT_OWNER` Flag in `DBeamPhoton_factory`

### DIFF
--- a/src/libraries/ANALYSIS/DParticleComboCreator.cc
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.cc
@@ -66,7 +66,7 @@ void DParticleComboCreator::Reset(void)
 		cout << "Total # of Particle Combos Allocated (All threads): " << dResourcePool_ParticleCombo.Get_NumObjectsAllThreads() << endl;
 		cout << "Total # of Charged Hypos (All threads): " << dChargedTrackHypothesisFactory->Get_NumObjectsAllThreads() << endl;
 		cout << "Total # of Neutral Hypos (All threads): " << dNeutralParticleHypothesisFactory->Get_NumObjectsAllThreads() << endl;
-		cout << "Total # of Beam Photons (All threads): " << dBeamPhotonfactory->Get_NumObjectsAllThreads() << endl;
+		// cout << "Total # of Beam Photons (All threads): " << dBeamPhotonfactory->Get_NumObjectsAllThreads() << endl;
 		cout << "Total # of KinematicDatas (All threads): " << dResourcePool_KinematicData.Get_NumObjectsAllThreads() << endl;
 	}
 
@@ -88,7 +88,6 @@ void DParticleComboCreator::Reset(void)
 	dNeutralHypoMap.clear();
 	dKinFitNeutralHypoMap.clear();
 
-	dBeamPhotonfactory->Recycle_Resources(dCreated_BeamPhoton);
 	dKinFitBeamPhotonMap.clear();
 
 	dResourcePool_KinematicData.Recycle(dCreated_KinematicData);
@@ -99,7 +98,6 @@ void DParticleComboCreator::Reset(void)
 	decltype(dCreated_ParticleComboStep)().swap(dCreated_ParticleComboStep);
 	decltype(dCreated_ChargedHypo)().swap(dCreated_ChargedHypo);
 	decltype(dCreated_NeutralHypo)().swap(dCreated_NeutralHypo);
-	decltype(dCreated_BeamPhoton)().swap(dCreated_BeamPhoton);
 }
 
 bool DParticleComboCreator::Get_CreateNeutralErrorMatrixFlag_Combo(const DReactionVertexInfo* locReactionVertexInfo, DKinFitType locKinFitType)
@@ -647,8 +645,7 @@ const DBeamPhoton* DParticleComboCreator::Create_BeamPhoton_KinFit(const DBeamPh
 	if(locBeamIterator != dKinFitBeamPhotonMap.end())
 		return locBeamIterator->second;
 
-	DBeamPhoton* locNewBeamPhoton = dBeamPhotonfactory->Get_Resource();
-	dCreated_BeamPhoton.push_back(locNewBeamPhoton);
+	DBeamPhoton* locNewBeamPhoton = new DBeamPhoton();
 	dKinFitBeamPhotonMap.emplace(locKinFitParticle, locNewBeamPhoton);
 
 	locNewBeamPhoton->dCounter = locBeamPhoton->dCounter;

--- a/src/libraries/ANALYSIS/DParticleComboCreator.h
+++ b/src/libraries/ANALYSIS/DParticleComboCreator.h
@@ -99,7 +99,6 @@ class DParticleComboCreator
 		vector<DParticleComboStep*> dCreated_ParticleComboStep;
 		vector<DChargedTrackHypothesis*> dCreated_ChargedHypo;
 		vector<DNeutralParticleHypothesis*> dCreated_NeutralHypo;
-		vector<DBeamPhoton*> dCreated_BeamPhoton;
 
 		DParticleCombo* Get_ParticleComboResource(void)
 		{

--- a/src/libraries/PID/DBeamPhoton_factory.cc
+++ b/src/libraries/PID/DBeamPhoton_factory.cc
@@ -47,8 +47,6 @@ void DBeamPhoton_factory::Init()
     "Maximum energy difference in GeV between a TAGM-TAGH pair of beam photons"
     " for them to be merged into a single photon");
 
-	//Setting this flag makes it so that JANA does not delete the objects in _data.  This factory will manage this memory.
-	SetFactoryFlag(NOT_OBJECT_OWNER);
 }
 
 //------------------
@@ -71,9 +69,6 @@ void DBeamPhoton_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
 {
 	auto locEventNumber = event->GetEventNumber();
-	dResourcePool_BeamPhotons->Recycle(dCreated);
-	dCreated.clear();
-	mData.clear();
 
     vector<const DTAGMHit*> tagm_hits;
     event->Get(tagm_hits);
@@ -82,7 +77,7 @@ void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
     {
         if (!tagm_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
         if (tagm_hits[ih]->row > 0) continue; // Skip individual fiber readouts
-        DBeamPhoton* gamma = Get_Resource();
+		DBeamPhoton* gamma = new DBeamPhoton();
 
         Set_BeamPhoton(gamma, tagm_hits[ih], locEventNumber);
         Insert(gamma);
@@ -95,7 +90,7 @@ void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
     {
         if (!tagh_hits[ih]->has_fADC) continue; // Skip TDC-only hits (i.e. hits with no ADC info.)
         if (!tagh_hits[ih]->has_TDC) continue;  // Skip fADC-only hits (i.e. hits with no TDC info.)
-        DBeamPhoton* gamma = Get_Resource();
+		DBeamPhoton* gamma = new DBeamPhoton();
 
 	Set_BeamPhoton(gamma, tagh_hits[ih], locEventNumber);
         Insert(gamma);
@@ -103,7 +98,6 @@ void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
     }
 
 	sort(mData.begin(), mData.end(), DBeamPhoton_SortByTime);
-	dCreated = mData;
 }
 
 void DBeamPhoton_factory::Set_BeamPhoton(DBeamPhoton* gamma, const DTAGMHit* hit, uint64_t locEventNumber)

--- a/src/libraries/PID/DBeamPhoton_factory.h
+++ b/src/libraries/PID/DBeamPhoton_factory.h
@@ -19,24 +19,12 @@ class DBeamPhoton_factory:public JFactoryT<DBeamPhoton>
 	public:
 		DBeamPhoton_factory(void)
 		{
-			dResourcePool_BeamPhotons = new DResourcePool<DBeamPhoton>();
-			dResourcePool_BeamPhotons->Set_ControlParams(100, 20, 200, 500, 0);
 
 			dResourcePool_TMatrixFSym = std::make_shared<DResourcePool<TMatrixFSym>>();
 			dResourcePool_TMatrixFSym->Set_ControlParams(20, 20, 50);
 		}
 
-		void Recycle_Resources(vector<const DBeamPhoton*>& locBeams){dResourcePool_BeamPhotons->Recycle(locBeams);}
-		void Recycle_Resources(vector<DBeamPhoton*>& locBeams){dResourcePool_BeamPhotons->Recycle(locBeams);}
-		void Recycle_Resource(const DBeamPhoton* locBeam){dResourcePool_BeamPhotons->Recycle(locBeam);}
 
-		size_t Get_NumObjectsAllThreads(void) const{return dResourcePool_BeamPhotons->Get_NumObjectsAllThreads();}
-		DBeamPhoton* Get_Resource(void)
-		{
-			auto locBeam = dResourcePool_BeamPhotons->Get_Resource();
-			locBeam->Reset();
-			return locBeam;
-		}
 
 		void Init() override;
 		void BeginRun(const std::shared_ptr<const JEvent>& event) override;
@@ -45,17 +33,12 @@ class DBeamPhoton_factory:public JFactoryT<DBeamPhoton>
 		void Process(const std::shared_ptr<const JEvent>& event) override;
 		void Finish() override
 		{
-			for(auto locBeam : mData)
-				Recycle_Resource(locBeam);
-			mData.clear();
-			delete dResourcePool_BeamPhotons;
+			// OBJECT DELETION HANDLED BY JANA
 		}
 
 		double dTargetCenterZ;
 
 		//RESOURCE POOL
-		vector<DBeamPhoton*> dCreated;
-		DResourcePool<DBeamPhoton>* dResourcePool_BeamPhotons = nullptr;
 		shared_ptr<DResourcePool<TMatrixFSym>> dResourcePool_TMatrixFSym;
 
 		// config. parameters


### PR DESCRIPTION
The memory leak was caused by the `NOT_OBJECT_OWNER` flag being set in `DBeamPhoton_factory::Init()`. This flag informs JANA that the factory does not own its objects, preventing JANA from automatically deleting them.
```cpp
void DBeamPhoton_factory::Init()
{
    // Parameter initialization code
    SetFactoryFlag(NOT_OBJECT_OWNER);
}
```

### Object Deletion Handling
Deletion was managed inside `evnt` (JANA1) and `Process` (JANA2) as follows:
**JANA1 (`evnt` method):**

```cpp
jerror_t DBeamPhoton_factory::evnt(jana::JEventLoop *locEventLoop, uint64_t locEventNumber)
{
    dResourcePool_BeamPhotons->Recycle(dCreated);
    dCreated.clear();
    _data.clear();
    
    // Other factory code inserting objects into _data
    dCreated = _data;

    return NOERROR;
}
```

**JANA2 (`Process` method):**

```cpp
void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
{
    auto locEventNumber = event->GetEventNumber();
    dResourcePool_BeamPhotons->Recycle(dCreated);
    dCreated.clear();
    mData.clear();

    // Other factory code inserting objects into mData
    dCreated = mData;
}
```

This approach works **only if** the factory is creating the objects. In such cases, `Process` or `evnt` will always be called, ensuring proper recycling of objects before clearing `_data` (JANA1) or `mData` (JANA2).

### Problem: Objects Not Getting Deleted
However, the issue arises when objects are **read from a source** and directly inserted into the factory, bypassing `Process` or `evnt`.
Since the factory flag was set to `NOT_OBJECT_OWNER`, calling `ClearData` or `HardReset` on `JFactorySet` only cleared `_data` or `mData` vectors but **did not delete the actual objects**. This led to a memory leak, as only the pointers were removed, while the underlying objects remained allocated.
#### Why Did It Work in JANA1?
In JANA1, this issue **did not appear** due to a bug: `init` was never called if objects were obtained solely from the source using `GetObjects`.
- As a result, `NOT_OBJECT_OWNER` was **never set**.
- The factory retained its **default flag**, which assumes JANA is responsible for object deletion.
- When `HardReset` was called before the next `GetObjects` call, JANA automatically deleted the objects.
In contrast, **JANA2 always calls `Init` for a factory**, even when data is sourced externally. This means `NOT_OBJECT_OWNER` was **always set**, leading to a situation where objects were never deleted—only the vector pointers were cleared.

#### Behavior in `HardReset` (JANA1)
```cpp
template<class T>
jerror_t JFactory<T>::HardReset(void)
{
    /// Clear out the factory's current contents.
    if (!TestFactoryFlag(NOT_OBJECT_OWNER)) {
        for (unsigned int i = 0; i < _data.size(); i++) {
            delete _data[i];
        }
    }
    _data.clear();
    evnt_called = 0;

    return NOERROR;
}
```

Here, `TestFactoryFlag(NOT_OBJECT_OWNER)` **returns false** in JANA1 when objects are read from a source, meaning the flag was never set. This allowed JANA to delete objects properly.
#### Behavior in `ClearData` (JANA2)

```cpp
void ClearData() override
{
    // Skip if Init() hasn't been called
    if (mStatus == Status::Uninitialized) {
        return;
    }

    // Skip if persistent flag is set (manual recycling required)
    if (TestFactoryFlag(JFactory_Flags_t::PERSISTENT)) {
        return;
    }

    // Delete objects if we are the owner
    if (!TestFactoryFlag(JFactory_Flags_t::NOT_OBJECT_OWNER)) {
        for (auto p : mData) delete p;
    }

    mData.clear();
    mStatus = Status::Unprocessed;
    mCreationStatus = CreationStatus::NotCreatedYet;
}
```

Here, `TestFactoryFlag(JFactory_Flags_t::NOT_OBJECT_OWNER)` **returned true**, confirming that `Init` was called, and the flag was set. This led to **only vector clearing, without object deletion**, causing a memory leak.

### Observed Memory Leak
The memory leak was confirmed through profiling. The following graph from JANA2 shows a **steady memory increase** due to objects not being deleted:

![Memory Leak Graph](https://i.imgur.com/ZNVEBMK.png)

### Fix: Removing `NOT_OBJECT_OWNER` Flag
To verify if `NOT_OBJECT_OWNER` was causing the issue, we **commented out** `SetFactoryFlag(NOT_OBJECT_OWNER)`. This resulted in proper memory management, as seen in the corrected graph:

![Fixed Memory Graph](https://i.imgur.com/wcA6OU6.png)

### Final Solution

Since the only intent behind `NOT_OBJECT_OWNER` was to optimize memory allocation using `dResourcePool`, we **removed the factory flag** and **stopped using `dResourcePool`**. Instead, we now rely on JANA’s default object management.

#### **Before (with memory leak)**

```cpp
void DBeamPhoton_factory::Init()
{
    // Parameter initialization code
    SetFactoryFlag(NOT_OBJECT_OWNER);
}
```

```cpp
void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
{
    auto locEventNumber = event->GetEventNumber();
    dResourcePool_BeamPhotons->Recycle(dCreated);
    dCreated.clear();
    mData.clear();

    // Factory code inserting objects into mData
    dCreated = mData;
}
```

#### **After (fixed)**

```cpp
void DBeamPhoton_factory::Init()
{
    // Parameter initialization code
}
```

```cpp
void DBeamPhoton_factory::Process(const std::shared_ptr<const JEvent>& event)
{
    // Factory code inserting objects into mData
}
```

### Takeaways for Future Development
1. **If setting `NOT_OBJECT_OWNER`, ensure explicit object deletion.**
    - `Process` **may not be called** when reading objects from a source.
    - Delete objects in `Source::FinishEvent` or another function that runs after every event.
2. **If you need to clear `mData` after every event, avoid setting `NOT_OBJECT_OWNER`.**
    - Let JANA manage object deletion through `ClearData`.


