### PR TITLE
Fix mcsmear crash with JANA 2.4.2

### DIFF
--- a/src/libraries/BCAL/DBCALGeometry_factory.h
+++ b/src/libraries/BCAL/DBCALGeometry_factory.h
@@ -15,7 +15,11 @@
 
 class DBCALGeometry_factory:public JFactoryT<DBCALGeometry>{
 public:
-		DBCALGeometry_factory(){bcalgeometry=nullptr;};
+		DBCALGeometry_factory()	{
+			// DBCALGeometry need to be accessible from DEventSourceHDDM::GetObjects()
+			SetRegenerateFlag(true);
+			bcalgeometry=nullptr;
+		};
 		~DBCALGeometry_factory() override = default;
 
 		DBCALGeometry *bcalgeometry = nullptr;


### PR DESCRIPTION
**Description:**
Fixes [halld\_sim#363](https://github.com/JeffersonLab/halld_sim/issues/363) that mentions`mcsmear` crashing with JANA 2.4.2 due to a factory cycle.

### Summary of Fix:
* Set `SetRegenerateFlag(true)` in `DBCALGeometry_factory`, ensuring geometry objects are generated via `Process()` instead of triggering recursive calls through `GetObjects()`.

### Testing:
* Verified that `mcsmear` runs without crashing under JANA 2.4.2.
