### PR TITLE
Moficiations to PID monitoring for Low Energy

### DIFF
--- a/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_PID.C
@@ -9,7 +9,7 @@
 // e-mail: davidl@jlab.org
 // e-mail: staylor@jlab.org
 // e-mail: sdobbs@jlab.org
-// e-mail: tbritton@jlab.org
+// e-mail: dalton@jlab.org
 //
 
 #include <time.h>
@@ -518,6 +518,7 @@ class FitWrapper{
 	TH1* PiPlusPiMinus       = (TH1*)gDirectory->Get("PiPlusPiMinus");
 	TH1* KPlusKMinus         = (TH1*)gDirectory->Get("KPlusKMinus");
 	TH1* PiMinusProton       = (TH1*)gDirectory->Get("PiMinusProton");
+	TH1* PiMinusProton_Kshort = (TH1*)gDirectory->Get("PiMinusProton_Kshort");
 	TH1* PiPlusPiMinusPiZero = (TH1*)gDirectory->Get("PiPlusPiMinusPiZero");
 	TH1* L1bits_gtp          = (TH1*)gDirectory->Get("L1bits_gtp");
 	TH1* PSPairEnergy        = (TH1*)gDirectory->Get("PSPairEnergy");
@@ -554,7 +555,7 @@ class FitWrapper{
 	//Get/Make Canvas
 	TCanvas *locCanvas = NULL;
 	if(TVirtualPad::Pad() == NULL)
-		locCanvas = new TCanvas("PID", "PID", 1200, 600); //for testing
+		locCanvas = new TCanvas("PID", "PID", 1200, 800); //for testing, 1200x800 is default canvas in monitoring
 	else
 		locCanvas = gPad->GetCanvas();
 	locCanvas->Divide(3, 2);
@@ -589,20 +590,25 @@ class FitWrapper{
 	}
 
 	TLatex latex;
-
+	float TextSizeLarge = 0.06;
+	float TextSizeMed = 0.05;
+	float TextSizeSmall = 0.035;
 
 	//----------- Pi0 --------------
 	locCanvas->cd(1);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
 	if(TwoGammaMass != NULL)
 	{
 
-		TwoGammaMass->GetXaxis()->SetTitleSize(0.05);
-		TwoGammaMass->GetYaxis()->SetTitleSize(0.05);
-		TwoGammaMass->GetXaxis()->SetLabelSize(0.05);
-		TwoGammaMass->GetYaxis()->SetLabelSize(0.035);
+		TwoGammaMass->GetXaxis()->SetTitleSize(TextSizeMed);
+		TwoGammaMass->GetYaxis()->SetTitleSize(TextSizeMed);
+		TwoGammaMass->GetXaxis()->SetLabelSize(TextSizeMed);
+		TwoGammaMass->GetYaxis()->SetLabelSize(TextSizeSmall);
 		TwoGammaMass->SetStats(0);
+		TwoGammaMass->GetXaxis()->SetRangeUser(0.0, 0.8);
 
 		// Fit to pi0 peak
 		TF1 *fun = (TF1*)gDirectory->FindObjectAny("fun_pi0_fit");
@@ -648,22 +654,22 @@ class FitWrapper{
 
 
 		char str[256];
-		sprintf(str, "num. #pi^{o} : %g", I);
+		sprintf(str, "num. #pi^{o} : %.3g", I);
 
 		double max = 1.05*TwoGammaMass->GetMaximum();
 		latex.SetTextColor(kBlack);
 		latex.SetTextAngle(0.0);
 		latex.SetTextAlign(11);
-		latex.SetTextSize(0.075);
-		latex.DrawLatex(0.175, max*3.0/4.0, str);
+		latex.SetTextSize(TextSizeLarge);
+		latex.DrawLatexNDC(0.48, 0.87, str);
 
 		// Print rate per trigger
 		double Ntrig = Ntrig_tot - Ntrig_tot_pi0;
 		double rate_per_1ktrig = I/Ntrig*1000.0;
 		if(Ntrig>0.0){
-			sprintf(str, "%3.1f per 1k triggers (bits 1,2)", rate_per_1ktrig);
-			latex.SetTextSize(0.06);
-			latex.DrawLatex(0.3, max*0.65, str);
+			sprintf(str, "%3.1f per 1k trigs (bits 1,2)", rate_per_1ktrig);
+			latex.SetTextSize(TextSizeMed);
+			latex.DrawLatexNDC(0.45, 0.79, str);
 		}
 
 		// Print rate per PS (integral of reconstructed energy hist)
@@ -671,8 +677,8 @@ class FitWrapper{
 		double rate_per_ps = I/Nmy_ps*1000.0;
 		if(Nmy_ps>0.0){
 			sprintf(str, "%3.1f per 1k PS coin", rate_per_ps);
-			latex.SetTextSize(0.06);
-			latex.DrawLatex(0.3, max*0.565, str);
+			latex.SetTextSize(TextSizeMed);
+			latex.DrawLatexNDC(0.45, 0.735, str);
 		}
 
 		// Only try adding to time series if we have more than 2000 particles in peak
@@ -709,7 +715,7 @@ class FitWrapper{
 		lin.DrawLine(0.135, 0.0, 0.135, max);
 		
 		latex.SetTextAngle(90.0);
-		latex.SetTextSize(0.035);
+		latex.SetTextSize(TextSizeSmall);
 		latex.SetTextAlign(21);
 		latex.SetTextColor(kMagenta);
 		latex.DrawLatex(0.131, max/2.0, "135 MeV");
@@ -717,15 +723,15 @@ class FitWrapper{
 		// Print number of L1 triggers
 		latex.SetTextColor(kBlack);
 		latex.SetTextAngle(0.0);
-		latex.SetTextSize(0.05);
+		latex.SetTextSize(TextSizeSmall);
 		latex.SetTextAlign(12);
 		if(L1bits_gtp){
 			sprintf(str, "trig bit 1 (FCAL/BCAL): %g", (double)L1bits_gtp->GetBinContent(1));
-			latex.DrawLatex(0.4, max*0.45, str);
+			latex.DrawLatex(0.3, max*0.55, str);
 			sprintf(str, "trig bit 3 (BCAL): %g", (double)L1bits_gtp->GetBinContent(3));
-			latex.DrawLatex(0.4, max*0.35, str);
+			latex.DrawLatex(0.3, max*0.45, str);
 			sprintf(str, "trig bit 4 (PS): %g", (double)L1bits_gtp->GetBinContent(4));
-			latex.DrawLatex(0.4, max*0.25, str);
+			latex.DrawLatex(0.3, max*0.35, str);
 		}	
 	}
 
@@ -733,12 +739,14 @@ class FitWrapper{
 	locCanvas->cd(2);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
 	if(KPlusKMinus != NULL)
 	{
-		KPlusKMinus->GetXaxis()->SetTitleSize(0.05);
-		KPlusKMinus->GetYaxis()->SetTitleSize(0.05);
-		KPlusKMinus->GetXaxis()->SetLabelSize(0.05);
-		KPlusKMinus->GetYaxis()->SetLabelSize(0.035);
+		KPlusKMinus->GetXaxis()->SetTitleSize(TextSizeMed);
+		KPlusKMinus->GetYaxis()->SetTitleSize(TextSizeMed);
+		KPlusKMinus->GetXaxis()->SetLabelSize(TextSizeMed);
+		KPlusKMinus->GetYaxis()->SetLabelSize(TextSizeSmall);
 		KPlusKMinus->SetStats(0);
 		KPlusKMinus->GetXaxis()->SetRangeUser(0.8, 2.0);
 		
@@ -748,22 +756,22 @@ class FitWrapper{
 
 		if(I>0.0){
 			char str[256];
-			sprintf(str, "num. #phi : %g", I);
+			sprintf(str, "num. #phi : %.3g", I);
 
 			double max = 1.05*KPlusKMinus->GetMaximum();
 			latex.SetTextColor(kBlack);
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
-			latex.SetTextSize(0.075);
-			latex.DrawLatex(1.4, max*3.0/4.0, str);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_phi;
 			double rate_per_1ktrig = I/Ntrig*1000.0;
 			if(Ntrig_tot>0.0){
-				sprintf(str, "%3.3f per 1k triggers (bits 1,2)", rate_per_1ktrig);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.4, max*0.65, str);
+				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -771,8 +779,8 @@ class FitWrapper{
 			double rate_per_ps = I/Nmy_ps*1000.0;
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.4, max*0.565, str);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 200 particles in peak
@@ -809,37 +817,40 @@ class FitWrapper{
 	locCanvas->cd(5);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
+
 	if(PiMinusProton != NULL)
 	{
-		PiMinusProton->GetXaxis()->SetTitleSize(0.05);
-		PiMinusProton->GetYaxis()->SetTitleSize(0.05);
-		PiMinusProton->GetXaxis()->SetLabelSize(0.05);
-		PiMinusProton->GetYaxis()->SetLabelSize(0.035);
+		PiMinusProton->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiMinusProton->GetYaxis()->SetLabelSize(TextSizeSmall);
 		PiMinusProton->SetStats(0);
-		PiMinusProton->GetXaxis()->SetRangeUser(1.0, 1.4);
+		PiMinusProton->GetXaxis()->SetRangeUser(1.04, 1.23);
 
 		Double_t pars_out[3*2];
 		Double_t errs_out[3*2];
-		Double_t I = FitWrapper::FitPeaksWithBackgr(PiMinusProton, 0.938+0.139, 1.3, "GG", 1.116, 0.006, 0.0, 0.00, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiMinusProton, 0.938+0.139, 1.3, "G", 1.116, 0.006, 0.0, 0.00, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
 
 		if(I>0.0){
 			char str[256];
-			sprintf(str, "num. #Lambda : %g", I);
+			sprintf(str, "num. #Lambda : %.4g", I);
 
 			double max = 1.05*PiMinusProton->GetMaximum();
 			latex.SetTextColor(kBlack);
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
-			latex.SetTextSize(0.075);
-			latex.DrawLatex(1.2, max*0.45, str);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_lambda;
-			double rate_per_1ktrig = I/Ntrig*1000.0;
+			double rate_per_1ktrig = I/Ntrig*1000000.0;
 			if(Ntrig_tot>0.0){
-				sprintf(str, "%3.3f per 1k triggers (bits 1,2)", rate_per_1ktrig);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.2, max*0.35, str);
+				sprintf(str, "%3.1f per 1M trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -847,8 +858,8 @@ class FitWrapper{
 			double rate_per_ps = I/Nmy_ps*1000.0;
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.2, max*0.255, str);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 200 particles in peak
@@ -881,16 +892,97 @@ class FitWrapper{
 			}
 		}
 	}
+	//----------- Lambda with Kshort--------------
+	locCanvas->cd(6);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
+	if(PiMinusProton_Kshort != NULL)
+	{
+		PiMinusProton_Kshort->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton_Kshort->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton_Kshort->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiMinusProton_Kshort->GetYaxis()->SetLabelSize(TextSizeSmall);
+		PiMinusProton_Kshort->SetStats(0);
+		PiMinusProton_Kshort->GetXaxis()->SetRangeUser(1.04, 1.23);
+
+		Double_t pars_out[3*2];
+		Double_t errs_out[3*2];
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiMinusProton_Kshort, 0.938+0.139, 1.2, "G", 1.116, 0.006, 0.0, 0.00, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+
+		if(I>0.0){
+			char str[256];
+			sprintf(str, "num. #Lambda : %.4g", I);
+
+			double max = 1.05*PiMinusProton_Kshort->GetMaximum();
+			latex.SetTextColor(kBlack);
+			latex.SetTextAngle(0.0);
+			latex.SetTextAlign(11);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
+
+			// Print rate per trigger
+			double Ntrig = Ntrig_tot - Ntrig_tot_lambda;
+			double rate_per_1ktrig = I/Ntrig*1000000.0;
+			if(Ntrig_tot>0.0){
+				sprintf(str, "%.1f per 1M trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.79, str);
+			}
+
+			// Print rate per PS (integral of reconstructed energy hist)
+			double Nmy_ps = Nps - Nps_lambda;
+			double rate_per_ps = I/Nmy_ps*1000.0;
+			if(Nmy_ps>0.0){
+				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.735, str);
+			}
+
+			// Only try adding to time series if we have more than 200 particles in peak
+			cout << "====== Lambda: I="<<I<<"  mean: " << pars_out[1] << " +/- " << errs_out[1] << "   sigma: "<< pars_out[2] << " +/- " << errs_out[2] << endl;
+			if( (I>200.0) && (errs_out[1]<0.07*pars_out[1]) && (errs_out[2]<0.2*pars_out[2]) ){
+
+				// Add to time series
+				InsertSeriesMassFit("lambda", pars_out[1], pars_out[2], errs_out[1], errs_out[2], unix_time);
+
+				// per 1k triggers
+				if(Ntrig_tot>0.0){
+					stringstream ss;
+					ss << "fit_stats,ptype=lambda ";
+					ss << "rate_per_1ktrig="<<rate_per_1ktrig;
+					ss << ",rate_per_1kps="<<rate_per_ps;
+					ss << ",counts="<<I;
+					ss << ",Ntrig_phys="<<Ntrig_phys;
+					ss << ",Ntrig_ps="<<Ntrig_ps;
+					ss << ",Nps="<<Nmy_ps;
+					if(unix_time!=0.0) ss<<" "<<(uint64_t)(unix_time*1.0E9);  // time is in units of ns
+					InsertSeriesData( ss.str() );
+				}
+
+				// Optionally reset the histogram so next fit is independent of this one
+				if(rs_GetFlag("RESET_AFTER_FIT")){
+					rs_ResetHisto("/highlevel/PiMinusProton_Kshort");
+					PIDNorms->SetBinContent(NORM_lambda_trig, Ntrig_tot);
+					PIDNorms->SetBinContent(NORM_lambda_ps  , Nps);
+				}
+			}
+		}
+	}
+
 	//----------- Rho --------------
 	locCanvas->cd(3);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
 	if(PiPlusPiMinus != NULL)
 	{
-		PiPlusPiMinus->GetXaxis()->SetTitleSize(0.05);
-		PiPlusPiMinus->GetYaxis()->SetTitleSize(0.05);
-		PiPlusPiMinus->GetXaxis()->SetLabelSize(0.05);
-		PiPlusPiMinus->GetYaxis()->SetLabelSize(0.035);
+		PiPlusPiMinus->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiPlusPiMinus->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiPlusPiMinus->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiPlusPiMinus->GetYaxis()->SetLabelSize(TextSizeSmall);
 		PiPlusPiMinus->SetStats(0);
 
 		Double_t pars_out[3*2];
@@ -900,22 +992,22 @@ class FitWrapper{
 		
 		if(I>0.0){
 			char str[256];
-			sprintf(str, "num. #rho : %g", I);
+			sprintf(str, "num. #rho : %.4g", I);
 
 			double max = 1.05*PiPlusPiMinus->GetMaximum();
 			latex.SetTextColor(kBlack);
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
-			latex.SetTextSize(0.075);
-			latex.DrawLatex(1.005, max*3.0/4.0, str);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_rho;
 			double rate_per_1ktrig = I/Ntrig*1000.0;
 			if(Ntrig_tot>0.0){
-				sprintf(str, "%3.3f per 1k triggers (bits 1,2)", rate_per_1ktrig);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.010, max*0.65, str);
+				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -923,8 +1015,8 @@ class FitWrapper{
 			double rate_per_ps = I/Nmy_ps*1000.0;
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.010, max*0.565, str);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 1000 particles in peak
@@ -961,37 +1053,41 @@ class FitWrapper{
 	locCanvas->cd(4);
 	gPad->SetTicks();
 	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
 	if(PiPlusPiMinusPiZero != NULL)
 	{
-		PiPlusPiMinusPiZero->GetXaxis()->SetTitleSize(0.05);
-		PiPlusPiMinusPiZero->GetYaxis()->SetTitleSize(0.05);
-		PiPlusPiMinusPiZero->GetXaxis()->SetLabelSize(0.05);
-		PiPlusPiMinusPiZero->GetYaxis()->SetLabelSize(0.035);
+		PiPlusPiMinusPiZero->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiPlusPiMinusPiZero->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiPlusPiMinusPiZero->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiPlusPiMinusPiZero->GetYaxis()->SetLabelSize(TextSizeSmall);
 		PiPlusPiMinusPiZero->SetStats(0);
+		PiPlusPiMinusPiZero->GetXaxis()->SetRangeUser(0.4, 1.2);
+
 	
 		Double_t pars_out[3*2];
 		Double_t errs_out[3*2];
 		//Double_t I = FitWrapper::FitWithBackground(PiPlusPiMinusPiZero, 0.782, 0.03, 0.42, 1.6);
-		Double_t I = FitWrapper::FitPeaksWithBackgr(PiPlusPiMinusPiZero, 0.139*2+0.135, 1.3, "G", 0.782, 0.009, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
-		
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiPlusPiMinusPiZero, 0.139*2+0.135, 1.2, "GG", 0.782, 0.009, 0.547, 0.01, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+
 		if(I>0.0){
 			char str[256];
-			sprintf(str, "num. #omega : %g", I);
+			sprintf(str, "num. #omega : %.4g", I);
 
 			double max = 1.05*PiPlusPiMinusPiZero->GetMaximum();
 			latex.SetTextColor(kBlack);
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
-			latex.SetTextSize(0.075);
-			latex.DrawLatex(1.005, max*0.8, str);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_omega;
 			double rate_per_1ktrig = I/Ntrig*1000.0;
 			if(Ntrig_tot>0.0){
-				sprintf(str, "%3.3f per 1k triggers (bits 1,2)", rate_per_1ktrig);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.010, max*0.65, str);
+				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -999,8 +1095,8 @@ class FitWrapper{
 			double rate_per_ps = I/Nmy_ps*1000.0;
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
-				latex.SetTextSize(0.06);
-				latex.DrawLatex(1.010, max*0.565, str);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 200 particles in peak
@@ -1033,3 +1129,4 @@ class FitWrapper{
 		}
 	}
 }
+

--- a/src/plugins/monitoring/highlevel_online/HistMacro_PID_LowE.C
+++ b/src/plugins/monitoring/highlevel_online/HistMacro_PID_LowE.C
@@ -558,7 +558,7 @@ class FitWrapper{
 		locCanvas = new TCanvas("PID", "PID", 1200, 800); //for testing, 1200x800 is default canvas in monitoring
 	else
 		locCanvas = gPad->GetCanvas();
-	locCanvas->Divide(2, 2);
+	locCanvas->Divide(3, 2);
 
 	double Ntrig_tot  = 0.0;
 	double Ntrig_phys = 0.0;
@@ -661,7 +661,7 @@ class FitWrapper{
 		latex.SetTextAngle(0.0);
 		latex.SetTextAlign(11);
 		latex.SetTextSize(TextSizeLarge);
-		latex.DrawLatexNDC(0.58, 0.87, str);
+		latex.DrawLatexNDC(0.48, 0.87, str);
 
 		// Print rate per trigger
 		double Ntrig = Ntrig_tot - Ntrig_tot_pi0;
@@ -669,7 +669,7 @@ class FitWrapper{
 		if(Ntrig>0.0){
 			sprintf(str, "%3.1f per 1k trigs (bits 1,2)", rate_per_1ktrig);
 			latex.SetTextSize(TextSizeMed);
-			latex.DrawLatexNDC(0.55, 0.79, str);
+			latex.DrawLatexNDC(0.45, 0.79, str);
 		}
 
 		// Print rate per PS (integral of reconstructed energy hist)
@@ -678,7 +678,7 @@ class FitWrapper{
 		if(Nmy_ps>0.0){
 			sprintf(str, "%3.1f per 1k PS coin", rate_per_ps);
 			latex.SetTextSize(TextSizeMed);
-			latex.DrawLatexNDC(0.55, 0.735, str);
+			latex.DrawLatexNDC(0.45, 0.735, str);
 		}
 
 		// Only try adding to time series if we have more than 2000 particles in peak
@@ -763,7 +763,7 @@ class FitWrapper{
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
 			latex.SetTextSize(TextSizeLarge);
-			latex.DrawLatexNDC(0.58, 0.87, str);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_phi;
@@ -771,7 +771,7 @@ class FitWrapper{
 			if(Ntrig_tot>0.0){
 				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.79, str);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -780,7 +780,7 @@ class FitWrapper{
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.735, str);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 200 particles in peak
@@ -813,6 +813,164 @@ class FitWrapper{
 			}
 		}
 	}
+	//----------- Lambda --------------
+	locCanvas->cd(5);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
+
+	if(PiMinusProton != NULL)
+	{
+		PiMinusProton->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiMinusProton->GetYaxis()->SetLabelSize(TextSizeSmall);
+		PiMinusProton->SetStats(0);
+		PiMinusProton->GetXaxis()->SetRangeUser(1.04, 1.23);
+
+		Double_t pars_out[3*2];
+		Double_t errs_out[3*2];
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiMinusProton, 0.938+0.139, 1.3, "G", 1.116, 0.006, 0.0, 0.00, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+
+		if(I>0.0){
+			char str[256];
+			sprintf(str, "num. #Lambda : %.4g", I);
+
+			double max = 1.05*PiMinusProton->GetMaximum();
+			latex.SetTextColor(kBlack);
+			latex.SetTextAngle(0.0);
+			latex.SetTextAlign(11);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
+
+			// Print rate per trigger
+			double Ntrig = Ntrig_tot - Ntrig_tot_lambda;
+			double rate_per_1ktrig = I/Ntrig*1000000.0;
+			if(Ntrig_tot>0.0){
+				sprintf(str, "%3.1f per 1M trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.79, str);
+			}
+
+			// Print rate per PS (integral of reconstructed energy hist)
+			double Nmy_ps = Nps - Nps_lambda;
+			double rate_per_ps = I/Nmy_ps*1000.0;
+			if(Nmy_ps>0.0){
+				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.735, str);
+			}
+
+			// Only try adding to time series if we have more than 200 particles in peak
+			cout << "====== Lambda: I="<<I<<"  mean: " << pars_out[1] << " +/- " << errs_out[1] << "   sigma: "<< pars_out[2] << " +/- " << errs_out[2] << endl;
+			if( (I>200.0) && (errs_out[1]<0.07*pars_out[1]) && (errs_out[2]<0.2*pars_out[2]) ){
+
+				// Add to time series
+				InsertSeriesMassFit("lambda", pars_out[1], pars_out[2], errs_out[1], errs_out[2], unix_time);
+			
+				// per 1k triggers
+				if(Ntrig_tot>0.0){
+					stringstream ss;
+					ss << "fit_stats,ptype=lambda ";
+					ss << "rate_per_1ktrig="<<rate_per_1ktrig;
+					ss << ",rate_per_1kps="<<rate_per_ps;
+					ss << ",counts="<<I;
+					ss << ",Ntrig_phys="<<Ntrig_phys;
+					ss << ",Ntrig_ps="<<Ntrig_ps;
+					ss << ",Nps="<<Nmy_ps;
+					if(unix_time!=0.0) ss<<" "<<(uint64_t)(unix_time*1.0E9);  // time is in units of ns
+					InsertSeriesData( ss.str() );
+				}
+
+				// Optionally reset the histogram so next fit is independent of this one
+				if(rs_GetFlag("RESET_AFTER_FIT")){
+					rs_ResetHisto("/highlevel/PiMinusProton");
+					PIDNorms->SetBinContent(NORM_lambda_trig, Ntrig_tot);
+					PIDNorms->SetBinContent(NORM_lambda_ps  , Nps);
+				}
+			}
+		}
+	}
+	//----------- Lambda with Kshort--------------
+	locCanvas->cd(6);
+	gPad->SetTicks();
+	gPad->SetGrid();
+	gPad->SetBottomMargin(0.1);
+	gPad->SetRightMargin(0.05);
+	if(PiMinusProton_Kshort != NULL)
+	{
+		PiMinusProton_Kshort->GetXaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton_Kshort->GetYaxis()->SetTitleSize(TextSizeMed);
+		PiMinusProton_Kshort->GetXaxis()->SetLabelSize(TextSizeMed);
+		PiMinusProton_Kshort->GetYaxis()->SetLabelSize(TextSizeSmall);
+		PiMinusProton_Kshort->SetStats(0);
+		PiMinusProton_Kshort->GetXaxis()->SetRangeUser(1.04, 1.23);
+
+		Double_t pars_out[3*2];
+		Double_t errs_out[3*2];
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiMinusProton_Kshort, 0.938+0.139, 1.2, "G", 1.116, 0.006, 0.0, 0.00, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+
+		if(I>0.0){
+			char str[256];
+			sprintf(str, "num. #Lambda : %.4g", I);
+
+			double max = 1.05*PiMinusProton_Kshort->GetMaximum();
+			latex.SetTextColor(kBlack);
+			latex.SetTextAngle(0.0);
+			latex.SetTextAlign(11);
+			latex.SetTextSize(TextSizeLarge);
+			latex.DrawLatexNDC(0.48, 0.87, str);
+
+			// Print rate per trigger
+			double Ntrig = Ntrig_tot - Ntrig_tot_lambda;
+			double rate_per_1ktrig = I/Ntrig*1000000.0;
+			if(Ntrig_tot>0.0){
+				sprintf(str, "%.1f per 1M trigs (bits 1,2)", rate_per_1ktrig);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.79, str);
+			}
+
+			// Print rate per PS (integral of reconstructed energy hist)
+			double Nmy_ps = Nps - Nps_lambda;
+			double rate_per_ps = I/Nmy_ps*1000.0;
+			if(Nmy_ps>0.0){
+				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
+				latex.SetTextSize(TextSizeMed);
+				latex.DrawLatexNDC(0.16, 0.735, str);
+			}
+
+			// Only try adding to time series if we have more than 200 particles in peak
+			cout << "====== Lambda: I="<<I<<"  mean: " << pars_out[1] << " +/- " << errs_out[1] << "   sigma: "<< pars_out[2] << " +/- " << errs_out[2] << endl;
+			if( (I>200.0) && (errs_out[1]<0.07*pars_out[1]) && (errs_out[2]<0.2*pars_out[2]) ){
+
+				// Add to time series
+				InsertSeriesMassFit("lambda", pars_out[1], pars_out[2], errs_out[1], errs_out[2], unix_time);
+
+				// per 1k triggers
+				if(Ntrig_tot>0.0){
+					stringstream ss;
+					ss << "fit_stats,ptype=lambda ";
+					ss << "rate_per_1ktrig="<<rate_per_1ktrig;
+					ss << ",rate_per_1kps="<<rate_per_ps;
+					ss << ",counts="<<I;
+					ss << ",Ntrig_phys="<<Ntrig_phys;
+					ss << ",Ntrig_ps="<<Ntrig_ps;
+					ss << ",Nps="<<Nmy_ps;
+					if(unix_time!=0.0) ss<<" "<<(uint64_t)(unix_time*1.0E9);  // time is in units of ns
+					InsertSeriesData( ss.str() );
+				}
+
+				// Optionally reset the histogram so next fit is independent of this one
+				if(rs_GetFlag("RESET_AFTER_FIT")){
+					rs_ResetHisto("/highlevel/PiMinusProton_Kshort");
+					PIDNorms->SetBinContent(NORM_lambda_trig, Ntrig_tot);
+					PIDNorms->SetBinContent(NORM_lambda_ps  , Nps);
+				}
+			}
+		}
+	}
+
 	//----------- Rho --------------
 	locCanvas->cd(3);
 	gPad->SetTicks();
@@ -841,7 +999,7 @@ class FitWrapper{
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
 			latex.SetTextSize(TextSizeLarge);
-			latex.DrawLatexNDC(0.58, 0.87, str);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_rho;
@@ -849,7 +1007,7 @@ class FitWrapper{
 			if(Ntrig_tot>0.0){
 				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.79, str);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -858,7 +1016,7 @@ class FitWrapper{
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.735, str);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 1000 particles in peak
@@ -904,13 +1062,13 @@ class FitWrapper{
 		PiPlusPiMinusPiZero->GetXaxis()->SetLabelSize(TextSizeMed);
 		PiPlusPiMinusPiZero->GetYaxis()->SetLabelSize(TextSizeSmall);
 		PiPlusPiMinusPiZero->SetStats(0);
-		PiPlusPiMinusPiZero->GetXaxis()->SetRangeUser(0.4, 2.0);
+		PiPlusPiMinusPiZero->GetXaxis()->SetRangeUser(0.4, 1.2);
 
 	
 		Double_t pars_out[3*2];
 		Double_t errs_out[3*2];
 		//Double_t I = FitWrapper::FitWithBackground(PiPlusPiMinusPiZero, 0.782, 0.03, 0.42, 1.6);
-		Double_t I = FitWrapper::FitPeaksWithBackgr(PiPlusPiMinusPiZero, 0.139*2+0.135, 1.2, "G", 0.782, 0.009, 0.547, 0.01, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
+		Double_t I = FitWrapper::FitPeaksWithBackgr(PiPlusPiMinusPiZero, 0.139*2+0.135, 1.2, "GG", 0.782, 0.009, 0.547, 0.01, 0.0, 0.0, 0.0, 0.0, pars_out, errs_out);
 
 		if(I>0.0){
 			char str[256];
@@ -921,7 +1079,7 @@ class FitWrapper{
 			latex.SetTextAngle(0.0);
 			latex.SetTextAlign(11);
 			latex.SetTextSize(TextSizeLarge);
-			latex.DrawLatexNDC(0.58, 0.87, str);
+			latex.DrawLatexNDC(0.48, 0.87, str);
 
 			// Print rate per trigger
 			double Ntrig = Ntrig_tot - Ntrig_tot_omega;
@@ -929,7 +1087,7 @@ class FitWrapper{
 			if(Ntrig_tot>0.0){
 				sprintf(str, "%3.3f per 1k trigs (bits 1,2)", rate_per_1ktrig);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.79, str);
+				latex.DrawLatexNDC(0.45, 0.79, str);
 			}
 
 			// Print rate per PS (integral of reconstructed energy hist)
@@ -938,7 +1096,7 @@ class FitWrapper{
 			if(Nmy_ps>0.0){
 				sprintf(str, "%3.3f per 1k PS coin", rate_per_ps);
 				latex.SetTextSize(TextSizeMed);
-				latex.DrawLatexNDC(0.55, 0.735, str);
+				latex.DrawLatexNDC(0.45, 0.735, str);
 			}
 
 			// Only try adding to time series if we have more than 200 particles in peak

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.cc
@@ -321,10 +321,21 @@ void JEventProcessor_highlevel_online::Init()
 
 	// K+ Lambda
 	if (isExclusive)
-	  sprintf(str, "#pi^{-}p inv. mass w/ identified proton;#pi^{-}p inv. mass (GeV)");
+	  sprintf(str, "#pi^{-}p inv. mass w/ identified K^{+};#pi^{-}p inv. mass (GeV)");
 	else
 	  sprintf(str, "#pi^{-}p inv. mass w/o reconstructed recoil;#pi^{-}p inv. mass (GeV)");
-	dpim_proton = new TH1I("PiMinusProton", str, 50, 1.0, 1.4);
+	dpim_proton = new TH1I("PiMinusProton", str, 100, 1.0, 1.5);
+
+	// K0 Lambda (from neutron)
+	if (isExclusive)
+	  sprintf(str, "#pi^{-}p inv. mass w/ identified K^{0};#pi^{-}p inv. mass (GeV)");
+	else
+	  sprintf(str, "#pi^{-}p inv. mass w/o reconstructed recoil;#pi^{-}p inv. mass (GeV)");
+	dpim_proton_Kshort = new TH1I("PiMinusProton_Kshort", str, 100, 1.0, 1.5);
+	sprintf(str, "#pi^{+}#pi^{-} inv. mass;#pi^{+}#pi^{-} inv. mass (GeV)");
+	dKshort = new TH1I("Kshort", str, 100, 0.2, 1.2);
+	sprintf(str, "inv. mass;#pi^{-}p inv. mass (GeV);#pi^{+}#pi^{-} inv. mass (GeV)");
+	dpim_proton_pippim = new TH2I("PiMinusProton_PiPlusPiMinus", str, 100, 1.0, 1.5, 100, 0.2, 1.2);
 
 	// pi+ pi- pi0
 	if (isExclusive)
@@ -1277,6 +1288,93 @@ void JEventProcessor_highlevel_online::Process(const std::shared_ptr<const JEven
 				  continue;
 				dpim_proton->Fill(LambdaP4.M());
 				break;
+			      }
+			    }
+			  }
+		}
+	}
+	/*************************************************************** Kshort Lambda from neutron *******************************************************/
+
+	for(auto t1 : locChargedTracks){
+		//look for proton
+		auto hypoth1 = t1->Get_Hypothesis(Proton);
+		if(!hypoth1) continue;
+
+		//timing cut
+		auto detector1 = hypoth1->t1_detector();
+		double locDeltaT = hypoth1->time() - hypoth1->t0();
+		if(fabs(locDeltaT) > dTimingCutMap[Proton][detector1])
+			continue;
+
+		const DLorentzVector &Protonmom = hypoth1->lorentzMomentum();
+
+		for(auto t2 : locChargedTracks){
+			if(t2 == t1) continue;
+
+			//look for pi-
+			auto hypoth2 = t2->Get_Hypothesis(PiMinus);
+			if(!hypoth2) continue;
+
+			//timing cut
+			auto detector2 = hypoth2->t1_detector();
+			locDeltaT = hypoth2->time() - hypoth2->t0();
+			if(fabs(locDeltaT) > dTimingCutMap[PiMinus][detector2])
+				continue;
+
+			const DLorentzVector &PiMinusmom = hypoth2->lorentzMomentum();
+			DLorentzVector LambdaP4(Protonmom + PiMinusmom);
+
+			for(auto locBeamPhoton : locBeamPhotons_InTime)
+			  {
+			    //for exclusive phi: require at least one beam photon in time with missing mass squared near 0
+			    if (isExclusive){
+			      for(auto t3 : locChargedTracks){
+				if(t3 == t1) continue;
+				if(t3 == t2) continue;
+
+				//look for Pi+ from kshort
+				auto hypoth3 = t3->Get_Hypothesis(PiPlus);
+				if(!hypoth3) continue;
+
+				//timing cut
+				auto detector3 = hypoth3->t1_detector();
+				locDeltaT = hypoth3->time() - hypoth3->t0();
+				if(fabs(locDeltaT) > dTimingCutMap[PiPlus][detector3])
+				  continue;
+
+				const DLorentzVector &KSPiPlusmom = hypoth3->lorentzMomentum();
+
+				for(auto t4 : locChargedTracks){
+				    if(t4 == t1) continue;
+				    if(t4 == t2) continue;
+				    if(t4 == t3) continue;
+
+				    //look for Pi- from kshort
+				    auto hypoth4 = t4->Get_Hypothesis(PiMinus);
+				    if(!hypoth4) continue;
+
+				    //timing cut
+				    auto detector4 = hypoth4->t1_detector();
+				    locDeltaT = hypoth4->time() - hypoth4->t0();
+				    if(fabs(locDeltaT) > dTimingCutMap[PiMinus][detector4])
+				      continue;
+
+				    const DLorentzVector &KSPiMinusmom = hypoth4->lorentzMomentum();
+
+				    DLorentzVector locKShortP4(KSPiPlusmom + KSPiMinusmom);
+				    DLorentzVector LambdaP4(Protonmom + PiMinusmom);
+				    DLorentzVector locTargetP4(0.0, 0.0, 0.0, ParticleMass(Proton));
+				    DLorentzVector locMissingP4 = locBeamPhoton->lorentzMomentum() + locTargetP4 - LambdaP4 - locKShortP4;
+				    if(fabs(locMissingP4.M2()) > 0.01)
+				      continue;
+				    dKshort->Fill(locKShortP4.M());
+				    dpim_proton_pippim->Fill(LambdaP4.M(),locKShortP4.M());
+				    // loose cut on Kshort mass
+				    if(locKShortP4.M()<0.4 || locKShortP4.M()>0.6)
+				      continue;
+				    dpim_proton_Kshort->Fill(LambdaP4.M());
+				    break;
+				}
 			      }
 			    }
 			  }

--- a/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
+++ b/src/plugins/monitoring/highlevel_online/JEventProcessor_highlevel_online.h
@@ -72,6 +72,9 @@ class JEventProcessor_highlevel_online:public JEventProcessor
 		TH1I *dpip_pim;
 		TH1I *dKp_Km;
 		TH1I *dpim_proton;
+		TH1I *dpim_proton_Kshort;
+		TH1I *dKshort;
+		TH2I *dpim_proton_pippim;
 		TH1I *dpip_pim_pi0;
 		TH2I *dbeta_vs_p;
 		TH2I *dbeta_vs_p_BCAL;


### PR DESCRIPTION
JEventProcessor_highlevel_online

Decreased bin size for Lambda to improve fit results.
Added histogram for K0 Lambda final state

HistMacro_PID.C

Change canvas dimensions to better match PlotBrowser expectations.
Tweaks to plotting style to fit the information in the canvas: decrease margins, decrease text size, move text.
Zoom x axes for better fits.
Plot new histogram in empty pad.

Example from first 5 files of run 140517

<img width="1663" height="1085" alt="PID_517" src="https://github.com/user-attachments/assets/cc164109-ad5f-4cd1-af96-0dffca320449" />