### PR TITLE
Use CCDB for amorphous normalization of photon beam energy monitoring

### DIFF
--- a/src/plugins/monitoring/highlevel_online/AmorphousNormalization/amo.py
+++ b/src/plugins/monitoring/highlevel_online/AmorphousNormalization/amo.py
@@ -1,0 +1,97 @@
+#! /usr/bin/python
+# coding:utf-8
+
+import os
+import sys
+import rcdb
+import ROOT
+import numpy
+import tempfile
+import subprocess
+
+
+def main():
+  args = sys.argv
+  if len(args) != 3:
+    print('usage: ./amo.py MINRUN MAXRUN')
+    exit(0)
+
+  MINRUN=int(args[1])
+  MAXRUN=int(args[2])
+
+  db = rcdb.RCDBProvider(os.environ.get('RCDB_CONNECTION'))
+  amo_runs = db.select_runs("@is_dirc_production and status!=0 and event_count > 10000000 and radiator_type==\"4.5x10-4 Al 40um\"", MINRUN, MAXRUN)
+
+  # Create an np array to store the amo runs
+  amo_runs_int = numpy.array([])
+
+  for RUN in range(MINRUN, MAXRUN+1):
+
+    # See if is amo run
+    rcdb_run_info = db.get_run(int(RUN))
+    if(rcdb_run_info not in amo_runs):
+      continue
+
+    runnum = int("%06d" % RUN)
+    amo_runs_int = numpy.append(amo_runs_int, runnum)
+
+ 
+  # Create an np array to store the good amo runs
+  amo_runs_good = numpy.array([])
+  # and a list with file names for their ccdb entries
+  tmp_list = []
+
+  for i in range(len(amo_runs_int)):
+    runnum = int(amo_runs_int[i])
+    
+    try:
+      file = ROOT.TFile.Open("/work/halld/online_monitoring/root/hdmon_online%d.root" % (runnum))
+      # for older run periods:
+      #file = ROOT.TFile.Open("/work/halld/data_monitoring/RunPeriod-2017-01/mon_ver62/rootfiles/hd_root_0%d.root" % (runnum))
+      if not file or file.IsZombie():
+        print("RootSpy file not found!")
+        continue
+    except OSError as e:
+      print(e)
+      continue
+
+    beam_energy = file.Get("rootspy/highlevel/BeamEnergy")
+    # for older run periods:
+    #beam_energy = file.Get("highlevel/BeamEnergy")
+    if not beam_energy:
+      print("Beam energy histogram not found!")
+      continue
+
+    # Get the number of bins
+    num_bins = beam_energy.GetNbinsX()
+
+    # Create an array to store the entries
+    entries = numpy.zeros(num_bins, dtype=int)
+
+    # Loop over the bins and save the entries
+    for i in range(1, num_bins + 1):
+      entries[i - 1] = int(beam_energy.GetBinContent(i))
+
+    # Close the ROOT file
+    file.Close()
+
+    # Create a temporary text file
+    with tempfile.NamedTemporaryFile(delete=False, mode='w') as temp_file:
+      # Write the entries to the file in one line
+      temp_file.write(' '.join(map(str, entries)))
+
+    amo_runs_good = numpy.append(amo_runs_good, runnum)
+    tmp_list.append(temp_file.name)
+
+
+  # Loop over all runs that have a good histogram
+  for i in range(len(amo_runs_good)):
+    runnum = int(amo_runs_good[i])
+    next = int(amo_runs_good[i + 1] - 1) if i + 1 < len(amo_runs_good) else int(MAXRUN)
+    
+    subprocess.call(['ccdb', 'add', '/PHOTON_BEAM/amo_norm', '-r', '%s-%s' % (runnum,next), tmp_list[i]])
+    subprocess.call(['rm', tmp_list[i]])
+
+
+if __name__ == '__main__':
+  main()

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
@@ -1,6 +1,7 @@
 // hnamepath: /highlevel/RFBeamBunchPeriod
 // hnamepath: /highlevel/RFBeamBunchPeriod_DFT
 // hnamepath: /highlevel/BeamEnergy
+// hnamepath: /highlevel/BeamEnergy_amo
 //
 // e-mail: davidl@jlab.org
 // e-mail: staylor@jlab.org
@@ -18,35 +19,8 @@
 // The working directory used was:
 //     ~hdops/2018.10.05.amorphous_normalization
 //
-string amorphous_label = "Normalized to Amorphous run 133141";
+string amorphous_label = "Normalized to Amorphous run from CCDB";
 
-	Double_t amorphous_data[] = {
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,    603024.0, 
-		   715809.0,    876503.0,    768876.0,    832468.0,    968221.0,    887220.0,    966896.0,    819973.0,    817816.0,    794689.0, 
-		   760821.0,    799343.0,    964819.0,    983185.0,    875640.0,   1007130.0,    872138.0,   1094751.0,    945558.0,   1248558.0, 
-		  1786723.0,   1123570.0,   1114447.0,   1497953.0,   1530973.0,    512074.0,    898413.0,    947271.0,   1394707.0,   1433727.0, 
-		  1377625.0,   1336832.0,    848098.0,   1720764.0,   1236145.0,   1203198.0,   1009402.0,   1193600.0,   1200645.0,   1659380.0, 
-		   763676.0,    961762.0,    982407.0,   1361042.0,   1243086.0,   1078576.0,   1152846.0,   1124651.0,   1086944.0,   1028931.0, 
-		  1045761.0,    974301.0,   1372879.0,    890618.0,   1532175.0,    605489.0,   1222477.0,   1147639.0,   1081689.0,   1532456.0, 
-		   929855.0,   1242304.0,    773876.0,    852506.0,    796618.0,   1023501.0,    891699.0,    911777.0,    678945.0,    387017.0, 
-		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
-	0.0};
-//--------------------------------------------------------------------
 	TDirectory *locTopDirectory = gDirectory;
 
 	//Goto Beam Path
@@ -58,6 +32,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 	TH1* locHist_RFBeamBunchPeriod = (TH1*)gDirectory->Get("RFBeamBunchPeriod");
 	TH1* locHist_RFBeamBunchPeriod_DFT = (TH1*)gDirectory->Get("RFBeamBunchPeriod_DFT");
 	TH1* locHist_BeamEnergy = (TH1*)gDirectory->Get("BeamEnergy");
+	TH1* locHist_BeamEnergy_amo = (TH1*)gDirectory->Get("BeamEnergy_amo");
 
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
@@ -112,7 +87,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 	locCanvas->cd(2);
 	gPad->SetTicks();
 	gPad->SetGrid();
-	if(locHist_BeamEnergy != NULL)
+	if(locHist_BeamEnergy != NULL && locHist_BeamEnergy_amo != NULL)
 	{
 		// Create normalized histogram
 		TH1D* locHist_BeamEnergy_norm = (TH1D*)gDirectory->Get("BeamEnergy_norm");
@@ -126,7 +101,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 			// Normalize to amorphous baseline 
 			double scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
-				Double_t norm = amorphous_data[ibin-1];
+				Double_t norm = locHist_BeamEnergy_amo->GetBinContent(ibin);
 				if( norm < 1000.0) continue;
 
 				Double_t v = (Double_t)locHist_BeamEnergy->GetBinContent(ibin);
@@ -141,7 +116,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 			// Find leftmost non-zero bin 
 			double left_scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
-				if( amorphous_data[ibin-1] < 10000.0) continue;
+				if( locHist_BeamEnergy_amo->GetBinContent(ibin) < 10000.0) continue;
 				Double_t v = (Double_t)locHist_BeamEnergy_norm->GetBinContent(ibin);
 				if(v>0.1){
 					left_scale = v;

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
@@ -19,8 +19,35 @@
 // The working directory used was:
 //     ~hdops/2018.10.05.amorphous_normalization
 //
-string amorphous_label = "Normalized to Amorphous run from CCDB";
+string amorphous_label = "Normalized to Amorphous run 133141";
 
+	Double_t amorphous_data[] = {
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,    603024.0, 
+		   715809.0,    876503.0,    768876.0,    832468.0,    968221.0,    887220.0,    966896.0,    819973.0,    817816.0,    794689.0, 
+		   760821.0,    799343.0,    964819.0,    983185.0,    875640.0,   1007130.0,    872138.0,   1094751.0,    945558.0,   1248558.0, 
+		  1786723.0,   1123570.0,   1114447.0,   1497953.0,   1530973.0,    512074.0,    898413.0,    947271.0,   1394707.0,   1433727.0, 
+		  1377625.0,   1336832.0,    848098.0,   1720764.0,   1236145.0,   1203198.0,   1009402.0,   1193600.0,   1200645.0,   1659380.0, 
+		   763676.0,    961762.0,    982407.0,   1361042.0,   1243086.0,   1078576.0,   1152846.0,   1124651.0,   1086944.0,   1028931.0, 
+		  1045761.0,    974301.0,   1372879.0,    890618.0,   1532175.0,    605489.0,   1222477.0,   1147639.0,   1081689.0,   1532456.0, 
+		   929855.0,   1242304.0,    773876.0,    852506.0,    796618.0,   1023501.0,    891699.0,    911777.0,    678945.0,    387017.0, 
+		        0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0,         0.0, 
+	0.0};
+//--------------------------------------------------------------------
 	TDirectory *locTopDirectory = gDirectory;
 
 	//Goto Beam Path
@@ -87,7 +114,7 @@ string amorphous_label = "Normalized to Amorphous run from CCDB";
 	locCanvas->cd(2);
 	gPad->SetTicks();
 	gPad->SetGrid();
-	if(locHist_BeamEnergy != NULL && locHist_BeamEnergy_amo != NULL)
+	if(locHist_BeamEnergy != NULL)
 	{
 		// Create normalized histogram
 		TH1D* locHist_BeamEnergy_norm = (TH1D*)gDirectory->Get("BeamEnergy_norm");
@@ -101,7 +128,13 @@ string amorphous_label = "Normalized to Amorphous run from CCDB";
 			// Normalize to amorphous baseline 
 			double scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
-				Double_t norm = locHist_BeamEnergy_amo->GetBinContent(ibin);
+				Double_t norm;
+				if (locHist_BeamEnergy_amo != NULL){
+				  amorphous_label = "Normalized to Amorphous run from CCDB";
+				  norm = locHist_BeamEnergy_amo->GetBinContent(ibin);
+				}
+				else
+				  norm = amorphous_data[ibin-1];
 				if( norm < 1000.0) continue;
 
 				Double_t v = (Double_t)locHist_BeamEnergy->GetBinContent(ibin);
@@ -116,7 +149,11 @@ string amorphous_label = "Normalized to Amorphous run from CCDB";
 			// Find leftmost non-zero bin 
 			double left_scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
-				if( locHist_BeamEnergy_amo->GetBinContent(ibin) < 10000.0) continue;
+				if( locHist_BeamEnergy_amo != NULL){
+				  if (locHist_BeamEnergy_amo->GetBinContent(ibin) < 10000.0) continue;
+				}
+				else
+				  if (amorphous_data[ibin-1] < 10000.0) continue;
 				Double_t v = (Double_t)locHist_BeamEnergy_norm->GetBinContent(ibin);
 				if(v>0.1){
 					left_scale = v;

--- a/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_Beam.C
@@ -60,6 +60,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 	TH1* locHist_RFBeamBunchPeriod_DFT = (TH1*)gDirectory->Get("RFBeamBunchPeriod_DFT");
 	TH1* locHist_BeamEnergy = (TH1*)gDirectory->Get("BeamEnergy");
 	TH1* locHist_BeamEnergy_amo = (TH1*)gDirectory->Get("BeamEnergy_amo");
+	bool locUseCCDB = (locHist_BeamEnergy_amo != NULL && locHist_BeamEnergy_amo->GetEntries() > 0);
 
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
@@ -129,7 +130,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 			double scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
 				Double_t norm;
-				if (locHist_BeamEnergy_amo != NULL){
+				if ( locUseCCDB ){
 				  amorphous_label = "Normalized to Amorphous run from CCDB";
 				  norm = locHist_BeamEnergy_amo->GetBinContent(ibin);
 				}
@@ -149,7 +150,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 			// Find leftmost non-zero bin 
 			double left_scale = 0.0;
 			for(int ibin=1; ibin<=locHist_BeamEnergy_norm->GetNbinsX(); ibin++){
-				if( locHist_BeamEnergy_amo != NULL){
+				if( locUseCCDB ){
 				  if (locHist_BeamEnergy_amo->GetBinContent(ibin) < 10000.0) continue;
 				}
 				else
@@ -204,7 +205,7 @@ string amorphous_label = "Normalized to Amorphous run 133141";
 		}
 
 		TPad *beamenergypad = (TPad*)gDirectory->FindObjectAny("beamenergypad");
-		if(!beamenergypad) beamenergypad = new TPad("beamenergypad", "", 0.45, 0.65, 0.885, 0.895);
+		if(!beamenergypad) beamenergypad = new TPad("beamenergypad", "", 0.11, 0.65, 0.51, 0.895);
 		beamenergypad->SetTicks();
 		beamenergypad->Draw();
 		beamenergypad->cd();

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -270,6 +270,7 @@ void JEventProcessor_highlevel_online::Init()
 
 	// Beam Energy from tagger
 	dHist_BeamEnergy = new TH1I("BeamEnergy", "Reconstructed Tagger Beam Energy;Beam Energy (GeV)", 240, 0.0, 12.0);
+	dHist_BeamEnergy_amo = new TH1I("BeamEnergy_amo", "Saved Tagger Beam Energy for AMO run;Beam Energy (GeV)", 240, 0.0, 12.0);
 
 	// Beam Energy from PS
 	dHist_PSPairEnergy = new TH1I("PSPairEnergy", "Reconstructed PS Beam Energy;Beam Energy (GeV)", 450, 3., 12.);
@@ -394,6 +395,12 @@ void JEventProcessor_highlevel_online::BeginRun(const std::shared_ptr<const JEve
 	map<string, double> photon_beam_param;
 	if(DEvent::GetCalib(event, "/PHOTON_BEAM/coherent_energy", photon_beam_param) == false)
 		dCoherentPeakRange = pair<double, double>(photon_beam_param["cohmin_energy"], photon_beam_param["cohedge_energy"]);
+
+	vector<int> locAmoNorm;
+	GetCalib(event, "PHOTON_BEAM/amo_norm", locAmoNorm);
+	for(size_t loc_i = 0; loc_i < locAmoNorm.size(); ++loc_i){
+	  dHist_BeamEnergy_amo->SetBinContent(loc_i+1, locAmoNorm[loc_i]);
+	}
 
 	fcal_cell_thr  =  65;
 	bcal_cell_thr  =  20;

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
@@ -57,6 +57,7 @@ class JEventProcessor_highlevel_online:public JEventProcessor
 		TH2I* dHist_NumHighLevelObjects;
 
 		TH1I* dHist_BeamEnergy;
+		TH1I* dHist_BeamEnergy_amo;
 		TH1I* dHist_PSPairEnergy;
 
 		TH2I* dHist_PVsTheta_Tracks;


### PR DESCRIPTION
* highlevel_online plugin writes out a histogram with normalization values from an amorphous run, that was previously saved in CCDB
* HistMacro_Beam uses this histogram to normalize the beam energy spectrum
* `./amo.py MINRUN MAXRUN` is used to fill the database with values from amorphous runs with this run range

It is indicated in the canvas that the values come from CCDB:
<img width="605" height="694" alt="amo_norm_from_CCDB" src="https://github.com/user-attachments/assets/edcb4e24-b7d1-4775-8941-44fc3c33deca" />
