### PR TITLE
DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # halld_recon
-Reconstruction for GlueX.
+Primary reconstruction and analysis software for the GlueX experiment at Jefferson Lab's Hall D.
 
 See the [Offline Software Wiki Page](https://halldweb.jlab.org/wiki/index.php/GlueX_Offline_Software#Software_Packages) for more information.
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/JeffersonLab/halld_recon)


### PR DESCRIPTION
links DeepWiki documentation to GitHub repository