### PR TITLE
Fix invalid matrix access bug in KINFITTER

### DIFF
--- a/src/libraries/KINFITTER/DKinFitter.cc
+++ b/src/libraries/KINFITTER/DKinFitter.cc
@@ -1588,7 +1588,7 @@ void DKinFitter::Calc_dF_Vertex_NotDecaying(size_t locFIndex, const DKinFitParti
       
       dF(locFIndex, 0) = locDeltaXDotH*locPDotH - locDeltaX.Dot(locMomentum)
 	+ PsqMinusPDotHsq*sinRhoS/locA;
-      dF(locFIndex, 1) = -locPCrossDeltaX.Dot(locH)
+      dF(locFIndex + 1, 0) = -locPCrossDeltaX.Dot(locH)
 	+ PsqMinusPDotHsq*OneMinusCosRhoS/locA;
 
       TVector3 dF0_dEta_VxVec = locMomentum 
@@ -1698,7 +1698,7 @@ void DKinFitter::Calc_dF_Vertex_NotDecaying(size_t locFIndex, const DKinFitParti
      
       dF(locFIndex, 0) = locDeltaXDotH*locPDotH - locDeltaX.Dot(locMomentum)
 	+ PsqMinusPDotHsq*sinRhoS/locA;
-      dF(locFIndex, 1) = -locPCrossDeltaX.Dot(locH)
+      dF(locFIndex + 1, 0) = -locPCrossDeltaX.Dot(locH)
 	+ PsqMinusPDotHsq*OneMinusCosRhoS/locA;
 
       TVector3 dF0_dEta_VxVec = locMomentum 


### PR DESCRIPTION
DKinFitter uses a TMatrixD column vector `dF` to store constraint equation values at each iteration.

Being a column vector, `dF` is [set to size `dNumF` x 1.](https://github.com/JeffersonLab/halld_recon/blob/a18515928455e9d7636ec3a4511bb78574651030/src/libraries/KINFITTER/DKinFitter.cc#L389)

If Paul Avery's equations are being used, `dF` is correctly updated by indexing into `dF(locFIndex, 0)` and [`dF(locFIndex + 1, 0)`](https://github.com/JeffersonLab/halld_recon/blob/a18515928455e9d7636ec3a4511bb78574651030/src/libraries/KINFITTER/DKinFitter.cc#L1563). However, if the non-asin fallback logic is used, the code accesses the first equation correctly `dF(locFIndex, 0)`, but then attempts to access a non-existent second column [`dF(locFIndex, 1)`](https://github.com/JeffersonLab/halld_recon/blob/a18515928455e9d7636ec3a4511bb78574651030/src/libraries/KINFITTER/DKinFitter.cc#L1591) when it should be accessing the `locFIndex + 1` row of column 0.

This results in `Error in <operator()>: Request column(1) outside matrix range of 0 - 1` being thrown for the subset of events that the asin equations can't be used for.

From my understanding, there's a chance this never affected fitting in production, depending on whether bounds-checking was turned off via the `NDEBUG` flag or if a very high `gErrorIgnoreLevel` is set. The TMatrix class stores the matrix as a 1D array, which it indexes into via `idx = (row * total_columns) + column` ([see ROOT source](https://github.com/root-project/root/blob/f4021887344af95349778bbb9b43d807d56ecc30/math/matrix/src/TMatrixT.cxx#L1182)). By lucky coincidence, `(locFIndex + 1, 0)` and `(locFIndex, 1)` both simplify to `locFIndex + 1`, so both accesses are technically identical. However, ROOT's `R__ASSERT` catches the semantically invalid access all the same and (to my understanding) throws a fatal error, which could possibly produce invalid fit results.

Testing this behavior is tricky. I identified this bug while working on a standalone KINFITTER separate from JANA/ReactionFilter, making these error messages very apparent. If this bug is being triggered in production, it should be detectable by grepping for the `Error in <operator()> ...` message in `hdroot` logs. My standalone fitting library should be published in the next few days, which will make it easier to test this bug (and in theory could be used to recalculate old fits and verify whether any problematic fit results were produced by this bug).
