### PR TITLE
Helicity board analysis updates

### DIFF
--- a/src/libraries/DAQ/DBeamHelicity_factory.cc
+++ b/src/libraries/DAQ/DBeamHelicity_factory.cc
@@ -33,6 +33,7 @@ void DBeamHelicity_factory::Init()
 	auto app = GetApplication();
 	app->SetDefaultParameter("PREFER_PROMPT_HELICITY_DATA", PREFER_PROMPT_HELICITY_DATA, "If both prompt and delayed helicity data are in the data stream, prefer the prompt. (default: true)");
 	app->SetDefaultParameter("HELICITY:HB_SHIFT", dHDBoardDelay, "Helicity board bits to shift to get prompt helicity. (default: 8)");
+	app->SetDefaultParameter("HELICITY:REJECT_TSETTLE", REJECT_TSETTLE, "Reject events when the helicity is changing (t_settle is on). (default: 1)");
 
 	return; //NOERROR;
 }
@@ -115,6 +116,11 @@ void DBeamHelicity_factory::Process(const std::shared_ptr<const JEvent>& event){
   }
   
   if(locBeamHelicity == nullptr)  return;
+
+  // perform optional event selections 
+  if(REJECT_TSETTLE && (locBeamHelicity->t_settle==0)) {
+	locBeamHelicity->valid = false;
+  }
   
   
   Insert(locBeamHelicity);
@@ -163,6 +169,7 @@ DBeamHelicity *DBeamHelicity_factory::Make_DBeamHelicity(const DHelicityData *lo
 
 	DBeamHelicity *locBeamHelicity = new DBeamHelicity;
 	locBeamHelicity->pattern_sync  = locHelicityData->trigger_pattern_sync;
+	//locBeamHelicity->t_settle      = !(locHelicityData->trigger_tstable);
 	locBeamHelicity->t_settle      = locHelicityData->trigger_tstable;
 	locBeamHelicity->helicity      = helicityDecoderCalcPolarity(locHelicityData->trigger_event_polarity, locHelicityData->helicity_seed, dHDBoardDelay);
 	locBeamHelicity->pair_sync     = locHelicityData->trigger_pair_sync;
@@ -220,8 +227,8 @@ void DBeamHelicity_factory::reportPredictorError(uint32_t testval) const
 	lval = advanceSeed(lval);
 	lval = advanceSeed(lval);
 	
-	jerr << "  Bad word: 0x" << hex << testval << endl;
-	jerr << "     Compare 0x" << rval << " to 0x" << lval << dec << endl;
+ 	jerr << "  Bad word: 0x" << hex << testval << endl;
+ 	jerr << "     Compare 0x" << rval << " to 0x" << lval << dec << endl;
 }
 
 //------------------

--- a/src/libraries/DAQ/DBeamHelicity_factory.h
+++ b/src/libraries/DAQ/DBeamHelicity_factory.h
@@ -38,7 +38,8 @@ class DBeamHelicity_factory:public JFactoryT<DBeamHelicity>{
 		uint32_t helicityDecoderCalcPolarity(uint32_t event_polarity, uint32_t seed, uint32_t delay);
 
 		bool PREFER_PROMPT_HELICITY_DATA;
-		
+		bool REJECT_TSETTLE = true;
+				
 		uint32_t dHDBoardDelay;
 };
 

--- a/src/libraries/DAQ/DBeamHelicity_factory_CORRECTED.cc
+++ b/src/libraries/DAQ/DBeamHelicity_factory_CORRECTED.cc
@@ -19,7 +19,7 @@ using namespace std;
 void DBeamHelicity_factory_CORRECTED::Init()
 {
 	auto app = GetApplication();
-	app->SetDefaultParameter("HELICITY:REJECT_TSETTLE", REJECT_TSETTLE, "Reject events when the helicity is changing (t_settle is on). (default: 1)");
+	app->SetDefaultParameter("CORRECTEDHELICITY:REJECT_TSETTLE", REJECT_TSETTLE, "Reject events when the helicity is changing (t_settle is on). (default: 0)");
 
 	return; //NOERROR;
 }
@@ -54,7 +54,7 @@ void DBeamHelicity_factory_CORRECTED::Process(const std::shared_ptr<const JEvent
 	for(size_t loc_i = 0; loc_i < locBeamHelicities.size(); ++loc_i) {
   		// make some (optional) quality selections
 		if(!locBeamHelicities[loc_i]->valid) continue;
-  		if(REJECT_TSETTLE && locBeamHelicities[loc_i]->t_settle) {
+  		if(REJECT_TSETTLE && (locBeamHelicities[loc_i]->t_settle==0)) {
   			return;
   		}
 	

--- a/src/libraries/DAQ/DBeamHelicity_factory_CORRECTED.h
+++ b/src/libraries/DAQ/DBeamHelicity_factory_CORRECTED.h
@@ -25,7 +25,7 @@ class DBeamHelicity_factory_CORRECTED:public JFactoryT<DBeamHelicity>{
 
 	private:
 		float dCorrectionFactor = 1.;
-		bool REJECT_TSETTLE = true;
+		bool REJECT_TSETTLE = false;
 
 };
 


### PR DESCRIPTION
made some changes to more accurately deal with helicity board data.
ran over some 2026-03, 2025-01 and 2023-01 raw data with the highlevel_online plugin and this seems to work reasonably well.

my suggestion is to merge these changes to help with the monitoring and then run more detailed offline analysis checks

* Move default t_settle reject logic into DBeamHelicity_factory
* reject events with t_settle==0