### PR TITLE
Fix crash in DEventSourceREST by setting JApplication on CCDB generator

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -73,6 +73,7 @@ DEventSourceREST::DEventSourceREST(std::string source_name, JApplication* app)
    		
    app->SetDefaultParameter("REST:JANACALIBCONTEXT", REST_JANA_CALIB_CONTEXT);
    calib_generator = new JCalibrationGeneratorCCDB;  // keep this around in case we need to use it
+   calib_generator->SetApplication(app);
 }
 
 //----------------


### PR DESCRIPTION
This PR fixes a crash in `DEventSourceREST` caused by manually creating a `JCalibrationGeneratorCCDB` instance without setting its required `JApplication` context. When this context is missing, `JCalibrationGeneratorCCDB::MakeJCalibration` fails while attempting to access the `ccdb:cache` parameter, which determines whether CCDB caching should be enabled.

### Details

When using the standard JANA interface to retrieve a `JCalibration` object, the `JCalibrationManager::acquire_services` method automatically configures the associated `JCalibrationGeneratorCCDB`, including setting the `JApplication` pointer. This pointer is later required to retrieve parameters such as `ccdb:cache`.

However, in `DEventSourceREST`, the generator was being created manually without setting this application context, resulting in a crash when the generator attempted to access the unset pointer.

To fix this, the following line has been added in the constructor of `DEventSourceREST`, immediately after creating the generator:

```cpp
calib_generator = new JCalibrationGeneratorCCDB; // keep this around in case we need to use it
calib_generator->SetApplication(app);
```

This ensures the generator has the correct `JApplication` context and can access required configuration values.

### Notes

- **Preferred approach:** Use the JANA-provided `JCalibration` service, which handles all setup automatically. For example:

  ```cpp
  DEvent::GetJCalibration(event);
  // or
  event->GetJApplication()->GetService<JCalibrationManager>()->GetJCalibration(event->GetRunNumber());
  ```

- **If creating your own generator:** Always call `SetApplication(app)` to initialize it correctly and avoid crashes.