### PR TITLE
Initial implementation of the ECAL into Event RF Bunch selection

### DIFF
--- a/src/libraries/PID/DEventRFBunch_factory.cc
+++ b/src/libraries/PID/DEventRFBunch_factory.cc
@@ -224,58 +224,66 @@ bool DEventRFBunch_factory::Find_TrackTimes_All(const DDetectorMatches* locDetec
 		//max can be off = rf-frequency/2 ns (if off by more, will pick wrong beam bunch)
 	for(size_t loc_i = 0; loc_i < locTrackTimeBasedVector.size(); ++loc_i)
 	{
-	  const DTrackTimeBased* locTrackTimeBased = locTrackTimeBasedVector[loc_i];
+		const DTrackTimeBased* locTrackTimeBased = locTrackTimeBasedVector[loc_i];
 
-	  // start with SC: closest to target, minimal dependence on particle type
-	  shared_ptr<const DSCHitMatchParams> locSCHitMatchParams;
-	  if(dParticleID->Get_BestSCMatchParams(locTrackTimeBased, locDetectorMatches, locSCHitMatchParams))
-	    {
-	      double locPropagatedTime = locSCHitMatchParams->dHitTime - locSCHitMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
-	      locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
-	      continue;
-	      
-	    }
-	  
-	  // Next use the TOF (best timing resolution for outer detectors
-	  //TOF resolution = 80ps, 3sigma = 240ps
-	  //max PID delta-t = 762ps (assuming 499 MHz and no buffer)
-	  //for pion-proton: delta-t is ~750ps at ~170 MeV/c or lower: cannot have proton this slow anyway
-	  //for pion-kaon delta-t is ~750ps at ~80 MeV/c or lower: won't reconstruct these anyway, and not likely to be forward-going anyway
-	  shared_ptr<const DTOFHitMatchParams> locTOFHitMatchParams;
-	  if(dParticleID->Get_BestTOFMatchParams(locTrackTimeBased, locDetectorMatches, locTOFHitMatchParams))
-	    {
-	      double locPropagatedTime = locTOFHitMatchParams->dHitTime - locTOFHitMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
-	      locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
-	      continue;
-	    }
-	  
-	  // Else match to BCAL if fast enough (low time resolution for slow particles)
-	  double locP = locTrackTimeBased->momentum().Mag();
-	  //at 250 MeV/c, BCAL t-resolution is ~310ps (3sigma = 920ps), BCAL delta-t error is ~40ps: ~960 ps < 1 ns: OK!!
-	  //at 225 MeV/c, BCAL t-resolution is ~333ps (3sigma = 999ps), BCAL delta-t error is ~40ps: ~1040ps: bad at 499 MHz
-	  if((locP < 0.25) && (dBeamBunchPeriod < 2.005))
-	    continue; //too slow for the BCAL to distinguish RF bunch
-	  
-	  shared_ptr<const DBCALShowerMatchParams> locBCALShowerMatchParams;
-	  if(dParticleID->Get_BestBCALMatchParams(locTrackTimeBased, locDetectorMatches, locBCALShowerMatchParams))
-	    {
-	      const DBCALShower* locBCALShower = locBCALShowerMatchParams->dBCALShower;
-	      double locPropagatedTime = locBCALShower->t - locBCALShowerMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
-	      locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
-	      continue;
-	    }
+		// start with SC: closest to target, minimal dependence on particle type
+		shared_ptr<const DSCHitMatchParams> locSCHitMatchParams;
+		if(dParticleID->Get_BestSCMatchParams(locTrackTimeBased, locDetectorMatches, locSCHitMatchParams))
+		{
+			double locPropagatedTime = locSCHitMatchParams->dHitTime - locSCHitMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
+			continue;
+		}
 
-	  // If all else fails, use FCAL 
-	  shared_ptr<const DFCALShowerMatchParams> locFCALShowerMatchParams;
-	  if(dParticleID->Get_BestFCALMatchParams(locTrackTimeBased, locDetectorMatches, locFCALShowerMatchParams))
-	    {
-	      const DFCALShower* locFCALShower = locFCALShowerMatchParams->dFCALShower;
-	      double locPropagatedTime = locFCALShower->getTime() - locFCALShowerMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
-	      locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
-	      continue;
-	    }
+		// Next use the TOF (best timing resolution for outer detectors
+		//TOF resolution = 80ps, 3sigma = 240ps
+		//max PID delta-t = 762ps (assuming 499 MHz and no buffer)
+		//for pion-proton: delta-t is ~750ps at ~170 MeV/c or lower: cannot have proton this slow anyway
+		//for pion-kaon delta-t is ~750ps at ~80 MeV/c or lower: won't reconstruct these anyway, and not likely to be forward-going anyway
+		shared_ptr<const DTOFHitMatchParams> locTOFHitMatchParams;
+		if(dParticleID->Get_BestTOFMatchParams(locTrackTimeBased, locDetectorMatches, locTOFHitMatchParams))
+		{
+			double locPropagatedTime = locTOFHitMatchParams->dHitTime - locTOFHitMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
+			continue;
+		}
 
-	  
+		// Else match to BCAL if fast enough (low time resolution for slow particles)
+		double locP = locTrackTimeBased->momentum().Mag();
+		//at 250 MeV/c, BCAL t-resolution is ~310ps (3sigma = 920ps), BCAL delta-t error is ~40ps: ~960 ps < 1 ns: OK!!
+		//at 225 MeV/c, BCAL t-resolution is ~333ps (3sigma = 999ps), BCAL delta-t error is ~40ps: ~1040ps: bad at 499 MHz
+		if((locP < 0.25) && (dBeamBunchPeriod < 2.005))
+			continue; //too slow for the BCAL to distinguish RF bunch
+
+		shared_ptr<const DBCALShowerMatchParams> locBCALShowerMatchParams;
+		if(dParticleID->Get_BestBCALMatchParams(locTrackTimeBased, locDetectorMatches, locBCALShowerMatchParams))
+		{
+			const DBCALShower* locBCALShower = locBCALShowerMatchParams->dBCALShower;
+			double locPropagatedTime = locBCALShower->t - locBCALShowerMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
+			continue;
+		}
+		
+		// Else, match to ECAL:
+		shared_ptr<const DECALShowerMatchParams> locECALShowerMatchParams;
+		if(dParticleID->Get_BestECALMatchParams(locTrackTimeBased, locDetectorMatches, locECALShowerMatchParams))
+		{
+			const DECALShower* locECALShower = locECALShowerMatchParams->dECALShower;
+			double locPropagatedTime = locECALShower->t - locECALShowerMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
+			continue;
+		}
+
+		// If all else fails, use FCAL 
+		shared_ptr<const DFCALShowerMatchParams> locFCALShowerMatchParams;
+		if(dParticleID->Get_BestFCALMatchParams(locTrackTimeBased, locDetectorMatches, locFCALShowerMatchParams))
+		{
+			const DFCALShower* locFCALShower = locFCALShowerMatchParams->dFCALShower;
+			double locPropagatedTime = locFCALShower->getTime() - locFCALShowerMatchParams->dFlightTime + (dTargetCenter.Z() - locTrackTimeBased->z())/29.9792458;
+			locTimes.push_back(pair<double, const JObject*>(locPropagatedTime, locTrackTimeBased));
+			continue;
+		}
+
 	}
 
 	return (!locTimes.empty());

--- a/src/libraries/PID/DEventRFBunch_factory.cc
+++ b/src/libraries/PID/DEventRFBunch_factory.cc
@@ -9,6 +9,7 @@
 #include "BCAL/DBCALShower.h"
 #include "FCAL/DFCALShower.h"
 #include "CCAL/DCCALShower.h"
+#include "ECAL/DECALShower.h"
 #include "DANA/DEvent.h"
 #include "DANA/DObjectID.h"
 
@@ -289,15 +290,31 @@ bool DEventRFBunch_factory::Find_NeutralTimes(const std::shared_ptr<const JEvent
 
 	for( size_t i = 0; i < fcalShowers.size(); ++i ){
 
-	  DVector3 locHitPoint = fcalShowers[i]->getPosition();
-	  DVector3 locPath = locHitPoint - dTargetCenter;
-	  double locPathLength = locPath.Mag();
-	  if(!(locPathLength > 0.0))
-	    continue;
-	  
-	  double locFlightTime = locPathLength/29.9792458;
-	  double locHitTime = fcalShowers[i]->getTime();
-	  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, fcalShowers[i] ) );
+		DVector3 locHitPoint = fcalShowers[i]->getPosition();
+		DVector3 locPath = locHitPoint - dTargetCenter;
+		double locPathLength = locPath.Mag();
+		if(!(locPathLength > 0.0))
+			continue;
+
+		double locFlightTime = locPathLength/29.9792458;
+		double locHitTime = fcalShowers[i]->getTime();
+		locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, fcalShowers[i] ) );
+	}
+
+	vector< const DECALShower* > ecalShowers;
+	event->Get( ecalShowers );
+
+	for( size_t i = 0; i < ecalShowers.size(); ++i ){
+
+		DVector3 locHitPoint = ecalShowers[i]->pos;
+		DVector3 locPath = locHitPoint - dTargetCenter;
+		double locPathLength = locPath.Mag();
+		if(!(locPathLength > 0.0))
+			continue;
+
+		double locFlightTime = locPathLength/29.9792458;
+		double locHitTime = ecalShowers[i]->t;
+		locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ecalShowers[i] ) );
 	}
 
 	vector< const DBCALShower* > bcalShowers;
@@ -305,15 +322,15 @@ bool DEventRFBunch_factory::Find_NeutralTimes(const std::shared_ptr<const JEvent
 
 	for( size_t i = 0; i < bcalShowers.size(); ++i ){
 
-	  DVector3 locHitPoint( bcalShowers[i]->x, bcalShowers[i]->y, bcalShowers[i]->z );
-	  DVector3 locPath = locHitPoint - dTargetCenter;
-	  double locPathLength = locPath.Mag();
-	  if(!(locPathLength > 0.0))
-	    continue;
-	  
-	  double locFlightTime = locPathLength/29.9792458;
-	  double locHitTime = bcalShowers[i]->t;
-	  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, bcalShowers[i] ) );
+		DVector3 locHitPoint( bcalShowers[i]->x, bcalShowers[i]->y, bcalShowers[i]->z );
+		DVector3 locPath = locHitPoint - dTargetCenter;
+		double locPathLength = locPath.Mag();
+		if(!(locPathLength > 0.0))
+		continue;
+
+		double locFlightTime = locPathLength/29.9792458;
+		double locHitTime = bcalShowers[i]->t;
+		locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, bcalShowers[i] ) );
 	}
 	/*
 	vector< const DCCALShower* > ccalShowers;
@@ -321,15 +338,15 @@ bool DEventRFBunch_factory::Find_NeutralTimes(const std::shared_ptr<const JEvent
 
 	for( size_t i = 0; i < ccalShowers.size(); ++i ){
 
-	  DVector3 locHitPoint( ccalShowers[i]->x, ccalShowers[i]->y, ccalShowers[i]->z );
-	  DVector3 locPath = locHitPoint - dTargetCenter;
-	  double locPathLength = locPath.Mag();
-	  if(!(locPathLength > 0.0))
-	    continue;
-	  
-	  double locFlightTime = locPathLength/29.9792458;
-	  double locHitTime = ccalShowers[i]->time;
-	  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ccalShowers[i] ) );
+		DVector3 locHitPoint( ccalShowers[i]->x, ccalShowers[i]->y, ccalShowers[i]->z );
+		DVector3 locPath = locHitPoint - dTargetCenter;
+		double locPathLength = locPath.Mag();
+		if(!(locPathLength > 0.0))
+			continue;
+
+		double locFlightTime = locPathLength/29.9792458;
+		double locHitTime = ccalShowers[i]->time;
+		locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ccalShowers[i] ) );
 	}
 	*/  
 	return (locTimes.size() > 1);
@@ -434,54 +451,55 @@ int DEventRFBunch_factory::Break_TieVote_Tracks(map<int, vector<const JObject*> 
 
 int DEventRFBunch_factory::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
-  //Break tie with highest total shower energy
+	//Break tie with highest total shower energy
 
-  int locBestRFBunchShift = 0;
-  double locHighestTotalEnergy = 0.0;
+	int locBestRFBunchShift = 0;
+	double locHighestTotalEnergy = 0.0;
 
-  set<int>::const_iterator locSetIterator = locBestRFBunchShifts.begin();
-  for(; locSetIterator != locBestRFBunchShifts.end(); ++locSetIterator)
-    {
-      int locRFBunchShift = *locSetIterator;
-      double locTotalEnergy = 0.0;
-
-      const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
-      for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
+	set<int>::const_iterator locSetIterator = locBestRFBunchShifts.begin();
+	for(; locSetIterator != locBestRFBunchShifts.end(); ++locSetIterator)
 	{
-	  // the pointers in locVoters that we care about will either be those to DBCALShower
-	  // or DFCALShower objects -- figure out which and record the energy
-	  
-	  const DFCALShower* fcalShower = dynamic_cast< const DFCALShower* >( locVoters[loc_i] );
-	  
-	  if( fcalShower != NULL ){
+		int locRFBunchShift = *locSetIterator;
+		double locTotalEnergy = 0.0;
 
-	    locTotalEnergy += fcalShower->getEnergy();
-	  }
-	  else{
-	    
-	    const DBCALShower* bcalShower = dynamic_cast< const DBCALShower* >( locVoters[loc_i] );
-	    if( bcalShower != NULL ){
-	      
-	      locTotalEnergy += bcalShower->E;
-	    }
-	    else{
-	      const DCCALShower* ccalShower = dynamic_cast< const DCCALShower* >( locVoters[loc_i] );
-	      if( ccalShower != NULL ){
-		
-		locTotalEnergy += ccalShower->E;
-	      }
-	    }
-	  }
+		const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
+		for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
+		{
+			// the pointers in locVoters that we care about will either be those to DBCALShower,
+			// DFCALShower, or DECALShower objects -- figure out which and record the energy
+
+			const DFCALShower* fcalShower = dynamic_cast< const DFCALShower* >( locVoters[loc_i] );
+			if( fcalShower != NULL ){
+				locTotalEnergy += fcalShower->getEnergy();
+			}
+			else{
+				const DBCALShower* bcalShower = dynamic_cast< const DBCALShower* >( locVoters[loc_i] );
+				if( bcalShower != NULL ){
+					locTotalEnergy += bcalShower->E;
+				}
+				else{
+					const DECALShower* ecalShower = dynamic_cast< const DECALShower* >( locVoters[loc_i] );
+					if( ecalShower != NULL ){
+						locTotalEnergy += ecalShower->E;
+					}
+					else {
+						const DCCALShower* ccalShower = dynamic_cast< const DCCALShower* >( locVoters[loc_i] );
+						if( ccalShower != NULL ){
+							locTotalEnergy += ccalShower->E;
+						}
+					}
+				}
+			}
+		}
+
+		if(locTotalEnergy > locHighestTotalEnergy)
+		{
+			locHighestTotalEnergy = locTotalEnergy;
+			locBestRFBunchShift = locRFBunchShift;
+		}
 	}
-      
-      if(locTotalEnergy > locHighestTotalEnergy)
-	{
-	  locHighestTotalEnergy = locTotalEnergy;
-	  locBestRFBunchShift = locRFBunchShift;
-	}
-    }
-  
-  return locBestRFBunchShift;
+
+	return locBestRFBunchShift;
 }
 
 

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
@@ -7,6 +7,7 @@
 #include "BCAL/DBCALShower.h"
 #include "FCAL/DFCALShower.h"
 #include "CCAL/DCCALShower.h"
+#include "ECAL/DECALShower.h"
 
 #include "DANA/DEvent.h"
 
@@ -146,7 +147,7 @@ bool DEventRFBunch_factory_CalorimeterOnly::Find_NeutralTimes(const std::shared_
 	if(USE_ECAL) {
 		vector< const DECALShower* > ecalShowers;
 		event->Get( ecalShowers );
-
+		
 		for( size_t i = 0; i < ecalShowers.size(); ++i ){
 			DVector3 locHitPoint = ecalShowers[i]->pos;
 			DVector3 locPath = locHitPoint - dTargetCenter;

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.cc
@@ -18,15 +18,17 @@ void DEventRFBunch_factory_CalorimeterOnly::Init()
 {
 	dMinTrackingFOM = 0.0;
 	
-	USE_BCAL = false;  
-	USE_CCAL = true; 
+	USE_BCAL = false;
+	USE_CCAL = true;
 	USE_FCAL = true;
+	USE_ECAL = true;
 
 	auto app = GetApplication();
 	
 	app->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_BCAL_SHOWERS", USE_BCAL, "Use BCAL showers for calorimeter-only RF bunch calculation");
 	app->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_CCAL_SHOWERS", USE_CCAL, "Use CCAL showers for calorimeter-only RF bunch calculation");
 	app->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_FCAL_SHOWERS", USE_FCAL, "Use FCAL showers for calorimeter-only RF bunch calculation");
+	app->SetDefaultParameter("EVENTRFBUNCH_CAL:USE_ECAL_SHOWERS", USE_ECAL, "Use ECAL showers for calorimeter-only RF bunch calculation");
 }
 
 //------------------
@@ -129,15 +131,32 @@ bool DEventRFBunch_factory_CalorimeterOnly::Find_NeutralTimes(const std::shared_
 		event->Get( fcalShowers );
 
 		for( size_t i = 0; i < fcalShowers.size(); ++i ){
-		  DVector3 locHitPoint = fcalShowers[i]->getPosition();
-		  DVector3 locPath = locHitPoint - dTargetCenter;
-		  double locPathLength = locPath.Mag();
-		  if(!(locPathLength > 0.0))
-			continue;
-  
-		  double locFlightTime = locPathLength/29.9792458;
-		  double locHitTime = fcalShowers[i]->getTime();
-		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, fcalShowers[i] ) );
+			DVector3 locHitPoint = fcalShowers[i]->getPosition();
+			DVector3 locPath = locHitPoint - dTargetCenter;
+			double locPathLength = locPath.Mag();
+			if(!(locPathLength > 0.0))
+				continue;
+
+			double locFlightTime = locPathLength/29.9792458;
+			double locHitTime = fcalShowers[i]->getTime();
+			locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, fcalShowers[i] ) );
+		}
+	}
+
+	if(USE_ECAL) {
+		vector< const DECALShower* > ecalShowers;
+		event->Get( ecalShowers );
+
+		for( size_t i = 0; i < ecalShowers.size(); ++i ){
+			DVector3 locHitPoint = ecalShowers[i]->pos;
+			DVector3 locPath = locHitPoint - dTargetCenter;
+			double locPathLength = locPath.Mag();
+			if(!(locPathLength > 0.0))
+				continue;
+
+			double locFlightTime = locPathLength/29.9792458;
+			double locHitTime = ecalShowers[i]->t;
+			locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ecalShowers[i] ) );
 		}
 	}
 
@@ -147,36 +166,35 @@ bool DEventRFBunch_factory_CalorimeterOnly::Find_NeutralTimes(const std::shared_
 
 		for( size_t i = 0; i < bcalShowers.size(); ++i ){
 
-		  DVector3 locHitPoint( bcalShowers[i]->x, bcalShowers[i]->y, bcalShowers[i]->z );
-		  DVector3 locPath = locHitPoint - dTargetCenter;
-		  double locPathLength = locPath.Mag();
-		  if(!(locPathLength > 0.0))
-			continue;
-	  
-		  double locFlightTime = locPathLength/29.9792458;
-		  double locHitTime = bcalShowers[i]->t;
-		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, bcalShowers[i] ) );
+			DVector3 locHitPoint( bcalShowers[i]->x, bcalShowers[i]->y, bcalShowers[i]->z );
+			DVector3 locPath = locHitPoint - dTargetCenter;
+			double locPathLength = locPath.Mag();
+			if(!(locPathLength > 0.0))
+				continue;
+
+			double locFlightTime = locPathLength/29.9792458;
+			double locHitTime = bcalShowers[i]->t;
+			locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, bcalShowers[i] ) );
 		}
 	}
-	
+
 	if(USE_CCAL) {
 		vector< const DCCALShower* > ccalShowers;
 		event->Get( ccalShowers );
 		
 		for( size_t i = 0; i < ccalShowers.size(); ++i ){
-		  DVector3 locHitPoint(ccalShowers[i]->x, ccalShowers[i]->y, ccalShowers[i]->z);
-		  DVector3 locPath = locHitPoint - dTargetCenter;
-		  double locPathLength = locPath.Mag();
-		  if(!(locPathLength > 0.0))
-			continue;
-  
-		  double locFlightTime = locPathLength/29.9792458;
-		  double locHitTime = ccalShowers[i]->time;
-		  locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ccalShowers[i] ) );
+			DVector3 locHitPoint(ccalShowers[i]->x, ccalShowers[i]->y, ccalShowers[i]->z);
+			DVector3 locPath = locHitPoint - dTargetCenter;
+			double locPathLength = locPath.Mag();
+			if(!(locPathLength > 0.0))
+				continue;
+
+			double locFlightTime = locPathLength/29.9792458;
+			double locHitTime = ccalShowers[i]->time;
+			locTimes.push_back( pair< double, const JObject*>( locHitTime - locFlightTime, ccalShowers[i] ) );
 		}
 	}
-	
-	    
+
 	return (locTimes.size() > 1);
 }
 
@@ -239,54 +257,55 @@ bool DEventRFBunch_factory_CalorimeterOnly::Break_TieVote_BeamPhotons(vector<con
 
 int DEventRFBunch_factory_CalorimeterOnly::Break_TieVote_Neutrals(map<int, vector<const JObject*> >& locNumBeamBucketsShiftedMap, set<int>& locBestRFBunchShifts)
 {
-  //Break tie with highest total shower energy
+	//Break tie with highest total shower energy
 
-  int locBestRFBunchShift = 0;
-  double locHighestTotalEnergy = 0.0;
+	int locBestRFBunchShift = 0;
+	double locHighestTotalEnergy = 0.0;
 
-  set<int>::const_iterator locSetIterator = locBestRFBunchShifts.begin();
-  for(; locSetIterator != locBestRFBunchShifts.end(); ++locSetIterator)
-    {
-      int locRFBunchShift = *locSetIterator;
-      double locTotalEnergy = 0.0;
-
-      const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
-      for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
+	set<int>::const_iterator locSetIterator = locBestRFBunchShifts.begin();
+	for(; locSetIterator != locBestRFBunchShifts.end(); ++locSetIterator)
 	{
-	  // the pointers in locVoters that we care about will either be those to DBCALShower
-	  // or DFCALShower objects -- figure out which and record the energy
-	  
-	  const DFCALShower* fcalShower = dynamic_cast< const DFCALShower* >( locVoters[loc_i] );
-	  if( fcalShower != NULL ){
+		int locRFBunchShift = *locSetIterator;
+		double locTotalEnergy = 0.0;
 
-	    locTotalEnergy += fcalShower->getEnergy();
-	  }
-	  else{
+		const vector<const JObject*>& locVoters = locNumBeamBucketsShiftedMap[locRFBunchShift];
+		for(size_t loc_i = 0; loc_i < locVoters.size(); ++loc_i)
+		{
+			// the pointers in locVoters that we care about will either be those to DBCALShower
+			// or DFCALShower objects -- figure out which and record the energy
 
-	    const DBCALShower* bcalShower = dynamic_cast< const DBCALShower* >( locVoters[loc_i] );
-	    if( bcalShower != NULL ){
+			const DFCALShower* fcalShower = dynamic_cast< const DFCALShower* >( locVoters[loc_i] );
+			if( fcalShower != NULL ){
+				locTotalEnergy += fcalShower->getEnergy();
+			}
+			else {
+				const DBCALShower* bcalShower = dynamic_cast< const DBCALShower* >( locVoters[loc_i] );
+				if( bcalShower != NULL ){
+					locTotalEnergy += bcalShower->E;
+				}
+				else{
+					const DECALShower* ecalShower = dynamic_cast< const DECALShower* >( locVoters[loc_i] );
+					if( ecalShower != NULL ){
+						locTotalEnergy += ecalShower->E;
+					} 	  
+					else{
+						const DCCALShower* ccalShower = dynamic_cast< const DCCALShower* >( locVoters[loc_i] );
+						if( ccalShower != NULL ){
+							locTotalEnergy += ccalShower->E;
+						}
+					}
+				}
+			}
 
-	      locTotalEnergy += bcalShower->E;
-	    } 	  
-	    else{
-
-		    const DCCALShower* ccalShower = dynamic_cast< const DCCALShower* >( locVoters[loc_i] );
-		    if( ccalShower != NULL ){
-			    
-			    locTotalEnergy += ccalShower->E;
-		    }
-	    }
-	  }
+			if(locTotalEnergy > locHighestTotalEnergy)
+			{
+				locHighestTotalEnergy = locTotalEnergy;
+				locBestRFBunchShift = locRFBunchShift;
+			}
+		}
 	}
-      
-      if(locTotalEnergy > locHighestTotalEnergy)
-	{
-	  locHighestTotalEnergy = locTotalEnergy;
-	  locBestRFBunchShift = locRFBunchShift;
-	}
-    }
 
-  return locBestRFBunchShift;
+	return locBestRFBunchShift;
 }
 
 jerror_t DEventRFBunch_factory_CalorimeterOnly::Create_NaNRFBunch(void)

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
@@ -27,6 +27,7 @@
 #include <TRACKING/DTrackTimeBased.h>
 #include <START_COUNTER/DSCHit.h>
 #include <BCAL/DBCALShower.h>
+#include <ECAL/DECALShower.h>
 #include <TOF/DTOFPoint.h>
 #include <PID/DBeamPhoton.h>
 
@@ -72,6 +73,7 @@ class DEventRFBunch_factory_CalorimeterOnly : public JFactoryT<DEventRFBunch>
 		bool USE_FCAL;
 		bool USE_BCAL;
 		bool USE_CCAL;
+		bool USE_ECAL;
 
 		void Init() override;
 		void BeginRun(const std::shared_ptr<const JEvent>& event) override;

--- a/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
+++ b/src/libraries/PID/DEventRFBunch_factory_CalorimeterOnly.h
@@ -27,7 +27,6 @@
 #include <TRACKING/DTrackTimeBased.h>
 #include <START_COUNTER/DSCHit.h>
 #include <BCAL/DBCALShower.h>
-#include <ECAL/DECALShower.h>
 #include <TOF/DTOFPoint.h>
 #include <PID/DBeamPhoton.h>
 


### PR DESCRIPTION
ECAL showers were included into the standard procedure for selecting the event RF bunch. In this implementation, they are only included whenever neutrals are used for voting on the RF bunch. For example, in DEventRFBunch_factory.cc, the track matches in the SC, TOF, BCAL, and then FCAL are first used to vote on the RF bunch. I did not add ECAL showers into this code, as I haven't personally studied the ECAL/track matching performance yet. But it should eventually be included here as well, probably before the FCAL.

For the cases where there are no track matches, the neutral showers in the calorimeters are allowed to vote on the RF bunch. In this code, I added in the ECAL in the same way as for the other calorimeters. Similarly, the ECAL was included in the "CalorimeterOnly" variation of the DEventRFBunch_factory, along with a parameter that can be used to switch it off via a command-line flag or jana config file. This is necessary for the few analyses which do not use any reconstructed tracks.