### PR TITLE
Warn Instead of Terminate When No Plugins Found

### DIFF
--- a/src/programs/Analysis/hd_root/hd_root.cc
+++ b/src/programs/Analysis/hd_root/hd_root.cc
@@ -45,7 +45,6 @@ int main(int narg, char *argv[])
 	app->GetParameter("PLUGINS", plugins);
 	if(plugins.empty()) {
 		printNoPluginsBanner();
-		return -1; // Exit early if no plugins are specified
 	}
 
 
@@ -206,6 +205,5 @@ void printNoPluginsBanner() {
     }
     std::cout << "WARNING: No plugins specified. It will result in no data being processed." << std::endl;
     std::cout << "         Use the -Pplugins=plugin1,plugin2,... command line option to specify plugins." << std::endl;
-	std::cout << "Terminating....." <<std::endl;
     std::cout << RESET << std::flush;
 }


### PR DESCRIPTION
This PR updates the logic introduced in #1041 to only display a warning and continue execution, rather than terminating the process.

This behavior is required for scenarios where users intentionally run without plugins (e.g., using the -PAUTOACTIVATE parameter or during certain testing).