### PR TITLE
Fix error handling in helicity board decoding

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -72,6 +72,7 @@ DEVIOWorkerThread::DEVIOWorkerThread(
 	PARSE_TRIGGER       = true;
 	PARSE_SSP           = true;
 	PARSE_GEMSRS        = true;
+	PARSE_HELICITY      = true;
         NSAMPLES_GEMSRS     = 9;
 	
 	LINK_TRIGGERTIME    = true;
@@ -1402,7 +1403,7 @@ void DEVIOWorkerThread::ParseJLabModuleData(uint32_t rocid, uint32_t* &iptr, uin
 //----------------
 void DEVIOWorkerThread::ParseHelicityDecoderBank(uint32_t rocid, uint32_t* &iptr, uint32_t *iend)
 {
-	//if(!PARSE_F250){ iptr = &iptr[(*iptr) + 1]; return; }
+	if(!PARSE_HELICITY){ iptr = &iptr[(*iptr) + 1]; return; }
 
 	auto pe_iter = current_parsed_events.begin();
 	DParsedEvent *pe = NULL;
@@ -1463,8 +1464,8 @@ void DEVIOWorkerThread::ParseHelicityDecoderBank(uint32_t rocid, uint32_t* &iptr
 					if(VERBOSE>7) cout << "      Helicity Decoder Data Header (0x"<<hex<<*iptr<<dec<<") header reserved=" << header_reserved << " header number words="<<header_number_words <<endl;
 					
 					// sanity checks
-					if(header_reserved != 0x18)  { jerr << "Bad helicity decoder header for rocid="<<rocid<<" slot="<<slot<<endl; throw JException("Bad helicity decoder header data", __FILE__, __LINE__);}
-					if(header_number_words != 14)  { jerr << "Bad helicity decoder header for rocid="<<rocid<<" slot="<<slot<<endl; throw JException("Bad helicity decoder header payload", __FILE__, __LINE__);}
+					if(header_reserved != 0x18)  { jerr << "Bad helicity decoder header for rocid="<<rocid<<" slot="<<slot<<endl; throw JExceptionDataFormat("Bad helicity decoder header data", __FILE__, __LINE__);}
+					if(header_number_words != 14)  { jerr << "Bad helicity decoder header for rocid="<<rocid<<" slot="<<slot<<endl; throw JExceptionDataFormat("Bad helicity decoder header payload", __FILE__, __LINE__);}
 
 					iptr++;
 					

--- a/src/libraries/DAQ/DEVIOWorkerThread.h
+++ b/src/libraries/DAQ/DEVIOWorkerThread.h
@@ -92,6 +92,7 @@ class DEVIOWorkerThread{
 		bool  PARSE_TRIGGER;
 		bool  PARSE_SSP;
 		bool  PARSE_GEMSRS;
+		bool  PARSE_HELICITY;
                 int   NSAMPLES_GEMSRS;
 
 		bool  LINK_TRIGGERTIME;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -102,6 +102,7 @@ void JEventSource_EVIOpp::Open() {
 	PARSE_TRIGGER = true;
 	PARSE_SSP = true;
 	PARSE_GEMSRS = false;
+	PARSE_HELICITY = false;
         NSAMPLES_GEMSRS = 9;
 	APPLY_TRANSLATION_TABLE = true;
 	IGNORE_EMPTY_BOR = false;
@@ -149,6 +150,7 @@ void JEventSource_EVIOpp::Open() {
 	japp->SetDefaultParameter("EVIO:PARSE_TRIGGER", PARSE_TRIGGER, "Set this to 0 to disable parsing of the built trigger bank from CODA (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:PARSE_SSP", PARSE_SSP, "Set this to 0 to disable parsing of the SSP (DIRC data) bank from CODA (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:PARSE_GEMSRS", PARSE_GEMSRS, "Set this to 0 to disable parsing of the SRS (GEM data) bank from CODA (for benchmarking/debugging)");
+	japp->SetDefaultParameter("EVIO:PARSE_HELICITY", PARSE_HELICITY, "Set this to 0 to disable parsing of the helicity decoder bank from CODA (for benchmarking/debugging)");
   japp->SetDefaultParameter("EVIO:NSAMPLES_GEMSRS", NSAMPLES_GEMSRS, "Set this to number of readout samples for SRS (GEM data) bank from CODA (for benchmarking/debugging)");
 	japp->SetDefaultParameter("EVIO:APPLY_TRANSLATION_TABLE", APPLY_TRANSLATION_TABLE, "Apply the translation table to create DigiHits (you almost always want this on)");
 	japp->SetDefaultParameter("EVIO:IGNORE_EMPTY_BOR", IGNORE_EMPTY_BOR, "Set to non-zero to continue processing data even if an empty BOR event is encountered.");

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -241,6 +241,7 @@ void JEventSource_EVIOpp::Open() {
 		w->PARSE_TRIGGER       = PARSE_TRIGGER;
 		w->PARSE_SSP           = PARSE_SSP;
 		w->PARSE_GEMSRS        = PARSE_GEMSRS;
+		w->PARSE_HELICITY      = PARSE_HELICITY;
                 w->NSAMPLES_GEMSRS     = NSAMPLES_GEMSRS;
 		w->LINK_TRIGGERTIME    = LINK_TRIGGERTIME;
 		w->LINK_CONFIG         = LINK_CONFIG;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.cc
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.cc
@@ -102,7 +102,7 @@ void JEventSource_EVIOpp::Open() {
 	PARSE_TRIGGER = true;
 	PARSE_SSP = true;
 	PARSE_GEMSRS = false;
-	PARSE_HELICITY = false;
+	PARSE_HELICITY = true;
         NSAMPLES_GEMSRS = 9;
 	APPLY_TRANSLATION_TABLE = true;
 	IGNORE_EMPTY_BOR = false;

--- a/src/libraries/DAQ/JEventSource_EVIOpp.h
+++ b/src/libraries/DAQ/JEventSource_EVIOpp.h
@@ -199,6 +199,7 @@ class JEventSource_EVIOpp: public JEventSource{
 		bool     PARSE_TRIGGER;
 		bool     PARSE_SSP;
 		bool     PARSE_GEMSRS;
+		bool     PARSE_HELICITY;
                 int      NSAMPLES_GEMSRS;
 		bool     APPLY_TRANSLATION_TABLE;
 		int      ET_STATION_NEVENTS;


### PR DESCRIPTION
- throw JExceptionDataFormat exception in case of data decoding error
- add in EVIO:PARSE_HELICITY switch for skipping helicity info

Addresses #924 

