### PR TITLE
add overflow to trigger energy correlation macro

### DIFF
--- a/src/plugins/monitoring/highlevel_online/HistMacro_Trigger_EnergyCorrelation.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Trigger_EnergyCorrelation.C
@@ -39,7 +39,8 @@
 {
 	TDirectory *locTopDirectory = gDirectory;
 
-
+	gStyle->SetOptStat("eou");
+	
 	// Grab remaining histos from highlevel directory
 	TDirectory *locDirectory = (TDirectory*)gDirectory->FindObjectAny("highlevel");
 	if(!locDirectory)
@@ -75,7 +76,7 @@
 	{
 		locHist_ECALVsFCAL_TrigBit1->GetXaxis()->SetTitleSize(0.05);
 		locHist_ECALVsFCAL_TrigBit1->GetYaxis()->SetTitleSize(0.04);
-		locHist_ECALVsFCAL_TrigBit1->SetStats(0);
+		//locHist_ECALVsFCAL_TrigBit1->SetStats(0);
 		locHist_ECALVsFCAL_TrigBit1->GetYaxis()->SetTitleOffset(2.0);
 		locHist_ECALVsFCAL_TrigBit1->Draw("colz");
 
@@ -92,7 +93,7 @@
 	{
 		locHist_BCALVsFCAL_TrigBit1->GetXaxis()->SetTitleSize(0.05);
 		locHist_BCALVsFCAL_TrigBit1->GetYaxis()->SetTitleSize(0.04);
-		locHist_BCALVsFCAL_TrigBit1->SetStats(0);
+		//locHist_BCALVsFCAL_TrigBit1->SetStats(0);
 		locHist_BCALVsFCAL_TrigBit1->GetYaxis()->SetTitleOffset(2.0);
 		locHist_BCALVsFCAL_TrigBit1->Draw("colz");
 
@@ -110,7 +111,7 @@
 	{
 		locHist_BCALVsFCAL2_TrigBit1->GetXaxis()->SetTitleSize(0.05);
 		locHist_BCALVsFCAL2_TrigBit1->GetYaxis()->SetTitleSize(0.04);
-		locHist_BCALVsFCAL2_TrigBit1->SetStats(0);
+		//locHist_BCALVsFCAL2_TrigBit1->SetStats(0);
 		locHist_BCALVsFCAL2_TrigBit1->GetYaxis()->SetTitleOffset(2.0);
 		locHist_BCALVsFCAL2_TrigBit1->Draw("colz");
                 entries = locHist_BCALVsFCAL2_TrigBit1->Integral();
@@ -130,7 +131,7 @@
 	{
 		locHist_BCALVsECAL_TrigBit1->GetXaxis()->SetTitleSize(0.05);
 		locHist_BCALVsECAL_TrigBit1->GetYaxis()->SetTitleSize(0.04);
-		locHist_BCALVsECAL_TrigBit1->SetStats(0);
+		//locHist_BCALVsECAL_TrigBit1->SetStats(0);
 		locHist_BCALVsECAL_TrigBit1->GetYaxis()->SetTitleOffset(2.0);
 		locHist_BCALVsECAL_TrigBit1->Draw("colz");
 


### PR DESCRIPTION
Added overflow and underflow for statistics box to see if outlier channel(s) are causing the histograms to appear empty, see https://logbooks.jlab.org/entry/4414579

<img width="1206" alt="Screenshot 2025-07-09 at 10 40 25 AM" src="https://github.com/user-attachments/assets/5fd85859-027a-4d34-95e6-be837793f450" />
