### PR TITLE
changed the histo to a profile so that results from several files can be combined with sensible results

### DIFF
--- a/src/plugins/monitoring/fa125_temp/JEventProcessor_fa125_temp.cc
+++ b/src/plugins/monitoring/fa125_temp/JEventProcessor_fa125_temp.cc
@@ -10,7 +10,7 @@
 #include "JEventProcessor_fa125_temp.h"
 
 #include <TDirectory.h>
-#include <TH2.h>
+#include <TProfile2D.h>
 
 
 #include "DAQ/Df125BORConfig.h"
@@ -61,7 +61,7 @@ void JEventProcessor_fa125_temp::Init()
   TDirectory *main = gDirectory;
   gDirectory->mkdir("fa125_temp")->cd();
 
-  htemp = new TH2D("temp","fa125 temperature (F) (must be below 185F); roc ; slot", 15, 1, 16, 17, 3, 20);
+  htemp = new TProfile2D("temp","fa125 temperature (F) (danger point: 185F); roc ; slot", 15, 1, 16, 17, 3, 20);
 
   for (int i=0; i<70; i++) rocmap[i] = 0;  // rocmap[rocid] = bin number for roc rocid in histogram
 


### PR DESCRIPTION
I changed the histogram into a TProfile so that the resulting root files can be combined from several runs (or files from the same run, as in one of our monitoring launches) and show the overall mean temperature instead of the temperature multiplied by the number of files added.   The temperature is read out at the beginning of each run and stored in the Df125BORConfig.  

The example shows plots for:

upper left: run 131289
lower left: run 133012

right: root file generated by summing (with hadd) the two root files shown on the left


<img width="1408" height="1059" alt="hadd_temp_profiles" src="https://github.com/user-attachments/assets/da0d888c-996c-42d7-9213-13ba7e7329e4" />
