### PR TITLE
Fix crash in DEventWriterREST when SYS_DIRC extrapolations are missing

### DIFF
--- a/src/libraries/HDDM/DEventWriterREST.cc
+++ b/src/libraries/HDDM/DEventWriterREST.cc
@@ -881,7 +881,6 @@ bool DEventWriterREST::Write_RESTEvent(const std::shared_ptr<const JEvent>& locE
 					}
 				}
 
-				vector<DTrackFitter::Extrapolation_t> extrapolations=tracks[loc_j]->extrapolations.at(SYS_DIRC);
 				DVector3 locProjPos = locDIRCMatchParams->dExtrapolatedPos;
 				DVector3 locProjMom = locDIRCMatchParams->dExtrapolatedMom;
 				double locFlightTime = locDIRCMatchParams->dExtrapolatedTime;


### PR DESCRIPTION
This PR fixes a crash in DEventWriterREST.cc observed when processing
2020 GlueX REST data. The code assumed that the SYS_DIRC entry always exists in the
DTrackFitter::extrapolations map and accessed it via .at(SYS_DIRC),
which can throw when the key is missing. The problematic variable was unused, so it has been removed,
preventing the crash.