### PR TITLE
Fix static triggers_enabled getting cleared in DL1MCTrigger_factory::…

### DIFF
--- a/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
+++ b/src/libraries/TRIGGER/DL1MCTrigger_factory.cc
@@ -208,10 +208,12 @@ void DL1MCTrigger_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 
   int status   = 0;
 
-  fcal_trig_mask.clear();
-  bcal_trig_mask.clear();
+  if(!RCDB_LOADED) {
+    fcal_trig_mask.clear();
+    bcal_trig_mask.clear();
 
-  triggers_enabled.clear();
+    triggers_enabled.clear();
+  }
 
   // Only print messages for one thread whenever run number change
 
@@ -921,7 +923,6 @@ int  DL1MCTrigger_factory::Read_RCDB(const std::shared_ptr<const JEvent>& event,
 	  if((triggerTypes[jj].size() >= 14) && (triggerTypes[jj][13].size() > 0)){
 	    trigger_tmp.gtp.tagh_pattern   =  stoi(triggerTypes[jj][13],nullptr,0);
 	  }
-
 	  trig_found++;
 	}  else if(triggerTypes[jj][1] == "TOF"){        //  TOF
 	  trigger_tmp.type     =  0x20;


### PR DESCRIPTION
This PR fixes an issue where the **monitoring histogram plots in `Hist_ReconnedThrownKinematics` and `Hist_GenReconTrackComparison` contained fewer events than expected**.
The problem occurred because `isPhysicsEvent` was returning `false` for most events, causing `DEventProcessor_monitoring_hists::Process()` to exit early before any histogram-filling routines were executed.

### Root Cause

The issue stemmed from the handling of the **static variable `triggers_enabled`** inside `DL1MCTrigger_factory::BeginRun()`.

Although both `triggers_enabled` and `RCDB_LOADED` are declared static to **preserve trigger configuration across threads**, `BeginRun()` was **clearing `triggers_enabled` in every thread**.
Since `RCDB_LOADED` was already set to `true` after the first thread completed initialization, subsequent threads **did not repopulate `triggers_enabled` from RCDB**, leaving it empty.

This resulted in:

* `FindTriggers()` returning `trig_found == 0`
* `DL1MCTrigger` not being created
* `L1TriggerBits` remaining unset
* `isPhysicsEvent` returning `false`
* Histogram-filling actions being skipped

This issue was **not visible in single-threaded runs**, where `BeginRun()` executed only once and the static data remained intact. It surfaced only under **multi-threaded execution**.

### Fix Implemented

`DL1MCTrigger_factory::BeginRun()` has been updated to **clear `triggers_enabled` only when `RCDB_LOADED == false`**.
This ensures that:

* Static trigger configuration persists correctly across all threads.
* RCDB data is loaded once and retained throughout execution.
* All threads share consistent trigger information.
* `isPhysicsEvent` is correctly evaluated, allowing histograms to be properly filled.

**Fixes:** #1060
