### PR TITLE
Fix #911 - Program crashing with multiple evio input files

### DIFF
--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -50,7 +50,12 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(std::string source_name):JEventSource(s
     SetTypeName(NAME_OF_THIS);
 	EnableGetObjects(true);  // Check the source first for existing objects; only invoke the factory to create them if they aren't found in the source.
 	EnableFinishEvent(true); // Ensure ::FinishEvent gets called. By default, it is disabled (false).
+}
 
+//----------------
+// Open
+//----------------
+void JEventSource_EVIOpp::Open() {
 	DONE = false;
 	DISPATCHER_END = false;
 	NEVENTS_PROCESSED = 0;
@@ -58,6 +63,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(std::string source_name):JEventSource(s
 	NEVENTBUFF_STALLED   = 0;
 	NPARSER_STALLED      = 0;
 
+	auto source_name = GetResourceName();
 	// Initialize dedicated logger
 	evioout.SetGroup("EVIO");
 	evioout.ShowTimestamp(true);
@@ -258,7 +264,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(std::string source_name):JEventSource(s
 
 	// Record start time
 	tstart = high_resolution_clock::now();
-
+	
 }
 
 //----------------
@@ -266,7 +272,7 @@ JEventSource_EVIOpp::JEventSource_EVIOpp(std::string source_name):JEventSource(s
 //----------------
 JEventSource_EVIOpp::~JEventSource_EVIOpp()
 {
-	// Set DONE flag to tell dispatcher thread to quit
+		// Set DONE flag to tell dispatcher thread to quit
 	// as well as anyone in a wait state
 	DONE = true;
 	PARSED_EVENTS_CV.notify_all();

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -121,13 +121,12 @@ class JEventSource_EVIOpp: public JEventSource{
 
 		                    JEventSource_EVIOpp(std::string source_name);
 		           virtual ~JEventSource_EVIOpp();
-		virtual const char* className(void){return static_className();}
-		 static const char* static_className(void){return "JEventSource_EVIOpp";}
-		
+				  
 		               void Dispatcher(void);
 		           jerror_t SkipEVIOBlocks(uint32_t N);
 		
-		           void GetEvent(std::shared_ptr<JEvent> event) override;
+		           void Open(); // called when JANA is ready to accept events from this event source
+				   void GetEvent(std::shared_ptr<JEvent> event) override;
 		               void FinishEvent(JEvent &event) override;
 		           bool GetObjects(const std::shared_ptr<const JEvent> &event, JFactory* factory) override;
 


### PR DESCRIPTION
### **Issue Overview**
The issue arose due to a difference in how **JANA1** and **JANA2** handle multiple event sources. In **JANA1**, an event source for the next file was only created once the previous file had been read and its associated event source had been closed. However, in **JANA2**, all event sources are instantiated at the start to set parameters during the initialization phase. This means that if **76 input files** are provided, **76 event sources** are created upfront.
### **Problem Cause**
The **EVIOpp event source** creates additional threads (4 default threads per event source) within its constructor. In **JANA2**, since all event sources for the input files are instantiated during the initialization phase, creating **76 event sources** for **76 input files** resulted in the launch of **4 x 76 threads**, in addition to the processing threads. Most of these threads were sitting idle, as only one event source is active at any given time. However, the large number of threads led to significant memory consumption, causing system crashes. The event source initialization code in **JANA2**:
```cpp
void JComponentManager::resolve_event_sources() {
    m_user_evt_src_gen = resolve_user_event_source_generator();

    for (auto& source_name : m_src_names) {
        auto* generator = resolve_event_source(source_name);
        auto source = generator->MakeJEventSource(source_name);
        source->SetPluginName(generator->GetPluginName());
        source->SetApplication(GetApplication());
        m_evt_srces.push_back(source);
    }

    for (auto source : m_evt_srces) {
        if (source->GetNSkip() == 0) source->SetNSkip(m_nskip);
        if (source->GetNEvents() == 0) source->SetNEvents(m_nevents);
    }
}
```
### **Solution**
To resolve this issue, the code inside the **EVIOpp event source** constructor has been moved to the newly introduced `::Open` function in **JANA2**. The `::Open` function is called only when JANA is ready to read events from the attached source, which ensures that threads are only launched when the event source is actually processing data. This approach prevents threads from being created during the initialization of the event sources.

With this change, threads are now created **only when the event source starts reading data** from the input files, instead of when event sources are created for all files. Furthermore, the threads launched by the event source exit when the event source reaches the end of the file. As a result, only **4 EVIO threads** are active at any given time, instead of **4 x (number of input files)**, significantly reducing the total number of threads in use.
### **Outcome**
This modification prevents the creation of an excessive number of threads, which in turn reduces memory consumption and prevents crashes caused by memory exhaustion. Now, only the necessary threads are created as each event source is processed, leading to improved memory usage and system stability.