### PR TITLE
Fix #1054: Missing histograms after upgrading from ROOT 6.24 to 6.32

### DIFF
--- a/src/programs/Analysis/hd_root/MyProcessor.cc
+++ b/src/programs/Analysis/hd_root/MyProcessor.cc
@@ -82,6 +82,13 @@ void MyProcessor::Init()
 //------------------------------------------------------------------
 void MyProcessor::BeginRun(const std::shared_ptr<const JEvent>& event)
 {
+	// Manually set gDirectory to ROOTfile because its value is not propagated
+	// from the main thread (which calls ::Init) to the thread that runs ::BeginRun.
+	// Setting it here ensures that all subsequent plugins see the correct gDirectory,
+	// since their ::BeginRun methods are called after this point. 
+	// This issue appeared after upgrading from ROOT 6.24.04 to 6.32.08.
+	gDirectory = ROOTfile;
+	
 	vector<string> factory_names;
 	for (JFactory* factory : event->GetFactorySet()->GetAllFactories()) {
 		factory_names.push_back(factory->GetFactoryName());


### PR DESCRIPTION
### **Description:**

After upgrading from **ROOT 6.24.04** to **6.32.08**, the global `gDirectory` variable stopped propagating correctly from the main thread (which calls `::Init`) to the thread executing `::BeginRun`.

As a result, `::BeginRun` was running in a different thread with an uninitialized `gDirectory` value. This caused any histograms created inside `::BeginRun` to be associated with a temporary, memory-resident ROOT directory instead of the intended output file.

Although histogram filling still occurred, those histograms were never written to the actual output file, resulting in **missing histograms in the final ROOT files**.

### **Fix:**

Explicitly set:

```cpp
gDirectory = ROOTfile;
```

at the start of `::BeginRun`.
This ensures that the current thread’s `gDirectory` points to the correct output file and maintains consistency across all plugins. Since other plugins’ `::BeginRun` methods are invoked after this point, they automatically inherit the correct directory context.

### **Impact:**
* Ensures that histograms created inside `::BeginRun` are properly written to the output ROOT file both for single and multiple threads.
* Resolves missing histograms that appeared after transitioning from ROOT 6.24.04 → 6.32.08.
* No changes to external interfaces or user workflow.

**Fixes:** #1054