### PR TITLE
Fix #1054: Extend ROOT 6.32 gDirectory workaround to ::Process

### DIFF
--- a/src/programs/Analysis/hd_root/MyProcessor.cc
+++ b/src/programs/Analysis/hd_root/MyProcessor.cc
@@ -152,6 +152,13 @@ void MyProcessor::BeginRun(const std::shared_ptr<const JEvent>& event)
 //------------------------------------------------------------------
 void MyProcessor::Process(const std::shared_ptr<const JEvent>& event)
 {
+	// Manually set gDirectory to ROOTfile because its value is not propagated
+	// from the other threads (::Init/BeginRun) to the thread that runs ::Process.
+	// All JEventProcessors for an event run in the same thread, so setting this value here
+	// ensures that subsequent plugins see the correct gDirectory when their ::Process methods are called.
+	// This issue appeared after upgrading from ROOT 6.24.04 to 6.32.08.
+	gDirectory = ROOTfile;
+
 	// Loop over factories explicitly mentioned on command line
 	for(unsigned int i=0;i<toprint.size();i++){
 		string name =fac_info[i].dataClassName;


### PR DESCRIPTION
Fixes #1054

Builds on top of #1057

Extends the gDirectory assignment workaround introduced in #1057 by adding the same `gDirectory` assignment to `ROOTfile` within `::Process`, in addition to `::BeginRun`.
This ensures consistent directory handling across both stages and prevents potential ROOT 6.32 `gDirectory` issues.