### PR TITLE
Only load RCDB info for trigger emulation once

### DIFF
--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
@@ -24,6 +24,27 @@ using namespace std;
 
 static bool print_data_message = true;
 
+bool DL1MCTrigger_factory::RCDB_LOADED = false;
+bool DL1MCTrigger_factory::PARAMS_LOADED = false;
+std::mutex DL1MCTrigger_factory::params_mutex;
+std::mutex DL1MCTrigger_factory::rcdb_mutex;
+
+vector<DL1MCTrigger_factory::trigger_conf> DL1MCTrigger_factory::triggers_enabled;
+
+vector<DL1MCTrigger_factory::fcal_mod> DL1MCTrigger_factory::fcal_trig_mask;
+vector<DL1MCTrigger_factory::bcal_mod> DL1MCTrigger_factory::bcal_trig_mask;
+
+int    DL1MCTrigger_factory::FCAL_CELL_THR = 65;
+int    DL1MCTrigger_factory::FCAL_NSA = 10;
+int    DL1MCTrigger_factory::FCAL_NSB = 3;
+int    DL1MCTrigger_factory::FCAL_WINDOW = 10;
+
+int    DL1MCTrigger_factory::BCAL_CELL_THR = 20;
+int    DL1MCTrigger_factory::BCAL_NSA = 19;
+int    DL1MCTrigger_factory::BCAL_NSB = 3;
+int    DL1MCTrigger_factory::BCAL_WINDOW = 20;
+
+
 //------------------
 // Init
 //------------------
@@ -44,18 +65,19 @@ void DL1MCTrigger_factory::Init()
   // spring run of 2017: 25 F + B > 45000
 
   FCAL_ADC_PER_MEV =  3.73;
-  FCAL_CELL_THR    =  65;
+  //FCAL_CELL_THR    =  65;
   FCAL_EN_SC       =  25;
-  FCAL_NSA         =  10;
-  FCAL_NSB         =  3;
-  FCAL_WINDOW      =  10;
+  //FCAL_NSA         =  10;
+  //FCAL_NSB         =  3;
+  //FCAL_WINDOW      =  10;
 
-  BCAL_ADC_PER_MEV =  34.48276; // Not corrected energy 
-  BCAL_CELL_THR    =  20;
+  //BCAL_ADC_PER_MEV =  34.48276; // Not corrected energy 
+  BCAL_ADC_PER_MEV =  22.7273;  
+  //BCAL_CELL_THR    =  20;
   BCAL_EN_SC       =  1;
-  BCAL_NSA         =  19;
-  BCAL_NSB         =  3;
-  BCAL_WINDOW      =  20;
+  //BCAL_NSA         =  19;
+  //BCAL_NSB         =  3;
+  //BCAL_WINDOW      =  20;
 
   FCAL_BCAL_EN     =  45000; 
 
@@ -87,29 +109,37 @@ void DL1MCTrigger_factory::Init()
                               "Bypass trigger by hard coding physics bit");
   app->SetDefaultParameter("TRIG:FCAL_ADC_PER_MEV", FCAL_ADC_PER_MEV,
 			      "FCAL energy calibration for the Trigger");
-  app->SetDefaultParameter("TRIG:FCAL_CELL_THR", FCAL_CELL_THR,
-			      "FCAL energy threshold per cell");
   app->SetDefaultParameter("TRIG:FCAL_EN_SC", FCAL_EN_SC,
 			      "FCAL energy threshold");
-  app->SetDefaultParameter("TRIG:FCAL_NSA", FCAL_NSA,
-			      "FCAL NSA");
-  app->SetDefaultParameter("TRIG:FCAL_NSB", FCAL_NSB,
-			      "FCAL NSB");
-  app->SetDefaultParameter("TRIG:FCAL_WINDOW", FCAL_WINDOW,
-			      "FCAL GTP integration window");
 
   app->SetDefaultParameter("TRIG:BCAL_ADC_PER_MEV", BCAL_ADC_PER_MEV,
 			      "BCAL energy calibration for the Trigger");
-  app->SetDefaultParameter("TRIG:BCAL_CELL_THR", BCAL_CELL_THR,
-			      "BCAL energy threshold per cell");
   app->SetDefaultParameter("TRIG:BCAL_EN_SC", BCAL_EN_SC,
 			      "BCAL energy threshold");
-  app->SetDefaultParameter("TRIG:BCAL_NSA", BCAL_NSA,
-			      "BCAL NSA");
-  app->SetDefaultParameter("TRIG:BCAL_NSB", BCAL_NSB,
-			      "BCAL NSB");
-  app->SetDefaultParameter("TRIG:BCAL_WINDOW", BCAL_WINDOW,
-			      "BCAL GTP integration window");
+
+  std::lock_guard<std::mutex> lock(params_mutex);
+  if(!PARAMS_LOADED) {
+	  PARAMS_LOADED = true;
+
+	  app->SetDefaultParameter("TRIG:FCAL_CELL_THR", FCAL_CELL_THR,
+					  "FCAL energy threshold per cell");
+	  app->SetDefaultParameter("TRIG:FCAL_NSA", FCAL_NSA,
+					  "FCAL NSA");
+	  app->SetDefaultParameter("TRIG:FCAL_NSB", FCAL_NSB,
+					  "FCAL NSB");
+	  app->SetDefaultParameter("TRIG:FCAL_WINDOW", FCAL_WINDOW,
+					  "FCAL GTP integration window");
+	
+	  app->SetDefaultParameter("TRIG:BCAL_CELL_THR", BCAL_CELL_THR,
+					  "BCAL energy threshold per cell");
+	  app->SetDefaultParameter("TRIG:BCAL_NSA", BCAL_NSA,
+					  "BCAL NSA");
+	  app->SetDefaultParameter("TRIG:BCAL_NSB", BCAL_NSB,
+					  "BCAL NSB");
+	  app->SetDefaultParameter("TRIG:BCAL_WINDOW", BCAL_WINDOW,
+					  "BCAL GTP integration window");
+  }
+  
 
   app->SetDefaultParameter("TRIG:ST_ADC_PER_MEV", ST_ADC_PER_MEV,
 			      "ST energy calibration for the Trigger");
@@ -699,6 +729,12 @@ int  DL1MCTrigger_factory::Read_RCDB(const std::shared_ptr<const JEvent>& event,
 {
 
 #if HAVE_RCDB
+
+  // RCDB queries are heavy, so we load the data once for all threads
+  std::lock_guard<std::mutex> lock(rcdb_mutex);
+  
+  if(RCDB_LOADED) return 0;
+  RCDB_LOADED = true;
 
   vector<const DTranslationTable*> ttab;  
   event->Get(ttab);

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.h
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.h
@@ -140,10 +140,10 @@ class DL1MCTrigger_factory:public JFactoryT<DL1MCTrigger>{
 		  int end;
 		} bcal_mod;
 
-		vector<trigger_conf> triggers_enabled;
+		static vector<trigger_conf> triggers_enabled;
 
-		vector<fcal_mod> fcal_trig_mask;
-		vector<bcal_mod> bcal_trig_mask;
+		static vector<fcal_mod> fcal_trig_mask;
+		static vector<bcal_mod> bcal_trig_mask;
 
 		vector<fcal_signal> fcal_signal_hits;
 		vector<bcal_signal> bcal_signal_hits;
@@ -151,20 +151,25 @@ class DL1MCTrigger_factory:public JFactoryT<DL1MCTrigger>{
 		vector<fcal_signal> fcal_merged_hits;
 		vector<bcal_signal> bcal_merged_hits;
 
+		static std::mutex params_mutex;
+		static std::mutex rcdb_mutex;
+  		static bool RCDB_LOADED;
+  		static bool PARAMS_LOADED;
+
 		int    BYPASS;
 		float  FCAL_ADC_PER_MEV;
-		int    FCAL_CELL_THR;
+		static int    FCAL_CELL_THR;
 		int    FCAL_EN_SC;
-		int    FCAL_NSA;
-		int    FCAL_NSB;
-		int    FCAL_WINDOW;
+		static int    FCAL_NSA;
+		static int    FCAL_NSB;
+		static int    FCAL_WINDOW;
 
 		float  BCAL_ADC_PER_MEV;
-		int    BCAL_CELL_THR;
+		static int    BCAL_CELL_THR;
 		int    BCAL_EN_SC;
-		int    BCAL_NSA;
-		int    BCAL_NSB;
-		int    BCAL_WINDOW;
+		static int    BCAL_NSA;
+		static int    BCAL_NSB;
+		static int    BCAL_WINDOW;
 
 		int    FCAL_BCAL_EN;
 		

--- a/src/libraries/TRIGGER/DL1MCTrigger_factory_DATA.h
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory_DATA.h
@@ -23,7 +23,7 @@ typedef  vector< vector<double> >  fcal_constants_t;
 
 class DL1MCTrigger_factory_DATA:public JFactoryT<DL1MCTrigger>{
 	public:
-		DL1MCTrigger_factory_DATA(){
+		DL1MCTrigger_factory_DATA() {
 			SetTag("DATA");
 		};
 		~DL1MCTrigger_factory_DATA(){};
@@ -143,10 +143,10 @@ class DL1MCTrigger_factory_DATA:public JFactoryT<DL1MCTrigger>{
 		  int end;
 		} bcal_mod;
 
-		vector<trigger_conf> triggers_enabled;
+		static vector<trigger_conf> triggers_enabled;
 
-		vector<fcal_mod> fcal_trig_mask;
-		vector<bcal_mod> bcal_trig_mask;
+		static vector<fcal_mod> fcal_trig_mask;
+		static vector<bcal_mod> bcal_trig_mask;
 
 		vector<fcal_signal> fcal_signal_hits;
 		vector<bcal_signal> bcal_signal_hits;
@@ -154,20 +154,25 @@ class DL1MCTrigger_factory_DATA:public JFactoryT<DL1MCTrigger>{
 		vector<fcal_signal> fcal_merged_hits;
 		vector<bcal_signal> bcal_merged_hits;
 
+		static std::mutex params_mutex;
+		static std::mutex rcdb_mutex;
+  		static bool RCDB_LOADED;
+  		static bool PARAMS_LOADED;
+
 		int    BYPASS;
 		float  FCAL_ADC_PER_MEV;
-		int    FCAL_CELL_THR;
+		static int    FCAL_CELL_THR;
 		int    FCAL_EN_SC;
-		int    FCAL_NSA;
-		int    FCAL_NSB;
-		int    FCAL_WINDOW;
+		static int    FCAL_NSA;
+		static int    FCAL_NSB;
+		static int    FCAL_WINDOW;
 
 		float  BCAL_ADC_PER_MEV;
-		int    BCAL_CELL_THR;
+		static int    BCAL_CELL_THR;
 		int    BCAL_EN_SC;
-		int    BCAL_NSA;
-		int    BCAL_NSB;
-		int    BCAL_WINDOW;
+		static int    BCAL_NSA;
+		static int    BCAL_NSB;
+		static int    BCAL_WINDOW;
 
 		int    FCAL_BCAL_EN;
 		


### PR DESCRIPTION
Make parameters loaded into the trigger emulation into static member values, and only load them once, to reduce DB accesses.

This solution fit well with the structure of the class.

Addresses issue #980 - Thanks to @RaiqaRasool for reporting it