### PR TITLE
Add some sanity checks to the helicity decoder data analysis

### DIFF
--- a/src/libraries/DAQ/DBeamHelicity_factory.cc
+++ b/src/libraries/DAQ/DBeamHelicity_factory.cc
@@ -160,6 +160,11 @@ DBeamHelicity *DBeamHelicity_factory::Make_DBeamHelicity(vector<const DHELIDigiH
 //------------------
 DBeamHelicity *DBeamHelicity_factory::Make_DBeamHelicity(const DHelicityData *locHelicityData)
 {
+	if(!checkPredictor(locHelicityData->last_helicity_state_pattern_sync)) {
+		jerr << "Consistency check of Helicity Decoder Board data failed!" << endl;
+		return nullptr;
+	}
+
 	DBeamHelicity *locBeamHelicity = new DBeamHelicity;
 	locBeamHelicity->pattern_sync  = locHelicityData->trigger_pattern_sync;
 	locBeamHelicity->t_settle      = locHelicityData->trigger_tstable;
@@ -194,6 +199,19 @@ uint32_t DBeamHelicity_factory::advanceSeed(uint32_t seed) const
         seed = advanceSeed(seed);
     return (seed ^ event_polarity) & 0x01;
 
+}
+
+//------------------
+// checkPredictor
+//------------------
+bool DBeamHelicity_factory::checkPredictor(uint32_t testval) const
+{
+	UInt_t rval = (testval)&0x3fffffff;
+	UInt_t lval = (testval>>2)&0x3fffffff;
+	lval = advanceSeed(lval);
+	lval = advanceSeed(lval);
+	
+	return (rval == lval);
 }
 
 

--- a/src/libraries/DAQ/DBeamHelicity_factory.h
+++ b/src/libraries/DAQ/DBeamHelicity_factory.h
@@ -33,6 +33,7 @@ class DBeamHelicity_factory:public JFactoryT<DBeamHelicity>{
 		DBeamHelicity *Make_DBeamHelicity(const DHelicityData *locHelicityData);
 
 		uint32_t advanceSeed(uint32_t seed) const;
+		bool checkPredictor(uint32_t testval) const;
 		uint32_t helicityDecoderCalcPolarity(uint32_t event_polarity, uint32_t seed, uint32_t delay);
 
 		bool PREFER_PROMPT_HELICITY_DATA;


### PR DESCRIPTION
add an internal consistency check of the historical data output by the board, seems fairly standard from talking to other people who analyze this data