### PR TITLE
new macro to show CDC occupancy as a fraction of the mean occupancy for the ring

### DIFF
--- a/src/plugins/monitoring/CDC_online/CDC_av_occupancy.C
+++ b/src/plugins/monitoring/CDC_online/CDC_av_occupancy.C
@@ -1,11 +1,5 @@
+
 {
-	// Get number of events
-	double Nevents = 1.0;
-	TDirectory *CDCdir = (TDirectory*)gDirectory->FindObjectAny("CDC");
-	if(CDCdir){
-		TH1I *cdc_num_events = (TH1I*)CDCdir->Get("cdc_num_events");
-		if(cdc_num_events) Nevents = (double)cdc_num_events->GetBinContent(1);
-	}
 
 	TDirectory *dir = (TDirectory*)gDirectory->FindObjectAny("rings_occupancy");
 	if(!dir) return;
@@ -24,13 +18,21 @@
 
 	TCanvas *c1 = gPad->GetCanvas();
 
+    	gStyle->SetPalette(kGreyYellow);  // 2nd choice kLake
+
+	int ncontours = 10;
+	double contours[] = {0.5, 0.6, 0.7, 0.8, 0.9, 1.1, 1.2, 1.3, 1.4, 1.5};
+	
 	// Draw axes
 	TH2D *axes = new TH2D("cdc_axes", "CDC Occupancy", 100, -57.0*4.0/3.0, 57.0*4.0/3.0, 100, -57.0, 57.0);
 
-	double minScale = 0.0, maxScale = 0.1;
+	double minScale = contours[0];
+	double maxScale = contours[ncontours-1];
+
 	axes->SetStats(0);
 	axes->Fill(100,100); // without this, the color ramp is not drawn
 	axes->GetZaxis()->SetRangeUser(minScale, maxScale);
+	axes->SetContour(ncontours, contours);
 	axes->GetXaxis()->SetNdivisions(0);
 	axes->GetYaxis()->SetNdivisions(0);	
 	axes->Draw("colz");
@@ -42,18 +44,30 @@
 	e = new TEllipse(0.0, 0.0, 9.55, 9.55);
 	e->SetLineWidth(2);
 	e->Draw();
-	
+
 	for(unsigned int iring=1; iring<=28; iring++){
 		char hname[256];
 		sprintf(hname, "cdc_occ_ring[%d]", iring);
-		TH1 *h = (TH1*)(dir->Get(hname));
+		TH2F *h = (TH2F*)(dir->Get(hname));
 		if(h){
-			sprintf(hname, "cdc_occ_ring_norm[%d]", iring);
-			TH1 *hh = (TH1*)h->Clone(hname);
-			hh->Scale(1.0/Nevents);
-			hh->GetZaxis()->SetRangeUser(minScale, maxScale);
+			TH2F *hh = (TH2F*)h->Clone(hname);
+			double nentries = hh->GetEntries();
+
+			if (!nentries) continue; //don't draw the ring if no hits
+
+			int nbins = hh->GetNbinsX();
+		        double mean_counts = nentries/double(nbins);
+			
+			for (unsigned int j=1; j<= nbins; j++) hh->SetBinContent(j, 1, hh->GetBinContent(j,1)/mean_counts);
+
 			hh->SetStats(0);
+			hh->SetLineWidth(1);
+			hh->SetLineColor(kGray);
+			hh->SetContour(ncontours, contours);
+			
 			hh->Draw("same col pol");  // draw remaining histos without overwriting color palette
+
 		}
+		
 	}
 }


### PR DESCRIPTION
and tidied up the old one, which is not the macro used by RootSpy, although very similar.   

The av_occupancy macro shows a static equivalent of the [CDC inspector](https://halldweb.jlab.org/gluex_demon/cdc/cdc_av.html?file=hd_root_131194.root)  which is a bit annoying from offsite as the files can't be referenced directly.   The examples below are for 131593.

<img width="698" height="476" alt="av_occ_131593" src="https://github.com/user-attachments/assets/6967cc12-6f8f-4c4a-b779-87c742a9dc04" />

<img width="698" height="476" alt="occ_131593" src="https://github.com/user-attachments/assets/18150dd2-bb4d-4f84-86e5-06fe0c734ab3" />

