### PR TITLE
add option to skip DIRC SSP parsing error

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -91,6 +91,7 @@ class DEVIOWorkerThread{
 		bool  PARSE_EVENTTAG;
 		bool  PARSE_TRIGGER;
 		bool  PARSE_SSP;
+	        bool  SKIP_SSP_FORMAT_ERROR;
 		bool  PARSE_GEMSRS;
                 int   NSAMPLES_GEMSRS;
 

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -101,6 +101,7 @@ void JEventSource_EVIOpp::Open() {
 	PARSE_EVENTTAG = true;
 	PARSE_TRIGGER = true;
 	PARSE_SSP = true;
+	SKIP_SSP_FORMAT_ERROR = false;
 	PARSE_GEMSRS = false;
         NSAMPLES_GEMSRS = 9;
 	APPLY_TRANSLATION_TABLE = true;
@@ -148,6 +149,7 @@ void JEventSource_EVIOpp::Open() {
 	japp->SetDefaultParameter("EVIO:PARSE_EVENTTAG", PARSE_EVENTTAG, "Set this to 0 to disable parsing of event tag data in the data stream (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:PARSE_TRIGGER", PARSE_TRIGGER, "Set this to 0 to disable parsing of the built trigger bank from CODA (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:PARSE_SSP", PARSE_SSP, "Set this to 0 to disable parsing of the SSP (DIRC data) bank from CODA (for benchmarking/debugging)");
+	japp->SetDefaultParameter("EVIO:SKIP_SSP_FORMAT_ERROR", SKIP_SSP_FORMAT_ERROR, "Set this to 1 to skip SSP format errors (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:PARSE_GEMSRS", PARSE_GEMSRS, "Set this to 0 to disable parsing of the SRS (GEM data) bank from CODA (for benchmarking/debugging)");
   japp->SetDefaultParameter("EVIO:NSAMPLES_GEMSRS", NSAMPLES_GEMSRS, "Set this to number of readout samples for SRS (GEM data) bank from CODA (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:APPLY_TRANSLATION_TABLE", APPLY_TRANSLATION_TABLE, "Apply the translation table to create DigiHits (you almost always want this on)");
@@ -238,6 +240,7 @@ void JEventSource_EVIOpp::Open() {
 		w->PARSE_EVENTTAG      = PARSE_EVENTTAG;
 		w->PARSE_TRIGGER       = PARSE_TRIGGER;
 		w->PARSE_SSP           = PARSE_SSP;
+		w->SKIP_SSP_FORMAT_ERROR = SKIP_SSP_FORMAT_ERROR;
 		w->PARSE_GEMSRS        = PARSE_GEMSRS;
                 w->NSAMPLES_GEMSRS     = NSAMPLES_GEMSRS;
 		w->LINK_TRIGGERTIME    = LINK_TRIGGERTIME;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -198,6 +198,7 @@ class JEventSource_EVIOpp: public JEventSource{
 		bool     PARSE_EVENTTAG;
 		bool     PARSE_TRIGGER;
 		bool     PARSE_SSP;
+	        bool     SKIP_SSP_FORMAT_ERROR;
 		bool     PARSE_GEMSRS;
                 int      NSAMPLES_GEMSRS;
 		bool     APPLY_TRANSLATION_TABLE;


### PR DESCRIPTION
Added command line option to skip SSP format error, similar to other modules as discussed in issue https://github.com/JeffersonLab/halld_recon/issues/920