### PR TITLE
Fix Methods Signatures in MilleField Plugins (Fixes #1007)

### DIFF
--- a/src/plugins/Alignment/MilleFieldOff/JEventProcessor_MilleFieldOff.cc
+++ b/src/plugins/Alignment/MilleFieldOff/JEventProcessor_MilleFieldOff.cc
@@ -43,7 +43,7 @@ void JEventProcessor_MilleFieldOff::Init() {
   milleWriter = new Mille(output_filename.data());
 }
 
-void JEventProcessor_MilleFieldOff::BeginRun(const std::shared_ptr<const JEvent> &event, int32_t runnumber) {
+void JEventProcessor_MilleFieldOff::BeginRun(const std::shared_ptr<const JEvent> &event) {
 
   // This is called whenever the run number changes
   // Check for magnetic field
@@ -60,7 +60,7 @@ void JEventProcessor_MilleFieldOff::BeginRun(const std::shared_ptr<const JEvent>
   }
 }
 
-void JEventProcessor_MilleFieldOff::Process(const std::shared_ptr<const JEvent> &event, uint64_t eventnumber) {
+void JEventProcessor_MilleFieldOff::Process(const std::shared_ptr<const JEvent> &event) {
 
   int straw_offset[29] = {0,    0,    42,   84,   138,  192,  258,  324,
                           404,  484,  577,  670,  776,  882,  1005, 1128,

--- a/src/plugins/Alignment/MilleFieldOff/JEventProcessor_MilleFieldOff.h
+++ b/src/plugins/Alignment/MilleFieldOff/JEventProcessor_MilleFieldOff.h
@@ -18,8 +18,8 @@ class JEventProcessor_MilleFieldOff : public JEventProcessor {
 
  private:
   void Init() override;
-  void BeginRun(const std::shared_ptr<const JEvent>& event, int32_t runnumber);
-  void Process(const std::shared_ptr<const JEvent>& event, uint64_t eventnumber);
+  void BeginRun(const std::shared_ptr<const JEvent>& event) override;
+  void Process(const std::shared_ptr<const JEvent>& event) override;
   void EndRun() override;
   void Finish() override;
 

--- a/src/plugins/Alignment/MilleFieldOn/JEventProcessor_MilleFieldOn.cc
+++ b/src/plugins/Alignment/MilleFieldOn/JEventProcessor_MilleFieldOn.cc
@@ -43,8 +43,8 @@ void JEventProcessor_MilleFieldOn::Init() {
   milleWriter = new Mille(output_filename.data());
 }
 
-void JEventProcessor_MilleFieldOn::BeginRun(const std::shared_ptr<const JEvent> &event, int32_t runnumber) {
-  // This is called whenever the run number changes
+void JEventProcessor_MilleFieldOn::BeginRun(const std::shared_ptr<const JEvent> &event) {
+   // This is called whenever the run number changes
   // Check for magnetic field
   bool dIsNoFieldFlag = (dynamic_cast<const DMagneticFieldMapNoField *>(DEvent::GetBfield(event)) != nullptr);
 
@@ -58,7 +58,7 @@ void JEventProcessor_MilleFieldOn::BeginRun(const std::shared_ptr<const JEvent> 
   }
 }
 
-void JEventProcessor_MilleFieldOn::Process(const std::shared_ptr<const JEvent> &event, uint64_t eventnumber) {
+void JEventProcessor_MilleFieldOn::Process(const std::shared_ptr<const JEvent> &event) {
 
   int straw_offset[29] = {0,    0,    42,   84,   138,  192,  258,  324,
                           404,  484,  577,  670,  776,  882,  1005, 1128,

--- a/src/plugins/Alignment/MilleFieldOn/JEventProcessor_MilleFieldOn.h
+++ b/src/plugins/Alignment/MilleFieldOn/JEventProcessor_MilleFieldOn.h
@@ -16,11 +16,8 @@ class JEventProcessor_MilleFieldOn : public JEventProcessor {
 
  private:
   void Init() override;
-  void BeginRun(
-      const std::shared_ptr<const JEvent>& event,
-      int32_t runnumber);  ///< Called everytime a new run number is detected.
-  void Process(const std::shared_ptr<const JEvent>& event,
-                uint64_t eventnumber);  ///< Called every event.
+  void BeginRun(const std::shared_ptr<const JEvent>& event) override;  ///< Called everytime a new run number is detected.
+  void Process(const std::shared_ptr<const JEvent>& event) override;  ///< Called every event.
   void EndRun() override;
                         ///< has been called.
   void Finish() override;


### PR DESCRIPTION
This PR fixes the function signatures for `::Process` and `::BeginRun` in both `JEventProcessor_MilleFieldOn` and `JEventProcessor_MilleFieldOff` classes to ensure they **correctly override** the corresponding virtual methods from `JANA::JEventProcessor`.

Previously, these methods were incorrectly declared, causing them to be treated as **new member functions** rather than overrides. As a result, they were **never invoked during the event processing lifecycle**, leading to the `hd_root.mil` file not being generated as expected.

With this fix:

* The overridden methods are now correctly registered and executed by JANA.
* The event lifecycle behavior is restored.
* Output file `hd_root.mil` is now properly filled.