### PR TITLE
Update DEVIOWorkerThread::Run to use JANA2-compliant quitting syntax

### DIFF
--- a/src/libraries/DAQ/DEVIOWorkerThread.cc
+++ b/src/libraries/DAQ/DEVIOWorkerThread.cc
@@ -130,13 +130,15 @@ void DEVIOWorkerThread::Run(void)
 			jerr << "Stack trace follows:" << endl;
 			jerr << e.GetStackTrace() << endl;
 			jerr << e.what() << endl;
-			japp->Quit(10);
+			japp->SetExitCode(10);
+			japp->Quit(true);
 		} catch (exception &e) {
 			jerr << e.what() << endl;
 			for(auto pe : parsed_event_pool) delete pe; // delete all parsed events any any objects they hold
 			parsed_event_pool.clear();
 			current_parsed_events.clear(); // (these are also in parsed_event_pool so were already deleted)
-			japp->Quit(-1);
+			japp->SetExitCode(-1);
+			japp->Quit(true);
 		}
 		
 		// Reset and mark us as available for use


### PR DESCRIPTION
This PR updates the exception handling logic in `DEVIOWorkerThread::Run` to use JANA2-compliant methods for exiting the application with a specific exit code.

Previously, the code used:

```cpp
japp->Quit(10); // or -1
```

However, in JANA2 (`JApplication::Quit(bool skip_join)`) above syntax does not set the exit code instead it sets `skip_join=true`, and the application exits with default code 0.

This PR replaces those lines with:

```cpp
japp->SetExitCode(10);  // or -1
japp->Quit(true);
```

This ensures the application exits with the correct non-zero code when encountering malformed or bad data, enabling better behavior in scripts and production workflows that rely on proper exit codes.

Fixes #1031.
