### PR TITLE
When expecting fa125 continuation word but not finding one, break fro…

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -1766,6 +1766,7 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					}
 					if( ((*iptr>>31) & 0x1) != 0 ){
 						jerr << " Truncated f125 CDC hit (missing continuation word!)" << endl;
+						--iptr;
 						continue;
 					}
 					uint32_t word2      = *iptr;
@@ -1820,11 +1821,12 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					      ++iptr;
 					      if(iptr>=iend){
 						    jerr << " Truncated f125 FDC hit (block ends before continuation word!)" << endl;
-						    continue;
+						    break;
 					      }
 					      if( ((*iptr>>31) & 0x1) != 0 ){
-						    jerr << " Truncated f125 FDC hit (missing continuation word!)" << endl;
-						    continue;
+						    jerr << " Truncated f125 FDC hit (missing continuation word) from rocid=" << rocid << " slot=" << slot << " chan=" << channel << " pulse_number="<<pulse_number << endl;
+						    --iptr; 
+						    break;
 					      }
 					      uint32_t word2      = *iptr;
 					      uint32_t pulse_peak = 0;
@@ -1909,11 +1911,12 @@ void DEVIOWorkerThread::Parsef125Bank(uint32_t rocid, uint32_t* &iptr, uint32_t 
 					      ++iptr;
 					      if(iptr>=iend){
 						    jerr << " Truncated f125 FDC hit (block ends before continuation word!)" << endl;
-						    continue;
+						    break;
 					      }
-					      if( ((*iptr>>31) & 0x1) != 0 ){
-						    jerr << " Truncated f125 FDC hit (missing continuation word!)" << endl;
-						    continue;
+					      if( ((*iptr>>31) & 0x1) != 0 ){						 
+ 						    jerr << " Truncated f125 FDC hit (missing continuation word) from rocid=" << rocid << " slot=" << slot << " chan=" << channel << " pulse_number="<<pulse_number << endl;
+						    --iptr;
+						    break;
 					      }
 					      uint32_t word2      = *iptr;
 					      uint32_t pulse_peak = (*iptr>>19) & 0xFFF;


### PR DESCRIPTION
…m the npk loop if in it, and step the pointer back by 1.    

This fixes [@alfab3 's issue 898](https://github.com/JeffersonLab/halld_recon/issues/898).   

