### PR TITLE
(1) Remove calls to hough transform algorithm.  This was very expensi…

### DIFF
--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.cc
@@ -5,7 +5,7 @@
 // Creator: staylor (on Linux ifarml1.jlab.org 2.4.21-47.0.1.ELsmp i686)
 //
 /// This factory links segments in the FDC packages into track candidates 
-/// by swimming through the field from one package to the next.
+/// by projecting through the field from one package to the next.
 
 #include "DTrackCandidate_factory_FDCCathodes.h"
 
@@ -18,10 +18,16 @@
 #include "FDC/DFDCPseudo.h"
 #include "FDC/DFDCSegment.h"
 #include "DHelicalFit.h"
-#include "DHoughFind.h"
 #include <TROOT.h>
 #include <TH1F.h>
 #include <TH2F.h>
+
+//------------------
+// Init
+//------------------
+void DTrackCandidate_factory_FDCCathodes::Init(void)
+{ 
+}
 
 ///
 /// DTrackCandidate_factory_FDCCathodes::BeginRun
@@ -58,32 +64,37 @@ void DTrackCandidate_factory_FDCCathodes::BeginRun(const std::shared_ptr<const J
   BEAM_VAR=1.;
   app->SetDefaultParameter("TRKFIND:BEAM_VAR",BEAM_VAR);
 
-  FDC_HOUGH_THRESHOLD=10.;
-  app->SetDefaultParameter("TRKFIND:FDC_HOUGH_THRESHOLD",FDC_HOUGH_THRESHOLD);
   ADD_VERTEX_POINT=true;
   app->SetDefaultParameter("TRKFIND:ADD_VERTEX_POINT", ADD_VERTEX_POINT);
  
   if(DEBUG_HISTS) {
     root_lock->RootWriteLock();
+    
     match_dist_fdc=(TH2F*)gROOT->FindObject("match_dist_fdc");
     if (!match_dist_fdc){ 
       match_dist_fdc=new TH2F("match_dist_fdc",
 			      "Matching distance for connecting FDC segments",
-			      50,0.,7,500,0,100.);
+			      500,0.,500,500,0,100.);
     }
     match_center_dist2=(TH2F*)gROOT->FindObject("match_center_dist2");
     if (!match_center_dist2){
-      match_center_dist2=new TH2F("match_center_dist2","matching distance squared between two circle centers vs p",50,0,1.5,100,0,100);
-      match_center_dist2->SetXTitle("p [GeV/c]");
+      match_center_dist2=new TH2F("match_center_dist2","matching distance squared between two circle centers vs rc",500,0,500.,100,0,100);
+      match_center_dist2->SetXTitle("rc [cm]");
       match_center_dist2->SetYTitle("(#Deltad)^{2} [cm^{2}]");
     }
 
     root_lock->RootUnLock();
   }
-    
-  // Initialize the stepper
-  stepper=new DMagneticFieldStepper(bfield);
-  stepper->SetStepSize(1.0);
+  
+  // For matching
+  app->SetDefaultParameter("TRKFIND:SEGMENT_MATCH_SCALE",
+			      SEGMENT_MATCH_SCALE);
+  app->SetDefaultParameter("TRKFIND:SEGMENT_MATCH_HI_CUT",
+			      SEGMENT_MATCH_HI_CUT);
+  app->SetDefaultParameter("TRKFIND:SEGMENT_MATCH_LO_CUT",
+			      SEGMENT_MATCH_LO_CUT);
+  app->SetDefaultParameter("TRKFIND:CENTER_MATCH_CUT",
+			      CENTER_MATCH_CUT);
 }
 
 
@@ -92,22 +103,13 @@ void DTrackCandidate_factory_FDCCathodes::BeginRun(const std::shared_ptr<const J
 //------------------
 void DTrackCandidate_factory_FDCCathodes::EndRun()
 {
-  if (stepper) {
-    delete stepper;
-    stepper = nullptr;
-  }
 }
 //------------------
 // Finish
 //------------------
 void DTrackCandidate_factory_FDCCathodes::Finish()
 {
-  if (stepper) {
-    delete stepper;
-    stepper = nullptr;
-  }  
 }
-
 
 // Local routine for sorting segments by charge and curvature
 inline bool DTrackCandidate_segment_cmp(const DFDCSegment *a, const DFDCSegment *b){
@@ -132,13 +134,13 @@ inline bool DTrackCandidate_segment_cmp_by_z(const DFDCSegment *a,
 void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JEvent>& event)
 {
   if (!USE_FDC) return;
-
+  
   vector<const DFDCSegment*>segments;
   event->Get(segments);
 
   // abort if there are no segments
   if (segments.size()==0.) return;
-
+   
   std::stable_sort(segments.begin(), segments.end(), DTrackCandidate_segment_cmp);
 
   // Group segments by package
@@ -181,7 +183,6 @@ void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JE
     }
   } 
   
-  
   // Link triplets with pairs to form groups of four linked segments
   vector<int>is_quadrupled(triplets.size());
   vector<vector<const DFDCSegment *> >quadruplets;
@@ -199,14 +200,22 @@ void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JE
     }
   }
 
-  // Start gathering groups into a list of linked segments to elevate to track
-  // candidates
-  vector<vector<const DFDCSegment *> >mytracks;
+  // Elevate quadruplets to track candidates
   for (unsigned int i=0;i<quadruplets.size();i++){
-    mytracks.push_back(quadruplets[i]);
+    MakeCandidate(quadruplets[i]);
   }
+
+  // if we could not link some of the triplets to other segments, create
+  // three-segment track candidates
+  for (unsigned int i=0;i<triplets.size();i++){
+    if (is_quadrupled[i]==0){
+      MakeCandidate(triplets[i]);
+    }
+  }
+
   // If we could not link some of the pairs together, create two-segment 
   // "tracks"
+  vector<vector<const DFDCSegment *> >mytracks;
   for (unsigned int i=0;i<is_tripled.size();i++){
     if (is_tripled[i]==0){
       vector<const DFDCSegment *>mytrack;
@@ -215,144 +224,74 @@ void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JE
       mytracks.push_back(mytrack);
     }
   }
-  // if we could not link some of the triplets to other segments, create 
-  // three-segment "tracks"
-  for (unsigned int i=0;i<triplets.size();i++){
-    if (is_quadrupled[i]==0){
-      mytracks.push_back(triplets[i]);
-    }
-  }
 
-  // For each set of matched segments, redo the helical fit with all the hits 
-  // and create a new track candidate
-  for (unsigned int i=0;i<mytracks.size();i++){  
-    // Create the fit object and add the hits
-    DHelicalFit fit; 
-    // Fake point at origin
-    if (ADD_VERTEX_POINT){
-      fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
-    }
-    double max_r=0.;
-    rc=0.,xc=0.,yc=0.,tanl=0.; //initialize helix variables
-    q=mytracks[i][0]->q;
-    // create a guess for rc and add hits
-    for (unsigned int m=0;m<mytracks[i].size();m++){
-      rc+=mytracks[i][m]->rc;
-      xc+=mytracks[i][m]->xc;
-      yc+=mytracks[i][m]->yc;
-      tanl+=mytracks[i][m]->tanl;
-      for (unsigned int n=0;n<mytracks[i][m]->hits.size();n++){
-	const DFDCPseudo *hit=mytracks[i][m]->hits[n];
-	fit.AddHit(hit);
-	
-	double r=hit->xy.Mod();
-	if (r>max_r){
-	  max_r=r;
+  // For each set of matched segments, redo the helical fit with all the hits,
+  // create a new track candidate and try to match to another pair of matched
+  // segments
+  vector<int>is_matched(mytracks.size());
+  for (unsigned int i=0;i<mytracks.size();i++){
+    if (is_matched[i]==0){
+      MakeCandidate(mytracks[i]);
+      for (unsigned int j=i+1;j<mytracks.size();j++){
+	if (mytracks[j][0]->package > mytracks[i][1]->package){
+	  // Try to connect the track stubs together
+	  const DFDCPseudo *myhit=mytracks[j][0]->hits[0];
+	  unsigned int index=mData.size()-1;
+	  double doca2=DocaSqToHelix(mData[index],myhit);
+	  bool got_match=(doca2<MatchR(mData[index]->rc));
+	  // if this does not work, try to match using the centers of the
+	  // circles
+	  if (got_match==false){
+	    double dx=mytracks[j][0]->xc-mData[index]->xc;
+	    double dy=mytracks[j][0]->yc-mData[index]->yc;
+	    if (dx*dx+dy*dy<CENTER_MATCH_CUT) got_match=true;
+	  }
+	  if (got_match==false){
+	    double dx=mytracks[j][1]->xc-mData[index]->xc;
+	    double dy=mytracks[j][1]->yc-mData[index]->yc;
+	    if (dx*dx+dy*dy<CENTER_MATCH_CUT) got_match=true;
+	  }
+	  if (got_match){
+	    is_matched[j]=1;
+
+	    // Add the new segments as associated objects to mData[index]
+	    mData[index]->AddAssociatedObject(mytracks[j][0]);
+	    mData[index]->AddAssociatedObject(mytracks[j][1]);
+	    
+	    vector<const DFDCSegment*>segments=mytracks[i];
+	    segments.insert(segments.end(),mytracks[j].begin(),mytracks[j].end());
+
+	    // Create fit object and perform helical fit
+	    DHelicalFit fit;
+	    DoHelicalFit(segments,fit);
+    
+	    //circle fit parameters
+	    mData[index]->rc=fit.r0;
+	    mData[index]->xc=fit.x0;
+	    mData[index]->yc=fit.y0;
+
+	    // Get position and momentum just upstream of first hit
+	    DVector3 pos,mom;
+	    GetPositionAndMomentum(fit,segments[0],pos,mom);
+	    
+	    mData[index]->chisq=fit.chisq;
+	    mData[index]->Ndof=fit.ndof;
+	    double q=FactorForSenseOfRotation*fit.h;
+	    mData[i]->setPID((q > 0.0) ? PiPlus : PiMinus);
+	    mData[i]->setPosition(pos);
+	    mData[i]->setMomentum(mom); 
+	  }
 	}
       }
     }
-    double mysize=double(mytracks[i].size());
-    rc/=mysize;
-    xc/=mysize;
-    yc/=mysize;
-    tanl/=mysize;
-
-    // Do the fit
-    if (fit.FitTrackRiemann(rc)==NOERROR){    
-      // New track parameters
-      tanl=fit.tanl;
-      xc=fit.x0;
-      yc=fit.y0;
-      rc=fit.r0;
-      q=FactorForSenseOfRotation*fit.h;
-
-      // Look for cases where the momentum is unrealistically large...
-      const DFDCPseudo *myhit=mytracks[0][0]->hits[0];
-      double Bz=fabs(bfield->GetBz(myhit->xy.X(),myhit->xy.Y(),myhit->wire->origin.z()));
-      double p=0.003*fit.r0*Bz/cos(atan(fit.tanl));
-
-      // Prune the fake hit at the origin in case we need to use an alternate
-      // fit
-      if (ADD_VERTEX_POINT){
-	fit.PruneHit(0);
-      }
-      if (p>10.){//... try alternate circle fit
-	fit.FitCircle();
-	rc=fit.r0;
-	xc=fit.x0;
-	yc=fit.y0;
-      } 
-      if (rc<0.5*max_r && max_r<10.0){
-	// ... we can also have issues near the beam line:
-	// Try to fix relatively high momentum tracks in the very forward 
-	// direction that look like low momentum tracks due to small pt.
-	// Assume that the particle came from the center of the target.
-	fit.FitTrack_FixedZvertex(TARGET_Z);
-	tanl=fit.tanl;
-	rc=fit.r0;
-	xc=fit.x0;
-	yc=fit.y0;
-	fit.FindSenseOfRotation();
-	q=FactorForSenseOfRotation*fit.h;      
-      }
-    }
-    
-    // Create new track, starting with the most upstream segment
-    DTrackCandidate *track = new DTrackCandidate;
-    //circle fit parameters
-    track->rc=rc;
-    track->xc=xc;
-    track->yc=yc;
-
-    // Get the momentum and position just upstream of first hit
-    DVector3 mom,pos;
-    GetPositionAndMomentum(mytracks[i],pos,mom);
-    
-    track->chisq=fit.chisq;
-    track->Ndof=fit.ndof;
-    track->setPID((q > 0.0) ? PiPlus : PiMinus);
-    track->setPosition(pos);
-    track->setMomentum(mom);
-    
-    for (unsigned int m=0;m<mytracks[i].size();m++){
-      track->AddAssociatedObject(mytracks[i][m]);
-    }
-    
-    Insert(track); 
- 
   }
 
-  
   // Now try to attach stray segments to existing tracks
   for (unsigned int i=0;i<4;i++){
     for (unsigned int k=0;k<packages[i].size();k++){
       DFDCSegment *segment=packages[i][k];
-      if (is_paired[i][k]==0 && LinkStraySegment(segment)) is_paired[i][k]=1;
-    }
-  }
- 
-  vector<pair<unsigned int,unsigned int> >unused_segments;
-  for (unsigned int j=0;j<4;j++){
-    for (unsigned int i=0;i<packages[j].size();i++){
-      if (is_paired[j][i]==0){
-	unused_segments.push_back(make_pair(j,i));
-      }
-    }
-  }
-
-  // Find track candidates using Hough transform
-  if (unused_segments.size()>1){
-    if (LinkSegmentsHough(unused_segments,packages,is_paired)){
-      unused_segments.clear();
-      for (unsigned int j=0;j<4;j++){
-	for (unsigned int i=0;i<packages[j].size();i++){
-	  if (is_paired[j][i]==0){
-	    unused_segments.push_back(make_pair(j,i));
-	  }
-	}
-      }
-      if (unused_segments.size()>1){
-	LinkSegmentsHough(unused_segments,packages,is_paired);
+      if (is_paired[i][k]==0 && LinkStraySegment(segment)){
+	is_paired[i][k]=1;
       }
     }
   }
@@ -373,11 +312,11 @@ void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JE
 	track->xc=segment->xc;
 	track->yc=segment->yc;
 	
+	track->chisq=segment->chisq;
+	track->Ndof=segment->Ndof;
+	track->setPID((segment->q > 0.0) ? PiPlus : PiMinus);
 	track->setPosition(pos);
 	track->setMomentum(mom);
-	track->setPID((segment->q > 0.0) ? PiPlus : PiMinus);
-	track->Ndof=segment->Ndof;
-	track->chisq=segment->chisq;
       
 	track->AddAssociatedObject(segment);
 	
@@ -389,23 +328,37 @@ void DTrackCandidate_factory_FDCCathodes::Process(const std::shared_ptr<const JE
   return;
 }
 
+// Project segment1 to a hit in segment 2 and compute the square of the doca
+// between the projection and the hit
+double DTrackCandidate_factory_FDCCathodes::DocaSqToHelix(const DFDCSegment *segment1,const DFDCSegment *segment2) const {
+   const DFDCPseudo *hit1=segment1->hits[0]; 
+   const DFDCPseudo *hit2=segment2->hits[0];
+   double z1=hit1->wire->origin.z();
+   double z2=hit2->wire->origin.z();
+   double x2=hit2->xy.X();
+   double y2=hit2->xy.Y();
+   double phi=segment1->Phi1+(z1-z2)*segment1->q/(segment1->rc*segment1->tanl);
+   double dx=segment1->xc+segment1->rc*cos(phi)-x2;
+   double dy=segment1->yc+segment1->rc*sin(phi)-y2;
+   
+   return dx*dx+dy*dy;
+}
 
-// Routine to do a crude match between fdc points and a helical approximation to
-// the trajectory
-double DTrackCandidate_factory_FDCCathodes::DocaSqToHelix(const DFDCPseudo *hit){
-  double sperp=(hit->wire->origin.z()-zs)*cotl;
-  double twoks=twokappa*sperp;
-  double sin2ks=sin(twoks);
-  double cos2ks=cos(twoks);
-  double one_minus_cos2ks=1.-cos2ks;
-  double one_over_twokappa=1./twokappa;
- 
-  double x=xs+(cosphi*sin2ks-sinphi*one_minus_cos2ks)*one_over_twokappa;
-  double y=ys+(sinphi*sin2ks+cosphi*one_minus_cos2ks)*one_over_twokappa;
-  double dx=x-hit->xy.X();
-  double dy=y-hit->xy.Y();
+// Project track candidate to a hit in a segment and compute the square of the 
+// doca between the projection and the hit
+double DTrackCandidate_factory_FDCCathodes::DocaSqToHelix(const DTrackCandidate *candidate,const DFDCPseudo *hit) const {
+  DVector3 pos=candidate->position();
+  DVector3 mom=candidate->momentum();
+  double z2=hit->wire->origin.z();
+  double x2=hit->xy.X();
+  double y2=hit->xy.Y();
+  double Phi1=atan2(pos.y()-candidate->yc,pos.x()-candidate->xc);
+  double mytanl=tan(M_PI_2-mom.Theta());
+  double phi=Phi1+(pos.z()-z2)*candidate->charge()/(candidate->rc*mytanl);
+  double dx=candidate->xc+candidate->rc*cos(phi)-x2;
+  double dy=candidate->yc+candidate->rc*sin(phi)-y2;
 
-  return (dx*dx+dy*dy);
+  return dx*dx+dy*dy;
 }
 
 // Propagate track from one package to the next and look for a match to a 
@@ -414,28 +367,24 @@ DFDCSegment *DTrackCandidate_factory_FDCCathodes::GetTrackMatch(DFDCSegment *seg
 								vector<DFDCSegment*>package,
 								unsigned int &match_id){
   DFDCSegment *match=NULL;
-
-  // Get the position and momentum at the exit of the package for the 
-  // current segment
-  GetPositionAndMomentum(segment);
   
   // Match to the next package
   double doca2_min=1e6,doca2;
   for (unsigned int j=0;j<package.size();j++){
     DFDCSegment *segment2=package[j];
-    doca2=DocaSqToHelix(segment2->hits[0]);
+    doca2=DocaSqToHelix(segment,segment2);
 
     if (doca2<doca2_min){
       doca2_min=doca2;
-      if(doca2<Match(p)){
-	match=segment2;
-	match_id=j;
-      }
+      match_id=j;
     }
+  }
+  if (doca2_min<MatchR(segment->rc)){
+    match=package[match_id];
   }
 
   if(DEBUG_HISTS){
-    match_dist_fdc->Fill(p,doca2_min);
+    match_dist_fdc->Fill(segment->rc,doca2_min);
   }
   if (match!=NULL) return match;
 
@@ -444,16 +393,16 @@ DFDCSegment *DTrackCandidate_factory_FDCCathodes::GetTrackMatch(DFDCSegment *seg
   doca2_min=1e6;
   for (unsigned int i=0;i<package.size();i++){
     DFDCSegment *segment2=package[i];
-    GetPositionAndMomentum(segment2);
-    doca2=DocaSqToHelix(segment->hits[segment->hits.size()-1]);
+    doca2=DocaSqToHelix(segment2,segment);
+
     if (doca2<doca2_min){
-      doca2_min=doca2;
-      if (doca2<Match(p)){
+      doca2_min=doca2;	
+      if (doca2<MatchR(segment2->rc)){
 	match=segment2;
 	match_id=i;
       }
     }       
-  }
+  } 
   if (match!=NULL) return match;
 
   // Match by centers of circles
@@ -467,64 +416,27 @@ DFDCSegment *DTrackCandidate_factory_FDCCathodes::GetTrackMatch(DFDCSegment *seg
     
     if (circle_center_diff2<circle_center_diff2_min){
       circle_center_diff2_min=circle_center_diff2;
-      if (circle_center_diff2_min<9.0){
+      if (circle_center_diff2_min<CENTER_MATCH_CUT){
 	match=segment2;
 	match_id=j;
       }
     }
   }
   if (DEBUG_HISTS){
-    match_center_dist2->Fill(p,circle_center_diff2_min);
+    match_center_dist2->Fill(segment->rc,circle_center_diff2_min);
   }  
   return match;
-}
-
-// Obtain position and momentum at the exit of a given package using the 
-// helical track model.
-//
-jerror_t DTrackCandidate_factory_FDCCathodes::GetPositionAndMomentum(const DFDCSegment *segment){
-  // Position of track segment at last hit plane of package
-  xs=segment->xc+segment->rc*cos(segment->Phi1);
-  ys=segment->yc+segment->rc*sin(segment->Phi1);
-  zs=segment->hits[0]->wire->origin.z();
-
-  // Track parameters
-  //double kappa=segment->q/(2.*segment->rc);
-  double my_phi0=segment->phi0;
-  double my_tanl=segment->tanl;
-  double z0=segment->z_vertex; 
-  twokappa=FactorForSenseOfRotation*segment->q/segment->rc;
-
-  cotl=1./my_tanl;
-
-  // Useful intermediate variables
-  double cosp=cos(my_phi0);
-  double sinp=sin(my_phi0);
-  double twoks=twokappa*(zs-z0)*cotl;
-  double sin2ks=sin(twoks);
-  double cos2ks=cos(twoks); 
-  
-  // Get Bfield
-  double Bz=fabs(bfield->GetBz(xs,ys,zs));
-
-  // Momentum
-  p=0.003*Bz*segment->rc/cos(atan(my_tanl));
-
-  cosphi=cosp*cos2ks-sinp*sin2ks;
-  sinphi=sinp*cos2ks+cosp*sin2ks;
-
-  return NOERROR;
 }
 
 // Routine to return momentum and position given the helical parameters and the
 // z-component of the magnetic field
 jerror_t 
-DTrackCandidate_factory_FDCCathodes::GetPositionAndMomentum(
-				        vector<const DFDCSegment *>segments,
+DTrackCandidate_factory_FDCCathodes::GetPositionAndMomentum(const DHelicalFit &fit,							    
+							    const DFDCSegment *segment,
 							    DVector3 &pos,
 							    DVector3 &mom){
   // Hit in the most upstream package
-  const DFDCPseudo *hit=segments[0]->hits[segments[0]->hits.size()-1];
+  const DFDCPseudo *hit=segment->hits[segment->hits.size()-1];
   double zhit=hit->wire->origin.z();
   double xhit=hit->xy.X();
   double yhit=hit->xy.Y();
@@ -532,41 +444,24 @@ DTrackCandidate_factory_FDCCathodes::GetPositionAndMomentum(
   // Position
   double dz=1.;
   double zmin=zhit-dz;
-  double phi1=atan2(yhit-yc,xhit-xc);
-  double q_over_rc_tanl=q/(rc*tanl);
+  double phi1=atan2(yhit-fit.y0,xhit-fit.x0);
+  double q=FactorForSenseOfRotation*fit.h;    
+  double q_over_rc_tanl=q/(fit.r0*fit.tanl);
   double dphi_s=dz*q_over_rc_tanl;
   double dphi1=phi1-dphi_s;// was -
-  double x=xc+rc*cos(dphi1);
-  double y=yc+rc*sin(dphi1);
+  double x=fit.x0+fit.r0*cos(dphi1);
+  double y=fit.y0+fit.r0*sin(dphi1);
   pos.SetXYZ(x,y,zmin);
 
   dphi1*=-1.;
   if (FactorForSenseOfRotation*q<0) dphi1+=M_PI;
-
-  // Find the average Bz
-  double Bz=0.;
-  double z=zmin;
-  unsigned int num_segments=segments.size();
-  double zmax=segments[num_segments-1]->hits[0]->wire->origin.z();
-  unsigned int num_samples=20*num_segments;
-  double one_over_denom=1./double(num_samples);
-  dz=(zmax-zmin)*one_over_denom;
-  for (unsigned int i=0;i<num_samples;i++){
-    double my_dphi=phi1+(z-zmin)*q_over_rc_tanl;
-    x=xc+rc*cos(my_dphi);
-    y=yc+rc*sin(my_dphi);
-    Bz+=bfield->GetBz(x,y,z);
-
-    z+=dz;
-  }
-  Bz=fabs(Bz)*one_over_denom;
   
-  
-  // Momentum 
-  double pt=0.003*Bz*rc; 
+  // Momentum
+  double Bz=fabs(bfield->GetBz(xhit,yhit,zhit));
+  double pt=0.003*Bz*fit.r0; 
   double px=pt*sin(dphi1);
   double py=pt*cos(dphi1);
-  double pz=pt*tanl;
+  double pz=pt*fit.tanl;
   mom.SetXYZ(px,py,pz);
 
   return NOERROR;
@@ -638,26 +533,7 @@ void DTrackCandidate_factory_FDCCathodes::LinkSegments(unsigned int pack1,
       is_paired[pack2][match_id]=1;
       is_paired[pack1][i]=1;
     }
-  
   }
-}
-
-// Routine for matching to a segment using the stepper
-bool DTrackCandidate_factory_FDCCathodes::GetTrackMatch(double q,
-							DVector3 &pos,
-							DVector3 &mom,
-							const DFDCSegment *segment){
-  const DVector3 norm(0,0,1.);
-  stepper->SetCharge(q);
-  
-  const DFDCPseudo *hit=segment->hits[0];
-  if (stepper->SwimToPlane(pos,mom,hit->wire->origin,norm,NULL)==false){
-    double dx=hit->xy.X()-pos.x();
-    double dy=hit->xy.Y()-pos.y();
-    double d2=dx*dx+dy*dy;
-    if (d2<Match(mom.Mag())) return true;
-  }
-  return false;
 }
 
 // Routine that tries to link a stray segment with an already existing track
@@ -668,8 +544,7 @@ bool DTrackCandidate_factory_FDCCathodes::LinkStraySegment(const DFDCSegment *se
     bool got_segment_in_package=false;
 
     // Get the segments already associated with this track 
-    vector<const DFDCSegment*>segments;
-    mData[i]->GetT(segments);
+    vector<const DFDCSegment*>segments=mData[i]->Get<DFDCSegment>();
     // Flag if segment is in a package that has already been used for this 
     // candidate
     for (unsigned int j=0;j<segments.size();j++){
@@ -679,231 +554,148 @@ bool DTrackCandidate_factory_FDCCathodes::LinkStraySegment(const DFDCSegment *se
       }
     }
     if (got_segment_in_package==false){
-      // Try to link this segment to an existing candidate
-      DVector3 pos=mData[i]->position();
-      DVector3 mom=mData[i]->momentum();
-
-      // Switch the direction of the momentum if we would need to backtrack to 
-      // get to the segment
-      if (segment->hits[0]->wire->origin.z()<pos.z()){
-	mom=-1.0*mom;
-      }
-      // Match by swimming to a plane in the stray segment
-      bool got_match=GetTrackMatch(mData[i]->charge(),pos,mom,segment);      
-      // if this does not work, try to match using the centers of the circles
-      if (got_match==false){
-	double dx=segment->xc-mData[i]->xc;
-	double dy=segment->yc-mData[i]->yc;
-	if (dx*dx+dy*dy<9.0) got_match=true;
-      }
-      if (got_match){
-	// Add the segment as an associated object to mData[i]
-	mData[i]->AddAssociatedObject(segment);
-   
-	// Add the new segment and sort by z
-	segments.push_back(segment);
-	stable_sort(segments.begin(),segments.end(),DTrackCandidate_segment_cmp_by_z);
-	
-	// Create fit object and add hits
-	DHelicalFit fit;  
-	// Fake point at origin
-	if (ADD_VERTEX_POINT){
-	  fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+      // Sort segments already associated with the track and try to match
+      // stray segments beyond one end or the other of the existing track
+      sort(segments.begin(),segments.end(),DTrackCandidate_segment_cmp_by_z);
+      unsigned int max_i=segments.size()-1;
+      if (segment->package<segments[0]->package 
+	  || segment->package>segments[max_i]->package){
+	const DFDCPseudo *myhit=segment->hits[0];
+	double doca2=DocaSqToHelix(mData[i],myhit);
+	bool got_match=(doca2<MatchR(mData[i]->rc));
+	// if this does not work, try to match using the centers of the circles
+	if (got_match==false){
+	  double dx=segment->xc-mData[i]->xc;
+	  double dy=segment->yc-mData[i]->yc;
+	  if (dx*dx+dy*dy<CENTER_MATCH_CUT) got_match=true;
 	}
-	double max_r=0.;
-	for (unsigned int m=0;m<segments.size();m++){ 
-	  for (unsigned int k=0;k<segments[m]->hits.size();k++){
-	    const DFDCPseudo *hit=segments[m]->hits[k];
-	    fit.AddHit(hit);
+	if (got_match){
+	  // Add the segment to mData[i]
+	  mData[i]->AddAssociatedObject(segment);
 
-	    double r=hit->xy.Mod();
-	    if (r>max_r){
-	      max_r=r;
-	    }
-	  }
-	}
+	  // Add the new segment and sort by z
+	  segments.push_back(segment);
+	  stable_sort(segments.begin(),segments.end(),DTrackCandidate_segment_cmp_by_z);
+	  
+	  // Create fit object and perform helical fit
+	  DHelicalFit fit;
+	  DoHelicalFit(segments,fit);
+	     
+	  //circle fit parameters
+	  mData[i]->rc=fit.r0;
+	  mData[i]->xc=fit.x0;
+	  mData[i]->yc=fit.y0;
 	
-	// Redo the helical fit with the additional hits
-	if (fit.FitTrackRiemann(mData[i]->rc)==NOERROR){      	
-	  rc=fit.r0;
-	  tanl=fit.tanl;
-	  xc=fit.x0;
-	  yc=fit.y0;
-	  q=FactorForSenseOfRotation*fit.h;
-	  
-	   // Look for cases where the momentum is unrealistically large...
-	  const DFDCPseudo *myhit=segments[0]->hits[0];
-	  double Bz=fabs(bfield->GetBz(myhit->xy.X(),myhit->xy.Y(),myhit->wire->origin.z()));
-	  double p=0.003*fit.r0*Bz/cos(atan(fit.tanl));
-	  
-	  // Prune the fake hit at the origin in case we need to use an 
-	  // alternate fit
-	  if (ADD_VERTEX_POINT){
-	    fit.PruneHit(0);
-	  }
-	  if (p>10.){//... try alternate circle fit 
-	    fit.FitCircle();
-	    rc=fit.r0;
-	    xc=fit.x0;
-	    yc=fit.y0;
-	  } 
-	  if (rc<0.5*max_r && max_r<10.0){
-	    // ... we can also have issues near the beam line:
-	    // Try to fix relatively high momentum tracks in the very forward 
-	    // direction that look like low momentum tracks due to small pt.
-	    // Assume that the particle came from the center of the target.	
-	    fit.FitTrack_FixedZvertex(TARGET_Z);
-	    tanl=fit.tanl;
-	    rc=fit.r0;
-	    xc=fit.x0;
-	    yc=fit.y0;
-	    fit.FindSenseOfRotation();
-	    q=FactorForSenseOfRotation*fit.h;      
-	  }
-	  
 	  // Get position and momentum just upstream of first hit
-	  GetPositionAndMomentum(segments,pos,mom);
+	  DVector3 pos,mom;
+	  GetPositionAndMomentum(fit,segments[0],pos,mom);
 	  
 	  mData[i]->chisq=fit.chisq;
 	  mData[i]->Ndof=fit.ndof;
+	  double q=FactorForSenseOfRotation*fit.h;
 	  mData[i]->setPID((q > 0.0) ? PiPlus : PiMinus);
 	  mData[i]->setPosition(pos);
 	  mData[i]->setMomentum(mom); 
-	}
-
-	return true;
+	
+	  return true;
+	} // got a match to a stray segment
       }
     }
-  }
+  } // loop over track candidates
+
   return false;
 }
 
-// Find circles using Hough transform
-bool DTrackCandidate_factory_FDCCathodes::LinkSegmentsHough(vector<pair<unsigned int,unsigned int> >&unused_segments,
-							    vector<DFDCSegment *>packages[4],
-							    vector<vector<int> >&is_paired){
-  DHoughFind hough(-400.0, +400.0, -400.0, +400.0, 100, 100);
-    
-  vector<pair<unsigned int, unsigned int> >associated_segments;
-  for (unsigned int i=0;i<unused_segments.size();i++){
-    unsigned int packNum=unused_segments[i].first;
-    unsigned int segmentNum=unused_segments[i].second;    
-    const DFDCSegment* segment=packages[packNum][segmentNum];
-    for (unsigned int m=0;m<segment->hits.size();m++){
-      hough.AddPoint(segment->hits[m]->xy);
-      associated_segments.push_back(unused_segments[i]);
+// For a given sent of linked segments, perform a helical fit using all the hits
+// and make a new track candidate object
+void DTrackCandidate_factory_FDCCathodes::MakeCandidate(vector<const DFDCSegment *>&mytrack){
+  // Create the fit object and perform the fit
+  DHelicalFit fit;
+  DoHelicalFit(mytrack,fit);
+  
+  // Create new track, starting with the most upstream segment
+  DTrackCandidate *track = new DTrackCandidate;
+
+  //circle fit parameters
+  track->rc=fit.r0;
+  track->xc=fit.x0;
+  track->yc=fit.y0;
+  
+  // Get the momentum and position just upstream of first hit
+  DVector3 mom,pos;
+  GetPositionAndMomentum(fit,mytrack[0],pos,mom);
+
+  track->chisq=fit.chisq;
+  track->Ndof=fit.ndof;
+  double q=FactorForSenseOfRotation*fit.h;
+  track->setPID((q > 0.0) ? PiPlus : PiMinus);
+  track->setPosition(pos);
+  track->setMomentum(mom);   
+
+  for (unsigned int m=0;m<mytrack.size();m++){
+    track->AddAssociatedObject(mytrack[m]);
+  }
+  
+  Insert(track); 
+}
+
+// Perform a Riemann Helical fit using the set of hits in the track candidate 
+// "mytrack"
+void DTrackCandidate_factory_FDCCathodes::DoHelicalFit(vector<const DFDCSegment *>&mytrack,DHelicalFit &fit){
+  // Fake point at origin
+  if (ADD_VERTEX_POINT){
+    fit.AddHitXYZ(0.,0.,TARGET_Z,BEAM_VAR,BEAM_VAR,0.);
+  }
+  double max_r=0.;
+  double rc=0.;
+  // create a guess for rc and add hits
+  for (unsigned int m=0;m<mytrack.size();m++){
+    rc+=mytrack[m]->rc;
+    for (unsigned int n=0;n<mytrack[m]->hits.size();n++){
+      const DFDCPseudo *hit=mytrack[m]->hits[n];
+      fit.AddHit(hit);
+      
+      double r=hit->xy.Mod();
+      if (r>max_r){
+	max_r=r;
+      }
     }
   }
-        
-  DVector2 Ro = hough.Find();
-  if(hough.GetMaxBinContent()>FDC_HOUGH_THRESHOLD){	
-    // Zoom in on resonance a little
-    double width = 60.0;
-    hough.SetLimits(Ro.X()-width, Ro.X()+width, Ro.Y()-width, Ro.Y()+width, 
-		    100, 100);
-    Ro = hough.Find();
+  double mysize=double(mytrack.size());
+  rc/=mysize;
+
+  // Do the fit
+  if (fit.FitTrackRiemann(rc)==NOERROR){    
+    // Look for cases where the momentum is unrealistically large...
+    const DFDCPseudo *myhit=mytrack[0]->hits[0];
+    double Bz=fabs(bfield->GetBz(myhit->xy.X(),myhit->xy.Y(),myhit->wire->origin.z()));
+    double p=0.003*fit.r0*Bz/cos(atan(fit.tanl));
     
-    // Zoom in on resonance once more
-    width = 8.0;
-    hough.SetLimits(Ro.X()-width, Ro.X()+width, Ro.Y()-width, Ro.Y()+width, 100, 100);
-    Ro = hough.Find();
-    
-    vector<DVector2> points=hough.GetPoints();
-    set<pair<unsigned int, unsigned int> >associated_segments_to_use;
-    unsigned int num_hits_to_use=0;
-    for (unsigned int m=0;m<points.size();m++){
-      // Calculate distance between Hough transformed line (i.e.
-      // the line on which a circle that passes through both the
-      // origin and the point at hit->pos) and the circle center.
-      DVector2 h=0.5*points[m];
-      DVector2 g(h.Y(), -h.X()); 
-      g /= g.Mod();
-      DVector2 Ro_minus_h=Ro-h;	
-      double dist = fabs(g.X()*Ro_minus_h.Y() - g.Y()*Ro_minus_h.X());
-      
-      // If this is not close enough to the found circle's center,
-      // reject it for this track candidate
-      if(dist < 2.0){
-	num_hits_to_use++;
-	associated_segments_to_use.emplace(associated_segments[m]);
-      }
+    // Prune the fake hit at the origin in case we need to use an alternate
+    // fit
+    if (ADD_VERTEX_POINT){
+      fit.PruneHit(0);
     }
-    if (num_hits_to_use>5&&associated_segments_to_use.size()>1){
-      bool same_package=false;
-      set<pair<unsigned int,unsigned int> >::iterator it=associated_segments_to_use.begin();
-      for (; it!=associated_segments_to_use.end(); ++it){
-	unsigned int first_packNo=(*it).first;
-	unsigned int first_segmentNo=(*it).second;
-	set<pair<unsigned int,unsigned int> >::iterator it2=associated_segments_to_use.begin();
-	for (; it2!=associated_segments_to_use.end(); ++it2){
-	  unsigned int packNo=(*it2).first;
-	  unsigned int segmentNo=(*it2).second;
-	  if (packNo==first_packNo){
-	    if (segmentNo==first_segmentNo) continue;
-	    
-	    same_package=true;
-	    break;
-	  }
-	}
-      }
-      if (same_package==false){
-	DHelicalFit fit;
-	
-	set<pair<unsigned int,unsigned int> >::iterator it=associated_segments_to_use.begin();
-	const DFDCSegment *first_segment=NULL;
-	bool got_first_segment=false;
-	for (; it!=associated_segments_to_use.end(); ++it){
-	  unsigned int packNo=(*it).first;
-	  unsigned int segmentNo=(*it).second;	    
-	    DFDCSegment *segment=packages[packNo][segmentNo];
-	    if (got_first_segment==false){
-	      first_segment=segment;
-	      got_first_segment=true;
-	    }
-	    for (unsigned int m=0;m<segment->hits.size();m++){
-	      fit.AddHit(segment->hits[m]);
-	    }
-	    
-	}
-	if (fit.FitTrackRiemann(Ro.Mod())==NOERROR){
-	  rc=fit.r0;
-	  tanl=fit.tanl;
-	  xc=fit.x0;
-	  yc=fit.y0;
-	  q=FactorForSenseOfRotation*fit.h;
-	  
-	  // Get the momentum and position at a specific z position
-	  DVector3 mom, pos;
-	  GetPositionAndMomentum(first_segment,pos,mom);
-	  
-	  // Create new track
-	  DTrackCandidate *track = new DTrackCandidate;
-	  track->rc=rc;
-	  track->xc=xc;
-	  track->yc=yc;
-	  
-	  track->setPosition(pos);
-	  track->setMomentum(mom);
-	  track->setPID((q > 0.0) ? PiPlus : PiMinus);
-	  track->Ndof=fit.ndof;
-	  track->chisq=fit.chisq;
-	  
-	  for (it=associated_segments_to_use.begin(); 
-	       it!=associated_segments_to_use.end(); ++it){
-	    unsigned int packNo=(*it).first;
-	    unsigned int segmentNo=(*it).second;	    
-	    DFDCSegment *segment=packages[packNo][segmentNo];
-	    track->AddAssociatedObject(segment);
-	    is_paired[packNo][segmentNo]=1;
-	  }
-	  
-	  Insert(track);
-	
-	  return true;
-	}
-      }
+    if (p>10.){//... try alternate circle fit
+      fit.FitCircle();
+      fit.FindSenseOfRotation();
+    } 
+    if (fit.r0<0.5*max_r && max_r<10.0){
+      // ... we can also have issues near the beam line:
+      // Try to fix relatively high momentum tracks in the very forward 
+      // direction that look like low momentum tracks due to small pt.
+      // Assume that the particle came from the center of the target.
+      fit.FitTrack_FixedZvertex(TARGET_Z);
+      fit.FindSenseOfRotation();
     }
-  } // got resonance
-  
-  return false;
+  }
+  else{
+    // Set tanl to guess from one of the segments
+    fit.tanl=mytrack[0]->tanl;
+    fit.h=FactorForSenseOfRotation*mytrack[0]->q;
+    if (ADD_VERTEX_POINT){
+      fit.PruneHit(0);
+    }
+    fit.FitCircle();
+  }
 }

--- a/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.h
+++ b/src/libraries/TRACKING/DTrackCandidate_factory_FDCCathodes.h
@@ -10,6 +10,7 @@
 
 #include <JANA/JFactoryT.h>
 #include "DTrackCandidate.h"
+#include <DTrackFinder.h>
 #include <DMatrix.h>
 #include "FDC/DFDCSegment_factory.h"
 #include "HDGEOMETRY/DMagneticFieldMap.h"
@@ -46,17 +47,15 @@ class DTrackCandidate_factory_FDCCathodes:public JFactoryT<DTrackCandidate>{
 
  private:  
   const DMagneticFieldMap *bfield;
-  DMagneticFieldStepper *stepper;
 		
-  //void Init() override;
+  void Init() override;
   void BeginRun(const std::shared_ptr<const JEvent>& event) override;
   void Process(const std::shared_ptr<const JEvent>& event) override;
   void EndRun() override;
   void Finish() override;
 
-  jerror_t GetPositionAndMomentum(const DFDCSegment *segment);
-  jerror_t GetPositionAndMomentum(DVector3 &pos,DVector3 &mom);
-  jerror_t GetPositionAndMomentum(vector<const DFDCSegment *>segments,
+  jerror_t GetPositionAndMomentum(const DHelicalFit &fit,
+				  const DFDCSegment *segment,
 				  DVector3 &pos,DVector3 &mom); 
   jerror_t GetPositionAndMomentum(const DFDCSegment *segment,
 				  DVector3 &pos,DVector3 &mom);
@@ -64,45 +63,40 @@ class DTrackCandidate_factory_FDCCathodes:public JFactoryT<DTrackCandidate>{
   double GetCharge(const DVector3 &pos,const DFDCSegment *segment);
   double GetCharge(const DVector3 &pos,vector<const DFDCSegment *>segments);
 
-  double DocaSqToHelix(const DFDCPseudo *hit);
+  double DocaSqToHelix(const DFDCSegment *segment1,const DFDCSegment *segment2) const;
+  double DocaSqToHelix(const DTrackCandidate *candidate,const DFDCPseudo *hit) const;
+
   DFDCSegment *GetTrackMatch(DFDCSegment *segment,vector<DFDCSegment*>package,
 			     unsigned int &match_id);
   void LinkSegments(unsigned int pack1,vector<DFDCSegment *>packages[4],
 		    vector<pair<const DFDCSegment*,const DFDCSegment*> >&paired_segments, vector<vector<int> >&is_paired); 
-  double Match(double p);
+  double MatchR(double rc) const;
 
-  bool GetTrackMatch(double q,DVector3 &pos,DVector3 &mom,
-		     const DFDCSegment *segment);
+  double DocaToCircle(const DFDCSegment *segment1,const DFDCSegment *segment2) const;
+  double DocaToCircle(const DTrackCandidate *candidate,const DFDCSegment *segment) const;
+
   bool LinkStraySegment(const DFDCSegment *segment);
-  bool LinkSegmentsHough(vector<pair<unsigned int,unsigned int> >&unused_segements,
-			 vector<DFDCSegment *>packages[4],
-			 vector<vector<int> >&is_paired);
-
+  void MakeCandidate(vector<const DFDCSegment *>&mytrack);
+  void DoHelicalFit(vector<const DFDCSegment *>&mytrack,DHelicalFit &fit);
 
   bool DEBUG_HISTS,USE_FDC,ADD_VERTEX_POINT;
 
+  double SEGMENT_MATCH_SCALE=1000.,SEGMENT_MATCH_HI_CUT=100.0;
+  double SEGMENT_MATCH_LO_CUT=5.0;
+  double CENTER_MATCH_CUT=25.0;
   TH2F *match_dist_fdc,*match_center_dist2;
  
   vector<double>z_wires;
-  double TARGET_Z,BEAM_VAR,FDC_HOUGH_THRESHOLD;
+  double TARGET_Z,BEAM_VAR;
   
   double FactorForSenseOfRotation;
-  
-  // Fit parameters
-  double xc,yc,rc,q,tanl;
-  
-  // Parameters at the end of the segment
-  double xs,ys,zs;
-  double p,cosphi,sinphi,twokappa,cotl;
 };
 
-inline double DTrackCandidate_factory_FDCCathodes::Match(double p){
-  double cut=5.5/p;
-  if (cut>9.0) cut=9.0;
-  if (cut<5.) cut=5.0;
+inline double DTrackCandidate_factory_FDCCathodes::MatchR(double rc) const {
+  double cut=SEGMENT_MATCH_SCALE/rc;
+  if (cut>SEGMENT_MATCH_HI_CUT) cut=SEGMENT_MATCH_HI_CUT;
+  if (cut<SEGMENT_MATCH_LO_CUT) cut=SEGMENT_MATCH_LO_CUT;
   return cut;
 }
 
-
 #endif // _DTrackCandidate_factory_FDCCathodes_
-


### PR DESCRIPTION
…ve with very little net benefit -- simple methods using a helical model are more than adequate for making matches between segments.  (2) remove usage of magnetic field stepper -- this is not necessary for the reason stated earlier. (3) made matching parameters configurable via the command line. (4) Simplified DocaSqToHelix code.