### PR TITLE
Add CCDB tables to control which detectors are used in different run periods

### DIFF
--- a/src/libraries/CCAL/DCCALGeometry_factory.h
+++ b/src/libraries/CCAL/DCCALGeometry_factory.h
@@ -9,7 +9,10 @@
 #define _DCCALGeometry_factory_
 
 #include <JANA/JFactoryT.h>
+#include <DANA/DEvent.h>
 #include "DCCALGeometry.h"
+#include <map>
+
 
 class DCCALGeometry_factory:public JFactoryT<DCCALGeometry>{
 	public:
@@ -17,6 +20,7 @@ class DCCALGeometry_factory:public JFactoryT<DCCALGeometry>{
 		~DCCALGeometry_factory(){};
 
 		DCCALGeometry *ccalgeometry = nullptr;
+		bool INSTALLED = true;
 
 		//------------------
 		// BeginRun
@@ -26,7 +30,16 @@ class DCCALGeometry_factory:public JFactoryT<DCCALGeometry>{
 			// (See DTAGHGeometry_factory.h)
 			SetFactoryFlag(NOT_OBJECT_OWNER);
 			ClearFactoryFlag(WRITE_TO_OUTPUT);
-			
+
+			map<string,string> installed;
+			DEvent::GetCalib(event, "/CCAL/install_status", installed);
+			if(atoi(installed["status"].data()) == 0)
+				INSTALLED = false;
+			else
+				INSTALLED = true;
+				
+			if(!INSTALLED) return;
+
 			delete ccalgeometry;
 			ccalgeometry = new DCCALGeometry();
 		}
@@ -36,6 +49,8 @@ class DCCALGeometry_factory:public JFactoryT<DCCALGeometry>{
 		//------------------
 		 void Process(const std::shared_ptr<const JEvent>& event) override
 		 {
+			if(!INSTALLED) return;
+
 			// Reuse existing DBCALGeometry object.
 			if( ccalgeometry ) Insert( ccalgeometry );
 		 }

--- a/src/libraries/CCAL/DCCALHit_factory.cc
+++ b/src/libraries/CCAL/DCCALHit_factory.cc
@@ -21,6 +21,7 @@ using namespace std;
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
 
+#include "DANA/DEvent.h"
 
 //----------------
 // Constructor
@@ -64,6 +65,8 @@ void DCCALHit_factory::Init()
     
     base_time  = 0;
     
+    INSTALLED = false;
+    
 }
 
 //------------------
@@ -71,6 +74,15 @@ void DCCALHit_factory::Init()
 //------------------
 void DCCALHit_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/CCAL/install_status", installed);
+	if(atoi(installed["status"].data()) == 0)
+		INSTALLED = false;
+	else
+		INSTALLED = true;
+		
+	if(!INSTALLED) return;
+
 	auto runnumber = event->GetRunNumber();
 	auto app = event->GetJApplication();
 	auto calibration = app->GetService<JCalibrationManager>()->GetJCalibration(runnumber);
@@ -209,6 +221,7 @@ void DCCALHit_factory::Process(const std::shared_ptr<const JEvent>& event)
     /// data in HDDM format. The HDDM event source will copy
     /// the precalibrated values directly into the _data vector.
 
+	if(!INSTALLED) return;
 
     // extract the CCAL Geometry
     vector<const DCCALGeometry*> ccalGeomVect;

--- a/src/libraries/CCAL/DCCALHit_factory.h
+++ b/src/libraries/CCAL/DCCALHit_factory.h
@@ -45,6 +45,8 @@ class DCCALHit_factory:public JFactoryT<DCCALHit>{
 			const vector<double> &ccal_const_ch, 
 			const DCCALGeometry  &ccalGeom);    
 		
+  		bool INSTALLED;
+
 		unsigned int DB_PEDESTAL;
 		unsigned int HIT_DEBUG;
 		

--- a/src/libraries/CCAL/DCCALShower_factory.cc
+++ b/src/libraries/CCAL/DCCALShower_factory.cc
@@ -11,6 +11,7 @@
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
 #include "DANA/DGeometryManager.h"
+#include <DANA/DEvent.h>
 #include "HDGEOMETRY/DGeometry.h"
 
 static mutex CCAL_MUTEX;
@@ -86,6 +87,12 @@ void DCCALShower_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
     auto jcalib = calib_man->GetJCalibration(runnumber);
     auto geo_manager = app->GetService<DGeometryManager>();
     auto geom = geo_manager->GetDGeometry(runnumber);
+
+	// check to see if the detector is install - don't load anything if it's not
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/CCAL/install_status", installed);
+	if(atoi(installed["status"].data()) == 0)
+		return;
 
     // Only print messages for one thread whenever run number change
     static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/libraries/DIRC/DDIRCPmtHit_factory.cc
+++ b/src/libraries/DIRC/DDIRCPmtHit_factory.cc
@@ -14,6 +14,7 @@ using namespace std;
 
 #include <JANA/JEvent.h>
 #include <JANA/Calibrations/JCalibrationManager.h>
+#include <DANA/DEvent.h>
 
 
 //------------------
@@ -45,6 +46,14 @@ void DDIRCPmtHit_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 	auto runnumber = event->GetRunNumber();
 	auto app = event->GetJApplication();
 	auto calibration = app->GetService<JCalibrationManager>()->GetJCalibration(runnumber);
+
+	// check to see if the detector is install - don't load anything if it's not
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/DIRC/install_status", installed);
+	if(atoi(installed["status"].data()) == 0) {
+		DIRC_SKIP = true;
+		return;
+	}
 
 	// Only print messages for one thread whenever run number change
 	static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/libraries/ECAL/DECALHit_factory.cc
+++ b/src/libraries/ECAL/DECALHit_factory.cc
@@ -78,6 +78,8 @@ void DECALHit_factory::Init(void)
     
     base_time  = 0;
     
+    INSTALLED = false;
+    
 
     return; //NOERROR;
 }
@@ -87,6 +89,15 @@ void DECALHit_factory::Init(void)
 //------------------
 void DECALHit_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/ECAL/install_status", installed);
+	if(atoi(installed["status"].data()) == 0)
+		INSTALLED = false;
+	else
+		INSTALLED = true;
+		
+	if(!INSTALLED) return;
+
     // Only print messages for one thread whenever run number change
     static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
     int runnumber = event->GetRunNumber();
@@ -215,6 +226,8 @@ void DECALHit_factory::Process(const std::shared_ptr<const JEvent>& event)
     /// Note that this code does NOT get called for simulated
     /// data in HDDM format. The HDDM event source will copy
     /// the precalibrated values directly into the _data vector.
+
+	if(!INSTALLED) return;
 
     vector<const DECALDigiHit*> digihits;
 

--- a/src/libraries/ECAL/DECALHit_factory.h
+++ b/src/libraries/ECAL/DECALHit_factory.h
@@ -59,6 +59,8 @@ public:
 
   unsigned int DB_PEDESTAL;
   unsigned int HIT_DEBUG;
+  
+  bool INSTALLED;
 
   bool   m_activeBlock[kECALBlocksTall][kECALBlocksWide];
   int    m_channelNumber[kECALBlocksTall][kECALBlocksWide];

--- a/src/libraries/FMWPC/DCTOFHit_factory.cc
+++ b/src/libraries/FMWPC/DCTOFHit_factory.cc
@@ -33,6 +33,9 @@ void DCTOFHit_factory::Init()
   t_scale    = 0.0625;   // 62.5 ps/count
   t_base_adc = 0.;       // ns
   t_base_tdc = 0.; // ns
+
+  INSTALLED = false;
+    
 }
 
 //------------------
@@ -40,6 +43,15 @@ void DCTOFHit_factory::Init()
 //------------------
 void DCTOFHit_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/CTOF/install_status", installed);
+	if(atoi(installed["status"].data()) == 0)
+		INSTALLED = false;
+	else
+		INSTALLED = true;
+		
+	if(!INSTALLED) return;
+
   // load base time offset
   map<string,double> base_time_offset;
   if ((GetCalib(event,"/CTOF/adc_base_time_offset",base_time_offset))==false){
@@ -60,6 +72,8 @@ void DCTOFHit_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 //------------------
 void DCTOFHit_factory::Process(const std::shared_ptr<const JEvent>& event)
 {   
+  if(!INSTALLED) return;
+
   const DTTabUtilities* locTTabUtilities = NULL;
   event->GetSingle(locTTabUtilities);
   

--- a/src/libraries/FMWPC/DCTOFHit_factory.h
+++ b/src/libraries/FMWPC/DCTOFHit_factory.h
@@ -23,6 +23,8 @@ class DCTOFHit_factory:public JFactoryT<DCTOFHit>{
   void EndRun() override;
   void Finish() override;
 
+  bool INSTALLED;
+
   double DELTA_T_ADC_TDC_MAX;
   double t_base_adc,t_base_tdc,t_scale;
   vector<double>adc_time_offsets,tdc_time_offsets,adc2E;

--- a/src/libraries/FMWPC/DCTOFPoint_factory.cc
+++ b/src/libraries/FMWPC/DCTOFPoint_factory.cc
@@ -18,6 +18,7 @@ using namespace std;
 #include "DCTOFPoint_factory.h"
 #include "DCTOFHit.h"
 #include "HDGEOMETRY/DGeometry.h"
+#include "DANA/DEvent.h"
 
 //------------------
 // Init
@@ -31,6 +32,9 @@ void DCTOFPoint_factory::Init()
 //------------------
 void DCTOFPoint_factory::BeginRun(const std::shared_ptr<const JEvent> &event)
 {
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/CTOF/install_status", installed);
+
   ATTENUATION_LENGTH=400.;
   LIGHT_PROPAGATION_SPEED=15.; // cm/ns
   THRESHOLD=0.0005; // GeV
@@ -41,6 +45,7 @@ void DCTOFPoint_factory::BeginRun(const std::shared_ptr<const JEvent> &event)
   auto geoman = app->GetService<DGeometryManager>();
   const DGeometry *geom = geoman->GetDGeometry(runnumber);
   geom->GetCTOFPositions(ctof_positions);
+
 }
 
 //------------------

--- a/src/libraries/FMWPC/DFMWPCCluster_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCCluster_factory.cc
@@ -50,6 +50,9 @@ void DFMWPCCluster_factory::Init()
 //------------------
 void DFMWPCCluster_factory::BeginRun(const std::shared_ptr<const JEvent> &event)
 {
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/FMWPC/install_status", installed);
+	if(atoi(installed["status"].data()) == 0) return;
 
   // Get pointer to DGeometry object
   dgeom  = DEvent::GetDGeometry(event);

--- a/src/libraries/FMWPC/DFMWPCHit_factory.cc
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.cc
@@ -47,6 +47,9 @@ void DFMWPCHit_factory::Init()
   amp_a_scale = a_scale*28.8;
   t_scale = 8.0/10.0;    // 8 ns/count and integer time is in 1/10th of sample
   t_base  = 0.;       // ns
+
+  INSTALLED = false;
+    
 }
 
 //------------------
@@ -54,6 +57,16 @@ void DFMWPCHit_factory::Init()
 //------------------
 void DFMWPCHit_factory::BeginRun(const std::shared_ptr<const JEvent> &event)
 {
+  map<string,string> installed;
+  DEvent::GetCalib(event, "/FMWPC/install_status", installed);
+  if(atoi(installed["status"].data()) == 0)
+	INSTALLED = false;
+  else
+	INSTALLED = true;
+	
+  if(!INSTALLED) return;
+
+
   auto runnumber = event->GetRunNumber();
   auto app = GetApplication();
   // Only print messages for one thread whenever run number change
@@ -199,6 +212,8 @@ void DFMWPCHit_factory::Process(const std::shared_ptr<const JEvent> &event)
   /// data in HDDM format. The HDDM event source will copy
   /// the precalibrated values directly into the _data vector.
   
+  if(!INSTALLED) return;
+
   /// In order to use the new Flash125 data types and maintain compatibility with the old code, what is below is a bit of a mess
 
   vector<const DFMWPCDigiHit*> digihits;

--- a/src/libraries/FMWPC/DFMWPCHit_factory.h
+++ b/src/libraries/FMWPC/DFMWPCHit_factory.h
@@ -62,6 +62,8 @@ class DFMWPCHit_factory:public JFactoryT<DFMWPCHit>{
 
   //void FillCalibTable(vector< vector<double> > &table, vector<double> &raw_table);
   
+  bool INSTALLED;
+
   // Geometry information
   unsigned int maxChannels;
   unsigned int Nlayers; // number of layers

--- a/src/libraries/TRD/DTRDHit_factory_Calib.cc
+++ b/src/libraries/TRD/DTRDHit_factory_Calib.cc
@@ -53,6 +53,15 @@ void DTRDHit_factory_Calib::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
 	auto runnumber = event->GetRunNumber();
 
+	map<string,string> installed;
+	DEvent::GetCalib(event, "/ECAL/install_status", installed);
+	if(atoi(installed["status"].data()) == 0)
+		INSTALLED = false;
+	else
+		INSTALLED = true;
+		
+	if(!INSTALLED) return;
+
 	// Only print messages for one thread whenever run number change
 	static pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
 	static set<int> runs_announced;
@@ -124,6 +133,8 @@ void DTRDHit_factory_Calib::Process(const std::shared_ptr<const JEvent>& event)
     /// Note that this code does NOT get called for simulated
     /// data in HDDM format. The HDDM event source will copy
     /// the precalibrated values directly into the _data vector.
+
+	if(!INSTALLED) return;
 
     vector<const DTRDDigiHit*> digihits;
     event->Get(digihits);

--- a/src/libraries/TRD/DTRDHit_factory_Calib.cc
+++ b/src/libraries/TRD/DTRDHit_factory_Calib.cc
@@ -54,7 +54,7 @@ void DTRDHit_factory_Calib::BeginRun(const std::shared_ptr<const JEvent>& event)
 	auto runnumber = event->GetRunNumber();
 
 	map<string,string> installed;
-	DEvent::GetCalib(event, "/ECAL/install_status", installed);
+	DEvent::GetCalib(event, "/TRD/install_status", installed);
 	if(atoi(installed["status"].data()) == 0)
 		INSTALLED = false;
 	else

--- a/src/libraries/TRD/DTRDHit_factory_Calib.h
+++ b/src/libraries/TRD/DTRDHit_factory_Calib.h
@@ -41,6 +41,8 @@ class DTRDHit_factory_Calib:public JFactoryT<DTRDHit>{
 		void Process(const std::shared_ptr<const JEvent>& event) override;
 		void EndRun() override;
 		void Finish() override;
+		
+		bool INSTALLED;
 
 };
 


### PR DESCRIPTION
Addresses issue #814 

I tried running over a few different run periods, and they seemed to work.  I did get an occasional crash for 2022-05, but this seemed to have to do with some unrelated geometry issue?  Might be good to get an independent check on this.
