### PR TITLE
Ecal track matching update

### DIFF
--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -1779,6 +1779,9 @@ bool DEventSourceREST::Extract_DDetectorMatches(const std::shared_ptr<const JEve
    vector<const DBCALShower*> locBCALShowers;
    locEvent->Get(locBCALShowers);
 
+   vector<const DECALShower*> locECALShowers;
+   locEvent->Get(locECALShowers);
+
    vector<const DFCALShower*> locFCALShowers;
    locEvent->Get(locFCALShowers);
 
@@ -1914,6 +1917,43 @@ bool DEventSourceREST::Extract_DDetectorMatches(const std::shared_ptr<const JEve
          locSingleHitMatchParams->dDOCAToHit = fcalSingleHitIter->getDoca();
 
          locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex],std::const_pointer_cast<const DFCALSingleHitMatchParams>(locSingleHitMatchParams));
+      }
+
+      // Lead tungstate insert
+      const hddm_r::EcalMatchParamsList &ecalList = iter->getEcalMatchParamses();
+      hddm_r::EcalMatchParamsList::iterator ecalIter = ecalList.begin();
+      for(; ecalIter != ecalList.end(); ++ecalIter)
+      {
+         size_t locShowerIndex = ecalIter->getShower();
+         size_t locTrackIndex = ecalIter->getTrack();
+
+         auto locShowerMatchParams = std::make_shared<DECALShowerMatchParams>();
+         locShowerMatchParams->dECALShower = locECALShowers[locShowerIndex];
+         locShowerMatchParams->dx = ecalIter->getDx();
+         locShowerMatchParams->dFlightTime = ecalIter->getTflight();
+         locShowerMatchParams->dFlightTimeVariance = ecalIter->getTflightvar();
+         locShowerMatchParams->dPathLength = ecalIter->getPathlength();
+         locShowerMatchParams->dDOCAToShower = ecalIter->getDoca();
+
+         locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex], locECALShowers[locShowerIndex], std::const_pointer_cast<const DECALShowerMatchParams>(locShowerMatchParams));
+      }
+
+      const hddm_r::EcalSingleHitMatchParamsList &ecalSingleHitList = iter->getEcalSingleHitMatchParamses();
+      hddm_r::EcalSingleHitMatchParamsList::iterator ecalSingleHitIter = ecalSingleHitList.begin();
+      for(; ecalSingleHitIter != ecalSingleHitList.end(); ++ecalSingleHitIter)
+      {
+         size_t locTrackIndex = ecalSingleHitIter->getTrack();
+
+         auto locSingleHitMatchParams = std::make_shared<DECALSingleHitMatchParams>();
+         locSingleHitMatchParams->dEHit = ecalSingleHitIter->getEhit();
+	 locSingleHitMatchParams->dTHit = ecalSingleHitIter->getThit();
+         locSingleHitMatchParams->dx = ecalSingleHitIter->getDx();
+         locSingleHitMatchParams->dFlightTime = ecalSingleHitIter->getTflight();
+         locSingleHitMatchParams->dFlightTimeVariance = ecalSingleHitIter->getTflightvar();
+         locSingleHitMatchParams->dPathLength = ecalSingleHitIter->getPathlength();
+         locSingleHitMatchParams->dDOCAToHit = ecalSingleHitIter->getDoca();
+
+         locDetectorMatches->Add_Match(locTrackTimeBasedVector[locTrackIndex],std::const_pointer_cast<const DECALSingleHitMatchParams>(locSingleHitMatchParams));
       }
 
 

--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -710,7 +710,46 @@ bool DEventWriterREST::Write_RESTEvent(const std::shared_ptr<const JEvent>& locE
 				bcalList().setTflight(locBCALShowerMatchParamsVector[loc_k]->dFlightTime);
 				bcalList().setTflightvar(locBCALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
 			}
+			
+			vector<shared_ptr<const DECALShowerMatchParams>> locECALShowerMatchParamsVector;
+			locDetectorMatches[loc_i]->Get_ECALMatchParams(tracks[loc_j], locECALShowerMatchParamsVector);
+			for (size_t loc_k = 0; loc_k < locECALShowerMatchParamsVector.size(); ++loc_k)
+			{
+			  hddm_r::EcalMatchParamsList ecalList = matches().addEcalMatchParamses(1);
+			  ecalList().setTrack(loc_j);
+			  
+			  const DECALShower* locECALShower = locECALShowerMatchParamsVector[loc_k]->dECALShower;
+			  size_t locECALindex = 0;
+			  for(; locECALindex < ecalshowers.size(); ++locECALindex)
+			    {
+			      if(ecalshowers[locECALindex] == locECALShower)
+				break;
+			    }
+			  ecalList().setShower(locECALindex);
 
+			  ecalList().setDoca(locECALShowerMatchParamsVector[loc_k]->dDOCAToShower);
+			  ecalList().setDx(locECALShowerMatchParamsVector[loc_k]->dx);
+			  ecalList().setPathlength(locECALShowerMatchParamsVector[loc_k]->dPathLength);
+			  ecalList().setTflight(locECALShowerMatchParamsVector[loc_k]->dFlightTime);
+			  ecalList().setTflightvar(locECALShowerMatchParamsVector[loc_k]->dFlightTimeVariance);
+			}
+
+			vector<shared_ptr<const DECALSingleHitMatchParams>> locECALSingleHitMatchParamsVector;
+			locDetectorMatches[loc_i]->Get_ECALSingleHitMatchParams(tracks[loc_j], locECALSingleHitMatchParamsVector);
+			for (size_t loc_k = 0; loc_k < locECALSingleHitMatchParamsVector.size(); ++loc_k)
+			{
+			  hddm_r::EcalSingleHitMatchParamsList ecalSingleHitList = matches().addEcalSingleHitMatchParamses(1);
+			  ecalSingleHitList().setTrack(loc_j);
+			  
+			  ecalSingleHitList().setEhit(locECALSingleHitMatchParamsVector[loc_k]->dEHit);
+			  ecalSingleHitList().setThit(locECALSingleHitMatchParamsVector[loc_k]->dTHit);
+			  ecalSingleHitList().setDoca(locECALSingleHitMatchParamsVector[loc_k]->dDOCAToHit);
+			  ecalSingleHitList().setDx(locECALSingleHitMatchParamsVector[loc_k]->dx);
+			  ecalSingleHitList().setPathlength(locECALSingleHitMatchParamsVector[loc_k]->dPathLength);
+			  ecalSingleHitList().setTflight(locECALSingleHitMatchParamsVector[loc_k]->dFlightTime);
+			  ecalSingleHitList().setTflightvar(locECALSingleHitMatchParamsVector[loc_k]->dFlightTimeVariance);
+			}
+			
 			vector<shared_ptr<const DFCALShowerMatchParams>> locFCALShowerMatchParamsVector;
 			locDetectorMatches[loc_i]->Get_FCALMatchParams(tracks[loc_j], locFCALShowerMatchParamsVector);
 			for (size_t loc_k = 0; loc_k < locFCALShowerMatchParamsVector.size(); ++loc_k)

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -146,6 +146,15 @@
                 track="int" shower="int"
                 dx="float" deltaphi="float" deltaz="float" pathlength="float" tflight="float" tflightvar="float"
                 tunit="ns" lunit="cm"/>
+      <ecalMatchParams maxOccurs="unbounded" minOccurs="0"
+                       track="int" shower="int"
+                       dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"
+                       tunit="ns" lunit="cm"/>
+      <ecalSingleHitMatchParams maxOccurs="unbounded" minOccurs="0"
+                track="int" ehit="float" thit="float"
+                dx="float" doca="float" pathlength="float" tflight="float"
+		tflightvar="float"
+                tunit="ns" lunit="cm"/>
       <fcalMatchParams maxOccurs="unbounded" minOccurs="0"
                 track="int" shower="int"
                 dx="float" doca="float" pathlength="float" tflight="float" tflightvar="float"

--- a/src/libraries/PID/DChargedTrackHypothesis.h
+++ b/src/libraries/PID/DChargedTrackHypothesis.h
@@ -72,6 +72,7 @@ class DChargedTrackHypothesis : public DKinematicData
 		shared_ptr<const DFMWPCMatchParams> Get_FMWPCMatchParams(void) const{return dTrackingInfo->dFMWPCMatchParams;}
   		shared_ptr<const DTRDMatchParams> Get_TRDMatchParams(void) const{return dTrackingInfo->dTRDMatchParams;}
   		shared_ptr<const DECALShowerMatchParams> Get_ECALShowerMatchParams(void) const{return dTrackingInfo->dECALShowerMatchParams;}
+  shared_ptr<const DECALSingleHitMatchParams> Get_ECALSingleHitMatchParams(void) const{return dTrackingInfo->dECALSingleHitMatchParams;}
 
 		//SETTERS
 
@@ -99,7 +100,8 @@ class DChargedTrackHypothesis : public DKinematicData
 		void Set_FMWPCMatchParams(shared_ptr<const DFMWPCMatchParams> locMatchParams){dTrackingInfo->dFMWPCMatchParams = locMatchParams;}
   		void Set_TRDMatchParams(shared_ptr<const DTRDMatchParams> locMatchParams){dTrackingInfo->dTRDMatchParams = locMatchParams;}
   		void Set_ECALShowerMatchParams(shared_ptr<const DECALShowerMatchParams> locMatchParams){dTrackingInfo->dECALShowerMatchParams = locMatchParams;}
-
+  void Set_ECALSingleHitMatchParams(shared_ptr<const DECALSingleHitMatchParams> locMatchParams){dTrackingInfo->dECALSingleHitMatchParams = locMatchParams;}
+  
 		void Summarize(JObjectSummary& summary) const override
 		{
 			summary.add(dTrackingInfo->dTrackTimeBased->candidateid, "candidate", "%d");
@@ -180,6 +182,7 @@ class DChargedTrackHypothesis : public DKinematicData
 				shared_ptr<const DFMWPCMatchParams> dFMWPCMatchParams=nullptr;
 		  		shared_ptr<const DTRDMatchParams> dTRDMatchParams=nullptr;
 		  		shared_ptr<const DECALShowerMatchParams> dECALShowerMatchParams = nullptr;
+		  shared_ptr<const DECALSingleHitMatchParams> dECALSingleHitMatchParams = nullptr;
 		};
 
 	private:
@@ -428,6 +431,7 @@ inline void DChargedTrackHypothesis::DTrackingInfo::Reset(void)
 	dFMWPCMatchParams = nullptr;
 	dTRDMatchParams = nullptr;
 	dECALShowerMatchParams = nullptr;
+	dECALSingleHitMatchParams = nullptr;
 }
 
 inline void DChargedTrackHypothesis::DEOverPInfo::Reset(void)

--- a/src/libraries/PID/DChargedTrackHypothesis_factory.cc
+++ b/src/libraries/PID/DChargedTrackHypothesis_factory.cc
@@ -265,6 +265,7 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 	shared_ptr<const DCTOFHitMatchParams> locCTOFHitMatchParams;
 	shared_ptr<const DTRDMatchParams> locTRDMatchParams;
 	shared_ptr<const DECALShowerMatchParams> locECALShowerMatchParams;
+	shared_ptr<const DECALSingleHitMatchParams> locECALSingleHitMatchParams;
 
 	if(dPIDAlgorithm->Get_BestBCALMatchParams(locTrackTimeBased, locDetectorMatches, locBCALShowerMatchParams))
 		locChargedTrackHypothesis->Set_BCALShowerMatchParams(locBCALShowerMatchParams);
@@ -283,6 +284,9 @@ DChargedTrackHypothesis* DChargedTrackHypothesis_factory::Create_ChargedTrackHyp
 	}
 	if(dPIDAlgorithm->Get_BestECALMatchParams(locTrackTimeBased, locDetectorMatches, locECALShowerMatchParams))
 	  locChargedTrackHypothesis->Set_ECALShowerMatchParams(locECALShowerMatchParams);
+	if(dPIDAlgorithm->Get_BestECALSingleHitMatchParams(locTrackTimeBased, locDetectorMatches, locECALSingleHitMatchParams))
+	  locChargedTrackHypothesis->Set_ECALSingleHitMatchParams(locECALSingleHitMatchParams);
+	
 	// Matching to CPP wire chambers
 	vector<shared_ptr<const DFMWPCMatchParams> > locFMWPCMatchParamsVec;
 	if (locDetectorMatches->Get_FMWPCMatchParams(locTrackTimeBased,

--- a/src/libraries/PID/DDetectorMatches.h
+++ b/src/libraries/PID/DDetectorMatches.h
@@ -66,6 +66,19 @@ public:
   double dDOCAToShower; //DOCA of track to shower
 };
 
+class DECALSingleHitMatchParams
+{
+ public:
+ DECALSingleHitMatchParams(void): dEHit(0.0), dTHit(0.0), dx(0.0), dFlightTime(0.0), dFlightTimeVariance(0.0), dPathLength(0.0), dDOCAToHit(0.0){}
+  double dEHit; // energy of ECAL hit
+  double dTHit; // time of ECAL hit
+  double dx; //the distance the track traveled through the block
+  double dFlightTime; //flight time from DKinematicData::position() to the block
+  double dFlightTimeVariance;
+  double dPathLength; //path length from DKinematicData::position() to the block
+  double dDOCAToHit; //DOCA of track to block
+};
+
 class DFCALSingleHitMatchParams
 {
  public:
@@ -222,6 +235,7 @@ class DDetectorMatches : public JObject
 		inline bool Get_SCMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DSCHitMatchParams> >& locMatchParams) const;
 		inline bool Get_DIRCMatchParams(const DTrackingData* locTrack, shared_ptr<const DDIRCMatchParams>& locMatchParams) const;
   		inline bool Get_TRDMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DTRDMatchParams> >& locMatchParams) const;
+  inline bool Get_ECALSingleHitMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DECALSingleHitMatchParams> >& locMatchParams) const;
   		inline bool Get_ECALMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DECALShowerMatchParams> >& locMatchParams) const;
 	
 		inline bool Get_IsMatchedToTrack(const DBCALShower* locBCALShower) const;
@@ -268,7 +282,8 @@ class DDetectorMatches : public JObject
 				      const shared_ptr<const DFMWPCMatchParams>& locFMWPCMatchParams);
   		inline void Add_Match(const DTrackingData* locTrack, const shared_ptr<const DTRDMatchParams>& locHitMatchParams);
   		inline void Add_Match(const DTrackingData* locTrack, const DECALShower* locECALShower, const shared_ptr<const DECALShowerMatchParams>& locShowerMatchParams);
-
+  inline void Add_Match(const DTrackingData* locTrack, const shared_ptr<const DECALSingleHitMatchParams>& locECALSingleHitMatchParams);
+  
 		inline void Set_DistanceToNearestTrack(const DBCALShower* locBCALShower, double locDeltaPhi, double locDeltaZ);
 		inline void Set_DistanceToNearestTrack(const DFCALShower* locFCALShower, double locDistanceToNearestTrack);
   		inline void Set_DistanceToNearestTrack(const DECALShower* locECALShower, double locDistanceToNearestTrack);
@@ -300,7 +315,8 @@ class DDetectorMatches : public JObject
 		map<const DTrackingData*, shared_ptr<const DDIRCMatchParams> > dTrackDIRCMatchParams;
   		map<const DTrackingData*, vector<shared_ptr<const DTRDMatchParams> > > dTrackTRDMatchParams;
   		map<const DTrackingData*, vector<shared_ptr<const DECALShowerMatchParams> > > dTrackECALMatchParams;
-
+  map<const DTrackingData*, vector<shared_ptr<const DECALSingleHitMatchParams> > > dTrackECALSingleHitMatchParams;
+  
 		//reverse-direction maps of the above (match params are the same objects)
 		map<const DBCALShower*, vector<shared_ptr<const DBCALShowerMatchParams> > > dBCALTrackMatchParams;
 		map<const DFCALShower*, vector<shared_ptr<const DFCALShowerMatchParams> > > dFCALTrackMatchParams;
@@ -329,6 +345,17 @@ inline bool DDetectorMatches::Get_BCALMatchParams(const DTrackingData* locTrack,
 	locMatchParams = locIterator->second;
 	return true;
 }
+
+inline bool DDetectorMatches::Get_ECALSingleHitMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DECALSingleHitMatchParams> >& locMatchParams) const
+{
+  locMatchParams.clear();
+  auto locIterator = dTrackECALSingleHitMatchParams.find(locTrack);
+  if(locIterator == dTrackECALSingleHitMatchParams.end())
+    return false;
+  locMatchParams = locIterator->second;
+  return true;
+}
+
 
 inline bool DDetectorMatches::Get_ECALMatchParams(const DTrackingData* locTrack, vector<shared_ptr<const DECALShowerMatchParams> >& locMatchParams) const
 {
@@ -673,6 +700,9 @@ inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const DBC
 {
 	dTrackBCALMatchParams[locTrack].push_back(locShowerMatchParams);
 	dBCALTrackMatchParams[locBCALShower].push_back(locShowerMatchParams);
+}
+inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const shared_ptr<const DECALSingleHitMatchParams>& locECALSingleHitMatchParams){
+  dTrackECALSingleHitMatchParams[locTrack].push_back(locECALSingleHitMatchParams);
 }
 inline void DDetectorMatches::Add_Match(const DTrackingData* locTrack, const DECALShower* locECALShower, const shared_ptr<const DECALShowerMatchParams>& locShowerMatchParams)
 {

--- a/src/libraries/PID/DDetectorMatches_factory.cc
+++ b/src/libraries/PID/DDetectorMatches_factory.cc
@@ -15,7 +15,7 @@ void DDetectorMatches_factory::Init()
   ENABLE_FCAL_SINGLE_HITS = false;
   GetApplication()->SetDefaultParameter("PID:ENABLE_FCAL_SINGLE_HITS",ENABLE_FCAL_SINGLE_HITS);
 
-  ENABLE_FCAL_SINGLE_HITS = false;
+  ENABLE_ECAL_SINGLE_HITS = false;
   GetApplication()->SetDefaultParameter("PID:ENABLE_ECAL_SINGLE_HITS",ENABLE_ECAL_SINGLE_HITS);
 }
 

--- a/src/libraries/PID/DDetectorMatches_factory.h
+++ b/src/libraries/PID/DDetectorMatches_factory.h
@@ -59,13 +59,17 @@ class DDetectorMatches_factory : public JFactoryT<DDetectorMatches>
 				 const DTrackTimeBased *locTrackTimeBased,
 				 vector<const DFCALHit *>&locSingleHits,
 				 DDetectorMatches* locDetectorMatches) const;
+  void MatchToECAL(const DParticleID* locParticleID,
+		   const DTrackTimeBased *locTrackTimeBased,
+		   vector<const DECALHit *>&locSingleHits,
+		   DDetectorMatches* locDetectorMatches) const;
 
 		//matching showers to tracks routines
 		void MatchToTrack(const DParticleID* locParticleID, const DBCALShower* locBCALShower, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, DDetectorMatches* locDetectorMatches) const;
 		void MatchToTrack(const DParticleID* locParticleID, const DFCALShower* locFCALShower, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, DDetectorMatches* locDetectorMatches) const;
   void MatchToTrack(const DParticleID* locParticleID, const DECALShower* locECALShower, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, DDetectorMatches* locDetectorMatches) const;
 
-		bool ENABLE_FCAL_SINGLE_HITS;
+  bool ENABLE_FCAL_SINGLE_HITS, ENABLE_ECAL_SINGLE_HITS;
 };
 
 #endif // _DDetectorMatches_factory_

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -4284,3 +4284,24 @@ void DParticleID::GetSingleFCALHits(vector<const DFCALShower*>&locFCALShowers,
     locSingleHits.push_back(locFCALHits[loc_i]);
   }
 }
+
+// Look for single hits in the ECAL not associated with clusters
+void DParticleID::GetSingleECALHits(vector<const DECALShower*>&locECALShowers,
+				    vector<const DECALHit *>&locECALHits,
+				    vector<const DECALHit*>&locSingleHits) const {
+  vector<oid_t>used_ecal_ids;
+  for (size_t loc_j=0;loc_j<locECALShowers.size();loc_j++){
+    const DECALCluster*cluster = locECALShowers[loc_j]->GetSingle<DECALCluster>();
+    vector<const DECALHit *>ecal_hits_in_cluster=cluster->Get<DECALHit>();
+    for (size_t loc_i=0;loc_i<ecal_hits_in_cluster.size();loc_i++){
+      used_ecal_ids.push_back(ecal_hits_in_cluster[loc_i]->id);
+    }
+  }
+  for (size_t loc_i=0;loc_i<locECALHits.size();loc_i++){
+    if (find(used_ecal_ids.begin(),used_ecal_ids.end(),
+	     locECALHits[loc_i]->id)!=used_ecal_ids.end()){
+      continue;
+    }
+    locSingleHits.push_back(locECALHits[loc_i]);
+  }
+}

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -2309,6 +2309,31 @@ shared_ptr<const DFCALSingleHitMatchParams> DParticleID::Get_BestFCALSingleHitMa
 	return locBestMatchParams;
 }
 
+bool DParticleID::Get_BestECALSingleHitMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DECALSingleHitMatchParams>& locBestMatchParams) const
+{
+	//choose the "best" shower to use for computing quantities
+	vector<shared_ptr<const DECALSingleHitMatchParams> > locMatchParams;
+	if(!locDetectorMatches->Get_ECALSingleHitMatchParams(locTrack, locMatchParams))
+		return false;
+
+	locBestMatchParams = Get_BestECALSingleHitMatchParams(locMatchParams);
+	return true;
+}
+
+shared_ptr<const DECALSingleHitMatchParams> DParticleID::Get_BestECALSingleHitMatchParams(vector<shared_ptr<const DECALSingleHitMatchParams> >& locMatchParams) const
+{
+	double locMinDistance = 9.9E9;
+	shared_ptr<const DECALSingleHitMatchParams> locBestMatchParams;
+	for(size_t loc_i = 0; loc_i < locMatchParams.size(); ++loc_i)
+	{
+		if(locMatchParams[loc_i]->dDOCAToHit >= locMinDistance)
+			continue;
+		locMinDistance = locMatchParams[loc_i]->dDOCAToHit;
+		locBestMatchParams = locMatchParams[loc_i];
+	}
+	return locBestMatchParams;
+}
+
 bool DParticleID::Get_DIRCMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DDIRCMatchParams>& locBestMatchParams) const
 {
 	//choose the "best" shower to use for computing quantities

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -275,7 +275,7 @@ class DParticleID: public JObject
 		
 		const DDIRCLut *Get_DIRCLut() const;
 		void GetSingleFCALHits(vector<const DFCALShower*>&locFCALShowers,vector<const DFCALHit*>&locFCALHits,vector<const DFCALHit*>&singleHits) const;
-	
+  void GetSingleECALHits(vector<const DECALShower*>&locECALShowers,vector<const DECALHit*>&locECALHits,vector<const DECALHit*>&singleHits) const;
 
 	protected:
 		// gas material properties

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -174,6 +174,7 @@ class DParticleID: public JObject
 		bool Get_DIRCMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DDIRCMatchParams>& locBestMatchParams) const;
   		bool Get_BestTRDMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DTRDMatchParams>& locBestMatchParams) const;
   		bool Get_BestECALMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DECALShowerMatchParams>& locBestMatchParams) const;
+  bool Get_BestECALSingleHitMatchParams(const DTrackingData* locTrack, const DDetectorMatches* locDetectorMatches, shared_ptr<const DECALSingleHitMatchParams>& locBestMatchParams) const;
 
 		// Actual
 		shared_ptr<const DBCALShowerMatchParams> Get_BestBCALMatchParams(DVector3 locMomentum, vector<shared_ptr<const DBCALShowerMatchParams> >& locShowerMatchParams) const;
@@ -184,7 +185,8 @@ class DParticleID: public JObject
 		shared_ptr<const DFCALSingleHitMatchParams> Get_BestFCALSingleHitMatchParams(vector<shared_ptr<const DFCALSingleHitMatchParams> >& locMatchParams) const;
   		shared_ptr<const DTRDMatchParams> Get_BestTRDMatchParams(vector<shared_ptr<const DTRDMatchParams> >& locTRDMatchParams) const;
   		shared_ptr<const DECALShowerMatchParams> Get_BestECALMatchParams(vector<shared_ptr<const DECALShowerMatchParams> >& locShowerMatchParams) const;
-
+  shared_ptr<const DECALSingleHitMatchParams> Get_BestECALSingleHitMatchParams(vector<shared_ptr<const DECALSingleHitMatchParams> >& locMatchParams) const;
+  
 		/********************************************************** GET CLOSEST TO TRACK **********************************************************/
 
 		// NOTE: an initial guess for start time is expected as input so that out-of-time hits can be skipped

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -28,6 +28,8 @@
 #include <FCAL/DFCALCluster.h>
 #include <FCAL/DFCALHit.h>
 #include <FCAL/DFCALGeometry_factory.h>
+#include <ECAL/DECALHit.h>
+#include <ECAL/DECALCluster.h>
 #include <ECAL/DECALGeometry.h>
 #include <FMWPC/DCTOFPoint.h>
 #include <TOF/DTOFPoint.h>

--- a/src/libraries/PID/DParticleID.h
+++ b/src/libraries/PID/DParticleID.h
@@ -126,6 +126,9 @@ class DParticleID: public JObject
 		bool Distance_ToTrack(const DReferenceTrajectory* rt, const DSCHit* locSCHit, double locInputStartTime, shared_ptr<DSCHitMatchParams>& locSCHitMatchParams, DVector3* locOutputProjPos = nullptr, DVector3* locOutputProjMom = nullptr) const;
 		bool ProjectTo_SC(const DReferenceTrajectory* rt, unsigned int locSCSector, double& locDeltaPhi, DVector3& locProjPos, DVector3& locProjMom, DVector3& locPaddleNorm, double& locPathLength, double& locFlightTime, double& locFlightTimeVariance, int& locSCPlane) const;
 
+  double Distance_ToTrack(const DECALHit *locECALHit,
+			  const DVector3 &locProjPos) const;
+  
 		double Distance_ToTrack(const DFCALShower *locFCALShower,
 					const DVector3 &locProjPos) const;
   double Distance_ToTrack(const DECALShower *locECALShower,
@@ -140,6 +143,7 @@ class DParticleID: public JObject
 		bool Distance_ToTrack(double locStartTime,const DTrackFitter::Extrapolation_t &extrapolation,const DFCALHit *locFCALHit,double &locDOCA,double &locHitTime) const;
   		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t>&extrapolations, const DTRDSegment* locTRDSegment,shared_ptr<DTRDMatchParams>& locTRDMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
   		bool Distance_ToTrack(const vector<DTrackFitter::Extrapolation_t> &extrapolations, const DECALShower* locECALShower, double locInputStartTime, shared_ptr<DECALShowerMatchParams>& locShowerMatchParams, DVector3* locOutputProjPos=nullptr, DVector3* locOutputProjMom=nullptr) const;
+  bool Distance_ToTrack(double locStartTime,const DTrackFitter::Extrapolation_t &extrapolation,const DECALHit *locECALHit,double &locDOCA,double &locHitTime) const;
 
 		/********************************************************** CUT MATCH DISTANCE **********************************************************/
 
@@ -233,6 +237,9 @@ class DParticleID: public JObject
 				   double& StartTime) const;
   bool Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &extrapolations,
 		     const vector<const DECALShower*>& ECALShowers,
+		     double& StartTime) const;
+  bool Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &extrapolations,
+		     const vector<const DECALHit*>& ECALHits,
 		     double& StartTime) const;
 		  
 		/********************************************************** MISCELLANEOUS **********************************************************/

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -17,6 +17,8 @@
 #include <BCAL/DBCALShower.h>
 #include <FCAL/DFCALShower.h>
 #include <FCAL/DFCALHit.h>
+#include <ECAL/DECALShower.h>
+#include <ECAL/DECALHit.h>
 #include <TOF/DTOFPoint.h>
 #include <CDC/DCDCHit.h>
 #include <START_COUNTER/DSCHit.h>
@@ -73,6 +75,8 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
 			   vector<const DBCALShower*>&bcal_showers,	  
 			   vector<const DFCALShower*>&fcal_showers,
 			   vector<const DFCALHit*>&fcal_hits,
+			   vector<const DECALShower*>&ecal_showers,
+			   vector<const DECALHit*>&ecal_hits,
 			   vector<DTrackTimeBased::DStartTime_t>&start_times);
   bool DoFit(const DTrackWireBased *track,
 	     vector<DTrackTimeBased::DStartTime_t>&start_times,
@@ -107,6 +111,7 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
   bool dIsNoFieldFlag,INSERT_MISSING_HYPOTHESES;
   bool USE_SC_TIME; // use start counter hits for t0
   bool USE_FCAL_TIME; // use fcal hits for t0
+  bool USE_ECAL_TIME; // use ecal hits for t0
   bool USE_BCAL_TIME; // use bcal hits for t0
   bool USE_TOF_TIME; // use tof hits for t0
 //  double SC_DPHI_CUT_WB;

--- a/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_ECAL.C
+++ b/src/plugins/Analysis/monitoring_hists/HistMacro_Matching_ECAL.C
@@ -65,7 +65,7 @@
 		locHist_ECAL_TrackDistanceVsP->GetYaxis()->SetLabelSize(0.05);
 		locHist_ECAL_TrackDistanceVsP->GetYaxis()->SetRangeUser(0,10.);
 		locHist_ECAL_TrackDistanceVsP->Draw("COLZ");
-		TF1* locFunc = new TF1("ECAL_LCut_VsP", "2.75", 0.0, 10.0);
+		TF1* locFunc = new TF1("ECAL_LCut_VsP", "1.5+1.8/x", 0.0, 10.0);
 		locFunc->Draw("SAME");
 	}
 
@@ -83,8 +83,6 @@
 		locHist_ECAL_TrackDistanceVsTheta->GetXaxis()->SetRangeUser(0,10.);
 		locHist_ECAL_TrackDistanceVsTheta->GetYaxis()->SetRangeUser(0,10.);
 		locHist_ECAL_TrackDistanceVsTheta->Draw("COLZ");
-		TF1* locFunc = new TF1("ECAL_LCut_VsTheta", "2.75*(1.+0.002*x*x)", 0.0, 20.0);
-		locFunc->Draw("SAME");
 	}
 
 	locCanvas->cd(3);


### PR DESCRIPTION
Improves track matching to ECAL showers and adds track matching to single isolated hits in the ECAL.  Adds matching information to REST output.  Add ECAL times to list of sources of t0 for time-based tracking.