### PR TITLE
Nsj badhit macro update - better titles

### DIFF
--- a/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
+++ b/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
@@ -8,9 +8,9 @@
 //
 //  This plot should be completely empty (white).
 //  
-//  Any filled cells indicate a data format problem with an fadc.
+//  Any filled cells indicate a problem with an evio data bank, or unlocked TDCs.
 //
-//  If there are many filled cells, stop the DAQ, reboot the bad ROC (the ROCid is on the plot's x-axis) and restart the DAQ.  If that does not clear the error, contact a DAQ expert. 
+//  If there are many filled cells in one ROC, rebooting it might help.  Stop the DAQ, reboot the bad ROC (the ROCid is on the plot's x-axis) and restart the DAQ. 
 //  
 // End Guidance: ----------------------------------------
 
@@ -54,7 +54,7 @@
 	
 	double total_errors = locHistroc->GetEntries();
 
-        TString htitle = "Errors found in data bank";
+        TString htitle = "Errors in data bank";
 
 	int num_banks = 0;
 	for (int i=1; i<=locHistroc->GetNbinsX(); i++) {
@@ -77,7 +77,7 @@
 
 	  if (special_bank_errs > 0) {
 	  
-	    TString banknames[6] = {"0:Swap ","1:TS scaler ","2:f250 scaler ","3:EPICS ","4:BOR ","5:Trigger "};
+	    TString banknames[6] = {"0 (swap) ","1 (TS scalers) ","2 (f250 scalers) ","3 (EPICS) ","4 (BOR) ","5 (Triggers) "};
   	    for (int i=1; i<7 ; i++) {
 	      if (locHistroc->GetBinContent(i) > 0) htitle.Append(banknames[i-1]);
 	    }
@@ -87,7 +87,7 @@
 
 	  if (special_bank_errs < (int)total_errors) {
 
-	    htitle.Append("from ROCid");
+	    htitle.Append("from ROC");
 		      
 	    // find the 3 rocids with the most problems
 	    int rocid[3] = {0};
@@ -123,22 +123,20 @@
 	    int sum_rocs_counted = 0;
 	    for (int i=0; i<3 ; i++) {
 	      if (count[i]>0) {
-		if (i>0) htitle.Append("and ");
-	        htitle.Append(Form("%i ",rocid[i]));
+		if (i>0) htitle.Append(" and ");
+	        htitle.Append(Form("%i",rocid[i]));
 	      }
 	      sum_rocs_counted += count[i];
 	    } 
 
-	    if (special_bank_errs + sum_rocs_counted  < (int)total_errors) htitle.Append("etc ");
+	    if (special_bank_errs + sum_rocs_counted  < (int)total_errors) htitle.Append(" etc");
 
 	  }
 
-	  htitle.Append(Form("in %.0f events",Nevents));
+	  htitle.Append(Form(".  Events processed: %.0f",Nevents));
 
 	}
 
-
-	cout << htitle << endl;
 	
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
@@ -171,7 +169,7 @@
 		if (total_errors > 0) {
 		  locHist->SetTitle(htitle);
 		} else {
-		  locHist->SetTitle("No errors found");
+		  locHist->SetTitle(Form("No errors found.  Events processed: %.0f",Nevents));
 		}
 		
 		locHist->SetStats(0);

--- a/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
+++ b/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
@@ -54,14 +54,26 @@
 	
 	double total_errors = locHistroc->GetEntries();
 
-        TString htitle = "Errors found in data bank(s) ";
+        TString htitle = "Errors found in data bank";
 
+	int num_banks = 0;
+	for (int i=1; i<=locHistroc->GetNbinsX(); i++) {
+	  if (locHistroc->GetBinContent(i) >0) num_banks++;
+	}
+
+	if (num_banks > 1) htitle.Append("s");
+	htitle.Append(" ");
+
+	
 	// NB there is no bin 0.  GetBinCenter(1) = 0
-
+	
 	if (total_errors > 0) {
 
 	  int special_bank_errs = 0;
-	  for (int i=i; i<7 ; i++) special_bank_errs += locHistroc->GetBinContent(i);
+
+	  for (int i=1 ; i<7 ; i++) {
+	    special_bank_errs += locHistroc->GetBinContent(i);
+	  }
 
 	  if (special_bank_errs > 0) {
 	  
@@ -71,13 +83,11 @@
 	    }
 
 	    if (special_bank_errs < (int)total_errors) htitle.Append("and ");
-
-	    cout << htitle << endl;
 	  }
 
 	  if (special_bank_errs < (int)total_errors) {
 
-	    htitle.Append("from ROCid(s) ");
+	    htitle.Append("from ROCid");
 		      
 	    // find the 3 rocids with the most problems
 	    int rocid[3] = {0};
@@ -107,9 +117,15 @@
 	      }
 	    }
 
+	    if (count[1] > 0) htitle.Append("s");
+	    htitle.Append(" ");
+	    
 	    int sum_rocs_counted = 0;
 	    for (int i=0; i<3 ; i++) {
-	      if (count[i] >0) htitle.Append(Form("%i ",rocid[i]));
+	      if (count[i]>0) {
+		if (i>0) htitle.Append("and ");
+	        htitle.Append(Form("%i ",rocid[i]));
+	      }
 	      sum_rocs_counted += count[i];
 	    } 
 
@@ -121,6 +137,9 @@
 
 	}
 
+
+	cout << htitle << endl;
+	
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)

--- a/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
+++ b/src/plugins/monitoring/bad_hits/HistMacro_bad_hits.C
@@ -42,34 +42,84 @@
 	}
 
 
-	// find the 3 rocids with the most problems
-	int rocid[3] = {0};
-	int count[3] = {0};
-	
-        for (int i=1; i<=locHistroc->GetXaxis()->GetNbins(); i++) {
-	  int nerrors = locHistroc->GetBinContent(i);
-
-          if (nerrors > count[0]) {
-	    count[2] = count[1];
-	    count[1] = count[0];
-	    rocid[2] = rocid[1];
-	    rocid[1] = rocid[0];
-
-	    count[0] = nerrors;
-	    rocid[0] = i;
-	    
-          } else if (nerrors > count[1]) {
-	    count[2] = count[1];
-	    rocid[2] = rocid[1];
-	    count[1] = nerrors;
-	    rocid[1] = i;
-	    
-          }else if (nerrors > count[2]) {
-	    count[2] = nerrors;
-	    rocid[2] = i;
-          }
+        TH1I *hevents = (TH1I*)gDirectory->Get("num_events");
+	if (!hevents) {
+             std::cout << "HistMacro_bad_hits: unable to find /bad_hits/num_events !" << std::endl;
+	     return;
 	}
 
+        double Nevents = (double)hevents->GetBinContent(1);
+        if (debug) std::cout << "HistMacro_bad_hits: Nevents=" << Nevents << std::endl;
+
+	
+	double total_errors = locHistroc->GetEntries();
+
+        TString htitle = "Errors found in data bank(s) ";
+
+	// NB there is no bin 0.  GetBinCenter(1) = 0
+
+	if (total_errors > 0) {
+
+	  int special_bank_errs = 0;
+	  for (int i=i; i<7 ; i++) special_bank_errs += locHistroc->GetBinContent(i);
+
+	  if (special_bank_errs > 0) {
+	  
+	    TString banknames[6] = {"0:Swap ","1:TS scaler ","2:f250 scaler ","3:EPICS ","4:BOR ","5:Trigger "};
+  	    for (int i=1; i<7 ; i++) {
+	      if (locHistroc->GetBinContent(i) > 0) htitle.Append(banknames[i-1]);
+	    }
+
+	    if (special_bank_errs < (int)total_errors) htitle.Append("and ");
+
+	    cout << htitle << endl;
+	  }
+
+	  if (special_bank_errs < (int)total_errors) {
+
+	    htitle.Append("from ROCid(s) ");
+		      
+	    // find the 3 rocids with the most problems
+	    int rocid[3] = {0};
+	    int count[3] = {0};
+	
+	    for (int i=7; i<=locHistroc->GetXaxis()->GetNbins(); i++) {
+	      int nerrors = locHistroc->GetBinContent(i);
+
+	      if (nerrors > count[0]) {
+		count[2] = count[1];
+		count[1] = count[0];
+		rocid[2] = rocid[1];
+		rocid[1] = rocid[0];
+
+		count[0] = nerrors;
+		rocid[0] = i-1;
+	    
+	      } else if (nerrors > count[1]) {
+		count[2] = count[1];
+		rocid[2] = rocid[1];
+		count[1] = nerrors;
+		rocid[1] = i-1;
+	    
+	      } else if (nerrors > count[2]) {
+		count[2] = nerrors;
+		rocid[2] = i-1;
+	      }
+	    }
+
+	    int sum_rocs_counted = 0;
+	    for (int i=0; i<3 ; i++) {
+	      if (count[i] >0) htitle.Append(Form("%i ",rocid[i]));
+	      sum_rocs_counted += count[i];
+	    } 
+
+	    if (special_bank_errs + sum_rocs_counted  < (int)total_errors) htitle.Append("etc ");
+
+	  }
+
+	  htitle.Append(Form("in %.0f events",Nevents));
+
+	}
 
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
@@ -99,14 +149,10 @@
 		locHist->GetYaxis()->SetNdivisions(210);  
 		locHist->GetXaxis()->SetNdivisions(15);
 
-		if (rocid[2]>0) {
-		  locHist->SetTitle(Form("Format errors in rocs %i %i %i",rocid[0],rocid[1],rocid[2]));
-		} else if (rocid[1]>0) {
-		  locHist->SetTitle(Form("Format errors in rocs %i %i",rocid[0],rocid[1]));
-		} else if (rocid[0]>0) {
-		  locHist->SetTitle(Form("Format errors in roc %i",rocid[0]));		  
+		if (total_errors > 0) {
+		  locHist->SetTitle(htitle);
 		} else {
-		  locHist->SetTitle("No format errors found");
+		  locHist->SetTitle("No errors found");
 		}
 		
 		locHist->SetStats(0);
@@ -120,16 +166,6 @@
 
           if (debug) std::cout << "HistMacro_bad_hits: RSAI block" << std::endl;
 
-          double Nevents = 1.0;
-
-          TH1I *hevents = (TH1I*)gDirectory->Get("num_events");
-
-          if(hevents){
-             Nevents = (double)hevents->GetBinContent(1);
-             if (debug) std::cout << "HistMacro_bad_hits: Nevents=" << Nevents << std::endl;
-          }else{
-             std::cout << "HistMacro_bad_hits: unable to find /bad_hits/num_events !" << std::endl;
-          }
 
 	  auto min_events = rs_GetFlag("MIN_EVENTS_RSAI");
 	  if( min_events < 1 ) min_events = 1E4;


### PR DESCRIPTION
The old macro numbered the rocs incorrectly, too big by one.   The plots & histograms are correct, the title was wrong.

Examples of new pictures, with links to the old ones:

run 140345 ([plot before this PR](https://halldweb.jlab.org/work/halld2/data_monitoring/RunPeriod-2026-03/mon_ver01/Run140345/HistMacro_bad_hits.png))
<img width="1212" height="834" alt="run140345" src="https://github.com/user-attachments/assets/5a4b2881-f612-4afa-96cf-1555150ba988" />

run 140344 ([plot before this PR](https://halldweb.jlab.org/work/halld2/data_monitoring/RunPeriod-2026-03/mon_ver01/Run140344/HistMacro_bad_hits.png))
<img width="1212" height="834" alt="run140344" src="https://github.com/user-attachments/assets/54bb5183-6e4d-4770-8837-a8384068ed61" />

run 140324 ([plot before this PR](https://halldweb.jlab.org/work/halld2/data_monitoring/RunPeriod-2026-03/mon_ver01/Run140324/HistMacro_bad_hits.png))
<img width="1212" height="834" alt="run140324" src="https://github.com/user-attachments/assets/97645ec2-ee49-44d8-9712-65cdb3d0db91" />
