### PR TITLE
* introduce support for double precision momentum components in the

### DIFF
--- a/src/libraries/HDDM/DEventSourceHDDM.cc
+++ b/src/libraries/HDDM/DEventSourceHDDM.cc
@@ -1181,9 +1181,14 @@ bool DEventSourceHDDM::Extract_DMCReaction(hddm_s::HDDM *record,
       const hddm_s::BeamList &beams = record->getBeams();
       if (beams.size() > 0) {
          hddm_s::Beam &beam = iter->getBeam();
-         DVector3 mom(beam.getMomentum().getPx(),
-                      beam.getMomentum().getPy(),
-                      beam.getMomentum().getPz());
+         hddm_s::Momentum &mome = beam.getMomentum();
+         DVector3 mom(mome.getPx(), mome.getPy(), mome.getPz());
+         hddm_s::Momentum_doubleList momd = mome.getMomentum_doubles();
+         if (momd.size() > 0) {
+            mom[0] = momd(0).getPx();
+            mom[1] = momd(0).getPy();
+            mom[2] = momd(0).getPz();
+         }
          mcreaction->beam.setPosition(locPosition);
          mcreaction->beam.setMomentum(mom);
          mcreaction->beam.setPID(Gamma);
@@ -1201,9 +1206,14 @@ bool DEventSourceHDDM::Extract_DMCReaction(hddm_s::HDDM *record,
       if (targets.size() > 0) {
          hddm_s::Target &target = iter->getTarget();
          DKinematicData target_kd;
-         DVector3 mom(target.getMomentum().getPx(),
-                      target.getMomentum().getPy(),
-                      target.getMomentum().getPz());
+         hddm_s::Momentum &mome = target.getMomentum();
+         DVector3 mom(mome.getPx(), mome.getPy(), mome.getPz());
+         hddm_s::Momentum_doubleList momd = mome.getMomentum_doubles();
+         if (momd.size() > 0) {
+            mom[0] = momd(0).getPx();
+            mom[1] = momd(0).getPy();
+            mom[2] = momd(0).getPz();
+         }
          mcreaction->target.setPosition(locPosition);
          mcreaction->target.setMomentum(mom);
          hddm_s::PropertiesList &properties = target.getPropertiesList();
@@ -1258,10 +1268,18 @@ bool DEventSourceHDDM::Extract_DMCThrown(hddm_s::HDDM *record,
       }
       hddm_s::ProductList::iterator piter;
       for (piter = prods.begin(); piter != prods.end(); ++piter) {
-         double E  = piter->getMomentum().getE();
-         double px = piter->getMomentum().getPx();
-         double py = piter->getMomentum().getPy();
-         double pz = piter->getMomentum().getPz();
+         hddm_s::Momentum &mome = piter->getMomentum();
+         double E  = mome.getE();
+         double px = mome.getPx();
+         double py = mome.getPy();
+         double pz = mome.getPz();
+         hddm_s::Momentum_doubleList momd = mome.getMomentum_doubles();
+         if (momd.size() > 0) {
+            E  = momd(0).getE();
+            px = momd(0).getPx();
+            py = momd(0).getPy();
+            pz = momd(0).getPz();
+         }
          double mass = sqrt(E*E - (px*px + py*py + pz*pz));
          if (!isfinite(mass))
             mass = 0.0;
@@ -2381,12 +2399,16 @@ bool DEventSourceHDDM::Extract_DTrackTimeBased(hddm_s::HDDM *record,
    const hddm_s::TracktimebasedList &ttbs = record->getTracktimebaseds();
    hddm_s::TracktimebasedList::iterator iter;
    for (iter = ttbs.begin(); iter != ttbs.end(); ++iter) {
-      DVector3 mom(iter->getMomentum().getPx(),
-                   iter->getMomentum().getPy(),
-                   iter->getMomentum().getPz());
-      DVector3 pos(iter->getOrigin().getVx(),
-                   iter->getOrigin().getVy(),
-                   iter->getOrigin().getVz());
+      hddm_s::Momentum &mome = iter->getMomentum();
+      hddm_s::Origin &orig = iter->getOrigin();
+      DVector3 mom(mome.getPx(), mome.getPy(), mome.getPz());
+      hddm_s::Momentum_doubleList momd = mome.getMomentum_doubles();
+      if (momd.size() > 0) {
+         mom[0] = momd(0).getPx();
+         mom[1] = momd(0).getPy();
+         mom[2] = momd(0).getPz();
+      }
+      DVector3 pos(orig.getVx(), orig.getVy(), orig.getVz());
       DTrackTimeBased *track = new DTrackTimeBased();
       track->setMomentum(mom);
       track->setPosition(pos);

--- a/src/libraries/HDDM/DEventSourceREST.cc
+++ b/src/libraries/HDDM/DEventSourceREST.cc
@@ -810,10 +810,18 @@ bool DEventSourceREST::Extract_DMCThrown(hddm_r::HDDM *record,
       const hddm_r::ProductList &products = iter->getProducts();
       hddm_r::ProductList::iterator piter;
       for (piter = products.begin(); piter != products.end(); ++piter) {
-         double E  = piter->getMomentum().getE();
-         double px = piter->getMomentum().getPx();
-         double py = piter->getMomentum().getPy();
-         double pz = piter->getMomentum().getPz();
+         hddm_r::Momentum &mome = piter->getMomentum();
+         double E  = mome.getE();
+         double px = mome.getPx();
+         double py = mome.getPy();
+         double pz = mome.getPz();
+         hddm_r::Momentum_doubleList momd = mome.getMomentum_doubles();
+         if (momd.size() > 0) {
+            E  = momd(0).getE();
+            px = momd(0).getPx();
+            py = momd(0).getPy();
+            pz = momd(0).getPz();
+         }
          double mass = sqrt(E*E - (px*px + py*py + pz*pz));
          if (!isfinite(mass)) {
             mass = 0.0;

--- a/src/libraries/HDDM/event.xml
+++ b/src/libraries/HDDM/event.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="no" ?>
+
 <HDDM xmlns="http://www.gluex.org/hddm" class="s" version="1.0">
 
   <geometry minOccurs="0" maxOccurs="1" md5simulation="string" md5smear="string" md5reconstruction="string"/>
@@ -8,18 +9,24 @@
     <ccdbContext minOccurs="0" maxOccurs="unbounded" text="string"/>
     <reaction maxOccurs="unbounded" minOccurs="0" type="int" weight="float">
       <beam minOccurs="0" type="Particle_t">
-        <momentum E="float" px="float" py="float" pz="float"/>
+        <momentum E="float" px="float" py="float" pz="float">
+          <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+        </momentum>
         <polarization minOccurs="0" Px="float" Py="float" Pz="float"/>
         <properties charge="int" mass="float"/>
       </beam>
       <target minOccurs="0" type="Particle_t">
-        <momentum E="float" px="float" py="float" pz="float"/>
+        <momentum E="float" px="float" py="float" pz="float">
+          <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+        </momentum>
         <polarization minOccurs="0" Px="float" Py="float" Pz="float"/>
         <properties charge="int" mass="float"/>
       </target>
       <vertex maxOccurs="unbounded">
         <product decayVertex="int" id="int" maxOccurs="unbounded" mech="int" parentid="int" pdgtype="int" type="Particle_t">
-          <momentum E="float" px="float" py="float" pz="float"/>
+          <momentum E="float" px="float" py="float" pz="float">
+            <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+          </momentum>
           <polarization minOccurs="0" Px="float" Py="float" Pz="float"/>
           <properties minOccurs="0" charge="int" mass="float"/>
         </product>
@@ -278,7 +285,9 @@
     </hitView>
     <reconView minOccurs="0" version="1.0">
       <tracktimebased maxOccurs="unbounded" minOccurs="0" FOM="float" Ndof="int" chisq="float" candidateid="int" trackid="int" id="int">
-        <momentum E="float" px="float" py="float" pz="float"/>
+        <momentum E="float" px="float" py="float" pz="float">
+          <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+        </momentum>
         <properties charge="int" mass="float"/>
         <origin t="float" vx="float" vy="float" vz="float"/>
         <errorMatrix Nrows="int" Ncols="int" type="string" vals="string"/>

--- a/src/libraries/HDDM/mc.xml
+++ b/src/libraries/HDDM/mc.xml
@@ -5,16 +5,22 @@
   <physicsEvent eventNo="int" maxOccurs="unbounded" runNo="int">
     <reaction maxOccurs="unbounded" minOccurs="0" type="int" weight="float">
       <beam minOccurs="0" type="Particle_t">
-        <momentum E="float" px="float" py="float" pz="float"/>
+        <momentum E="float" px="float" py="float" pz="float">
+          <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+        </momentum>
         <properties charge="int" mass="float"/>
       </beam>
       <target minOccurs="0" type="Particle_t">
-        <momentum E="float" px="float" py="float" pz="float"/>
+        <momentum E="float" px="float" py="float" pz="float">
+          <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+        </momentum>
         <properties charge="int" mass="float"/>
       </target>
       <vertex maxOccurs="unbounded">
         <product decayVertex="int" id="int" maxOccurs="unbounded" mech="int" parentid="int" pdgtype="int" type="Particle_t">
-          <momentum E="float" px="float" py="float" pz="float"/>
+          <momentum E="float" px="float" py="float" pz="float">
+            <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double"/>
+          </momentum>
           <properties minOccurs="0" charge="int" mass="float"/>
         </product>
         <origin t="float" vx="float" vy="float" vz="float"/>

--- a/src/libraries/HDDM/rest.xml
+++ b/src/libraries/HDDM/rest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="no" ?>
+
 <HDDM xmlns="http://www.gluex.org/hddm" class="r" version="1.1.0">
 
   <reconstructedPhysicsEvent eventNo="long" runNo="int">
@@ -12,8 +13,9 @@
       <vertex maxOccurs="unbounded">
         <origin t="float" vx="float" vy="float" vz="float" lunit="cm"/>
         <product id="int" maxOccurs="unbounded" parentId="int" pdgtype="int">
-          <momentum E="float" px="float" py="float" pz="float" Eunit="GeV"
-                    punit="GeV/c"/>
+          <momentum E="float" px="float" py="float" pz="float" Eunit="GeV" punit="GeV/c">
+            <momentum_double minOccurs="0" E="double" px="double" py="double" pz="double" punit="GeV/c"/>
+          </momentum>
         </product>
       </vertex>
     </reaction>


### PR DESCRIPTION
  <reaction> tag of mc events, optional if selected by the generator
  or output by the simulation. This change is fully backward compatible
  both ways (old apps, new data or new apps, old data). However for
  the double precision components to be reliable, you need the recent
  fixes to the external HDDM package to be applied. [rtj]