### PR TITLE
Port DReaction_factory tag setting from JANA1 to JANA2

### DIFF
--- a/src/plugins/Analysis/cpp_hists/DReaction_factory_cpp_hists.h
+++ b/src/plugins/Analysis/cpp_hists/DReaction_factory_cpp_hists.h
@@ -27,8 +27,8 @@ class DReaction_factory_cpp_hists : public JFactoryT<DReaction>
 		{
 			// This is so that the created DReaction objects persist throughout the life of the program instead of being cleared each event. 
 			SetFactoryFlag(PERSISTENT);
+			SetTag("cpp_hists");
 		}
-		const char* Tag(void){return "cpp_hists";}
 
 	private:
 		void Process(const std::shared_ptr<const JEvent>& event) override;

--- a/src/plugins/Analysis/npp_hists/DReaction_factory_npp_hists.h
+++ b/src/plugins/Analysis/npp_hists/DReaction_factory_npp_hists.h
@@ -27,8 +27,8 @@ class DReaction_factory_npp_hists : public JFactoryT<DReaction>
 		{
 			// This is so that the created DReaction objects persist throughout the life of the program instead of being cleared each event. 
 			SetFactoryFlag(PERSISTENT);
+			SetTag("npp_hists");
 		}
-		const char* Tag(void){return "npp_hists";}
 
 	private:
 		void Process(const std::shared_ptr<const JEvent>& event) override;


### PR DESCRIPTION
Running `hd_root` with both `npp_hists` and `cpp_hists` plugins enabled:

```bash
hd_root -PPLUGINS=npp_hists,cpp_hists /cache/halld/RunPeriod-2022-05/rawdata/Run101153/hd_rawdata_101153_007.evio
```

caused a crash with the following message:

```
JException
  Message:  Attempted to add duplicate factories
  Function: JFactorySet::Add
  Instance: DAnalysis::DReaction
  Plugin:   ,
  Backtrace:
```

## Root Cause

Both factories were relying on the legacy **JANA1** mechanism for setting factory tags:

```cpp
const char* Tag(void) { return "cpp_hists"; }  // JANA1 syntax
```

In **JANA2**, the `Tag()` method is no longer invoked by the framework. Instead, factory tags must be explicitly set using `SetTag()` in the factory constructor. Because the tags were never applied, both factories registered identical outputs, leading to a duplicate factory conflict when both plugins were loaded.

## Solution

Updated each factory to set its tag explicitly in the constructor using `SetTag()`, following the JANA2 pattern.

### Before (JANA1 syntax)

```cpp
DReaction_factory_cpp_hists()
{
    SetFactoryFlag(PERSISTENT);
}

const char* Tag(void) { return "cpp_hists"; }
```

### After (JANA2 syntax)

```cpp
DReaction_factory_cpp_hists()
{
    SetFactoryFlag(PERSISTENT);
    SetTag("cpp_hists");
}
```

The same change is applied to `DReaction_factory_npp_hists`, using the `"npp_hists"` tag.

## Testing

With this change applied, both plugins can be loaded simultaneously without conflicts. The application runs successfully, and no duplicate factory errors are observed.