### PR TITLE
TRD info small tweaks

### DIFF
--- a/src/libraries/TRD/DTRDSegment_factory.cc
+++ b/src/libraries/TRD/DTRDSegment_factory.cc
@@ -36,18 +36,22 @@ void DTRDSegment_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 		
 	if(!INSTALLED) return;
 
-  // get the geometry
-  DGeometry *geom = DEvent::GetDGeometry(event);
   // Get GEM geometry from xml (CCDB or private HDDS)
-  geom->GetGEMTRDz(dTRDz);
-  
+  auto runNumber = event->GetRunNumber();
+  auto app = event->GetJApplication();
+  auto geo_manager = app->GetService<DGeometryManager>();
+  auto dgeom = geo_manager->GetDGeometry(runNumber);
+  dgeom->GetGEMTRDz(dTRDz);
+
+  vector<double>xvec,yvec;
+  if(dgeom->GetGEMTRDxy_vec(xvec,yvec)){
+    dTRDx=xvec[0];
+    dTRDy=yvec[0];
+  }
+	
   return;
 }
 
-///
-/// DFDCSegment_factory::evnt():
-/// Routine where pseudopoints are combined into track segments
-///
 void DTRDSegment_factory::Process(const std::shared_ptr<const JEvent>& event)
 {
   vector<const DTRDPoint*> points;
@@ -57,9 +61,9 @@ void DTRDSegment_factory::Process(const std::shared_ptr<const JEvent>& event)
   vector<vector<const DTRDPoint *>>segments;
   FindSegments(points,segments);
   
-  for (unsigned int i=0;i<segments.size();i++){
+  for (unsigned int i=0; i<segments.size(); i++) {
     vector<const DTRDPoint *>segment=segments[i];
-    if (segment.size()>1){
+    if (segment.size()>1) {
       DTRDSegment *myTRDSegment = new DTRDSegment;
       double x=0,y=0,tx=0,ty=0;
       double var_x=0.,var_y=0.,var_tx=0.,var_ty=0.;
@@ -77,30 +81,25 @@ void DTRDSegment_factory::Process(const std::shared_ptr<const JEvent>& event)
       Insert(myTRDSegment);
     }
   }
-
   return;
-}  
+}
   
-void DTRDSegment_factory::FindSegments(const vector<const DTRDPoint *>&points,
-				      vector<vector<const DTRDPoint *>>&segments) const{
+void DTRDSegment_factory::FindSegments(const vector<const DTRDPoint *>&points, vector<vector<const DTRDPoint *>>&segments) const{
+  
   vector<const DTRDPoint *>mysegment_points;
-  for (unsigned int i=0;i<points.size();i++){
-    // Do some pattern recognition here
+  for (unsigned int i=0; i<points.size(); i++) {
+    // To-Do: some pattern recognition here
     mysegment_points.push_back(points[i]);
   }
   segments.push_back(mysegment_points);
-
 }
 
-
-void DTRDSegment_factory::FitLine(const vector<const DTRDPoint *>&points,
-				  double &x0,double &y0,double &tx,double &ty,
-				  double &var_x,double &var_y,double &var_tx,
-				  double &var_ty) const{
+void DTRDSegment_factory::FitLine(const vector<const DTRDPoint *>&points, double &x0, double &y0, double &tx, double &ty, double &var_x, double &var_y, double &var_tx, double &var_ty) const{
+  
   double varx=0.01,vary=0.01; // just a guess for now
-  double S1=0,S1z=0.,S1y=0.,S1zz=0.,S1zy=0.;
-  double S2=0,S2z=0.,S2x=0.,S2zz=0.,S2zx=0.; 
-  for (unsigned int i=0;i<points.size();i++){
+  double S1=0.,S1z=0.,S1y=0.,S1zz=0.,S1zy=0.;
+  double S2=0.,S2z=0.,S2x=0.,S2zz=0.,S2zx=0.; 
+  for (unsigned int i=0; i<points.size(); i++) {
     double x=points[i]->x;
     double y=points[i]->y;
     double z=points[i]->z-dTRDz;
@@ -118,17 +117,17 @@ void DTRDSegment_factory::FitLine(const vector<const DTRDPoint *>&points,
     S2x+=x*one_over_var2;
     S2zz+=z*z*one_over_var2;
     S2zx+=z*x*one_over_var2;
-   }
+  }
   
-   double D1=S1*S1zz-S1z*S1z;
-   y0=(S1zz*S1y-S1z*S1zy)/D1;
-   var_y=S1zz/D1;
-   ty=(S1*S1zy-S1z*S1y)/D1;
-   var_ty=S1/D1;
+  double D1=S1*S1zz-S1z*S1z;
+  y0=(S1zz*S1y-S1z*S1zy)/D1;
+  var_y=S1zz/D1;
+  ty=(S1*S1zy-S1z*S1y)/D1;
+  var_ty=S1/D1;
 
-   double D2=S2*S2zz-S2z*S2z;
-   x0=(S2zz*S2x-S2z*S2zx)/D2;
-   var_x=S2zz/D2;
-   tx=(S2*S2zx-S2z*S2x)/D2;
-   var_tx=S2/D2;
+  double D2=S2*S2zz-S2z*S2z;
+  x0=(S2zz*S2x-S2z*S2zx)/D2;
+  var_x=S2zz/D2;
+  tx=(S2*S2zx-S2z*S2x)/D2;
+  var_tx=S2/D2;
 }

--- a/src/libraries/TRD/DTRDSegment_factory.cc
+++ b/src/libraries/TRD/DTRDSegment_factory.cc
@@ -37,18 +37,8 @@ void DTRDSegment_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 	if(!INSTALLED) return;
 
   // Get GEM geometry from xml (CCDB or private HDDS)
-  auto runNumber = event->GetRunNumber();
-  auto app = event->GetJApplication();
-  auto geo_manager = app->GetService<DGeometryManager>();
-  auto dgeom = geo_manager->GetDGeometry(runNumber);
-  dgeom->GetGEMTRDz(dTRDz);
-
-  vector<double>xvec,yvec;
-  if(dgeom->GetGEMTRDxy_vec(xvec,yvec)){
-    dTRDx=xvec[0];
-    dTRDy=yvec[0];
-  }
-	
+  DGeometry *geom = DEvent::GetDGeometry(event);
+  geom->GetGEMTRDz(dTRDz);
   return;
 }
 

--- a/src/libraries/TRD/DTRDSegment_factory.h
+++ b/src/libraries/TRD/DTRDSegment_factory.h
@@ -34,7 +34,7 @@ private:
 	       double &x0,double &y0,double &tx,double &ty,
 	       double &var_x,double &var_y,double &var_tx,double &var_ty) const;
          
-  double dTRDz;
+  double dTRDx=0.,dTRDy=0., dTRDz=0.;
   int DEBUG_LEVEL;
   bool INSTALLED;
 };

--- a/src/libraries/TRD/DTRDSegment_factory_extrapolation.cc
+++ b/src/libraries/TRD/DTRDSegment_factory_extrapolation.cc
@@ -28,18 +28,8 @@ void DTRDSegment_factory_extrapolation::Init()
 void DTRDSegment_factory_extrapolation::BeginRun(const std::shared_ptr<const JEvent>& event) 
 { 
 	
-  auto runNumber = event->GetRunNumber();
-  auto app = event->GetJApplication();
-  auto geo_manager = app->GetService<DGeometryManager>();
-  auto dgeom = geo_manager->GetDGeometry(runNumber);
-  dgeom->GetGEMTRDz(dTRDz);
-  
-  vector<double>xvec,yvec;
-  if(dgeom->GetGEMTRDxy_vec(xvec,yvec)){
-    dTRDx=xvec[0];
-    dTRDy=yvec[0];
-  }
-  
+  DGeometry *geom = DEvent::GetDGeometry(event);
+  geom->GetGEMTRDz(dTRDz);
   return;
 }
 

--- a/src/libraries/TRD/DTRDSegment_factory_extrapolation.cc
+++ b/src/libraries/TRD/DTRDSegment_factory_extrapolation.cc
@@ -16,34 +16,38 @@ DTRDSegment_factory_extrapolation::~DTRDSegment_factory_extrapolation() {
 
 void DTRDSegment_factory_extrapolation::Init() 
 {
-  auto app = GetApplication();
-  
-  // DEBUG_LEVEL=0;
-  // app->SetDefaultParameter("TRD:DEBUG_LEVEL", DEBUG_LEVEL);
-
-  distToExtrp = 2.0; // cm  
-  app->SetDefaultParameter("TRD:DistToExtrp", distToExtrp, "Distance to extrapolation point (default: 2.0 cm)");
+  	auto app = GetApplication();
+  	
+   	DEBUG_LEVEL=0;
+   	app->SetDefaultParameter("TRD:DEBUG_LEVEL", DEBUG_LEVEL, "(default: 0 (Non-verbose))");
+	
+  	distToExtrp = 2.0; // cm  
+  	app->SetDefaultParameter("TRD:DistToExtrp", distToExtrp, "Distance to extrapolation point (default: 2.0 cm)");
 }
 
 void DTRDSegment_factory_extrapolation::BeginRun(const std::shared_ptr<const JEvent>& event) 
 { 
-  // get the geometry
-  DGeometry *geom = DEvent::GetDGeometry(event);
-  // Get GEM geometry from xml (CCDB or private HDDS)
-  geom->GetGEMTRDz(dTRDz);
+	
+  auto runNumber = event->GetRunNumber();
+  auto app = event->GetJApplication();
+  auto geo_manager = app->GetService<DGeometryManager>();
+  auto dgeom = geo_manager->GetDGeometry(runNumber);
+  dgeom->GetGEMTRDz(dTRDz);
+  
+  vector<double>xvec,yvec;
+  if(dgeom->GetGEMTRDxy_vec(xvec,yvec)){
+    dTRDx=xvec[0];
+    dTRDy=yvec[0];
+  }
   
   return;
 }
 
-///
-/// DFDCSegment_factory::evnt():
-/// Routine where pseudopoints are combined into track segments
-///
 void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEvent>& event)
 {
+  auto runNumber = event->GetRunNumber();
   vector<const DTRDPoint*> points;
   event->Get<DTRDPoint>(points);
-  
   vector<const DTrackTimeBased*> tracks; 
   event->Get(tracks);
 
@@ -51,7 +55,7 @@ void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEve
     return;
   }
 
-  // cout << "Number of tracks: " << tracks.size() << endl;
+  if (DEBUG_LEVEL>0) cout << "Number of tracks: " << tracks.size() << endl;
 
   vector<TrackPoint> trackPoints;
   vector<DTrackFitter::Extrapolation_t> trackExtrapolations;
@@ -62,15 +66,17 @@ void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEve
     if( track->PID()!=Electron && track->PID()!=Positron )  continue;
     //if( track->PID()!=PiPlus && track->PID()!=PiMinus )  continue;
   
-    //if (track==nullptr) continue; 
     vector<DTrackFitter::Extrapolation_t> extrapolations = track->extrapolations.at(SYS_TRD);
     if (extrapolations.size()==0) continue;
     DTrackFitter::Extrapolation_t extrapolation = extrapolations[0];
 	
-	//--This has changed with the 2026 run period!! Needs fixed!
-    if ((extrapolations[0].position.x() < -83.47 || extrapolations[0].position.x() > -11.47) || 
-        (extrapolations[0].position.y() < -68.6 || extrapolations[0].position.y() > -32.61)) continue;
-    
+	//Spring 2025 ECAL Commissioning Period
+    if (runNumber<140000 && ((extrapolations[0].position.x() < -83.47 || extrapolations[0].position.x() > -11.47) || 
+        (extrapolations[0].position.y() < -68.6 || extrapolations[0].position.y() > -32.61))) continue;
+	//Spring 2026 Low Energy Period
+    else if (runNumber>140000 && ((extrapolations[0].position.x() < -70.39 || extrapolations[0].position.x() > -10.39) ||  
+        (extrapolations[0].position.y() < -51.88 || extrapolations[0].position.y() > -25.48))) continue;
+	
     trackExtrapolations.push_back(extrapolation);
   }
 
@@ -81,23 +87,23 @@ void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEve
   FindSegmentPoints(trackPoints, trackExtrapolations, distToExtrp);
 
   vector<vector<const DTRDPoint *>> segments_TRDPoints;
-  for (unsigned int iSegmentPoint=0;iSegmentPoint<trackExtrapolations.size();iSegmentPoint++){
-    vector<const DTRDPoint *> segmentPoints;
-    for (unsigned int i=0;i<trackPoints.size();i++){
-      // cout << "TrackID: " << trackPoints[i].trackID << " x: " << trackPoints[i].point->x << " y: " << trackPoints[i].point->y << endl;
-      if (trackPoints[i].trackID==(int)iSegmentPoint){
-        segmentPoints.push_back(trackPoints[i].point);
-      }
+  for (unsigned int iSegmentPoint=0; iSegmentPoint<trackExtrapolations.size(); iSegmentPoint++) {
+	vector<const DTRDPoint *> segmentPoints;
+    for (unsigned int i=0; i<trackPoints.size(); i++) {
+      	if (DEBUG_LEVEL>0) cout << "TrackID: " << trackPoints[i].trackID << " x: " << trackPoints[i].point->x << " y: " << trackPoints[i].point->y << endl;
+      	if (trackPoints[i].trackID==(int)iSegmentPoint) {
+        	segmentPoints.push_back(trackPoints[i].point);
+      	}
     }
     segments_TRDPoints.push_back(segmentPoints);
   }
-
+	
   // If no segments were found, create a default segment with all points
   if (segments_TRDPoints.size()==0) segments_TRDPoints.push_back(points);
 
-  for (unsigned int i=0;i<segments_TRDPoints.size();i++){
+  for (unsigned int i=0; i<segments_TRDPoints.size(); i++) {
     DTRDSegment *myTRDSegment = new DTRDSegment;
-    double x=0,y=0,tx=0,ty=0;
+    double x=0.,y=0.,tx=0.,ty=0.;
     double var_x=0.,var_y=0.,var_tx=0.,var_ty=0.;
     FitLine(segments_TRDPoints[i],x,y,tx,ty,var_x,var_y,var_tx,var_ty);
     
@@ -116,7 +122,7 @@ void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEve
     myTRDSegment->NumHitsX = 0;
     myTRDSegment->NumHitsY = 0;
 
-    for (unsigned int j=0;j<segments_TRDPoints[i].size();j++){
+    for (unsigned int j=0; j<segments_TRDPoints[i].size(); j++) {
       const DTRDPoint *point = segments_TRDPoints[i][j];
       const vector<const DTRDStripCluster*> stripClusters = point->AssociatedStripClusters;
       for (const DTRDStripCluster* stripCluster: stripClusters) {
@@ -129,32 +135,25 @@ void DTRDSegment_factory_extrapolation::Process(const std::shared_ptr<const JEve
         }
       }
     }
-    
     Insert(myTRDSegment);  
   }
-
   return;
-}  
+}
   
-void DTRDSegment_factory_extrapolation::FindSegments(const vector<const DTRDPoint *>&points,
-				      vector<vector<const DTRDPoint *>>&segments) const{
+void DTRDSegment_factory_extrapolation::FindSegments(const vector<const DTRDPoint *>&points, vector<vector<const DTRDPoint *>>&segments) const{
   vector<const DTRDPoint *>mysegment_points;
-  for (unsigned int i=0;i<points.size();i++){
+  for (unsigned int i=0; i<points.size(); i++) {
     mysegment_points.push_back(points[i]);
   }
   segments.push_back(mysegment_points);
-
 }
 
-
-void DTRDSegment_factory_extrapolation::FitLine(const vector<const DTRDPoint *>&points,
-				  double &x0,double &y0,double &tx,double &ty,
-				  double &var_x,double &var_y,double &var_tx,
-				  double &var_ty) const{
+void DTRDSegment_factory_extrapolation::FitLine(const vector<const DTRDPoint *>&points, double &x0, double &y0, double &tx, double &ty, double &var_x, double &var_y, double &var_tx, double &var_ty) const{
+  
   double varx=0.01,vary=0.01; // just a guess for now
   double S1=0,S1z=0.,S1y=0.,S1zz=0.,S1zy=0.;
   double S2=0,S2z=0.,S2x=0.,S2zz=0.,S2zx=0.; 
-  for (unsigned int i=0;i<points.size();i++){
+  for (unsigned int i=0; i<points.size(); i++) {
     double x=points[i]->x;
     double y=points[i]->y;
     double z=points[i]->z-dTRDz;
@@ -172,24 +171,24 @@ void DTRDSegment_factory_extrapolation::FitLine(const vector<const DTRDPoint *>&
     S2x+=x*one_over_var2;
     S2zz+=z*z*one_over_var2;
     S2zx+=z*x*one_over_var2;
-   }
+  }
   
-   double D1=S1*S1zz-S1z*S1z;
-   y0=(S1zz*S1y-S1z*S1zy)/D1;
-   var_y=S1zz/D1;
-   ty=(S1*S1zy-S1z*S1y)/D1;
-   var_ty=S1/D1;
+  double D1=S1*S1zz-S1z*S1z;
+  y0=(S1zz*S1y-S1z*S1zy)/D1;
+  var_y=S1zz/D1;
+  ty=(S1*S1zy-S1z*S1y)/D1;
+  var_ty=S1/D1;
 
-   double D2=S2*S2zz-S2z*S2z;
-   x0=(S2zz*S2x-S2z*S2zx)/D2;
-   var_x=S2zz/D2;
-   tx=(S2*S2zx-S2z*S2x)/D2;
-   var_tx=S2/D2;
+  double D2=S2*S2zz-S2z*S2z;
+  x0=(S2zz*S2x-S2z*S2zx)/D2;
+  var_x=S2zz/D2;
+  tx=(S2*S2zx-S2z*S2x)/D2;
+  var_tx=S2/D2;
 }
 
 void DTRDSegment_factory_extrapolation::FindSegmentPoints(vector<TrackPoint> &trackPoints, vector<DTrackFitter::Extrapolation_t> &trackExtrapolations, double distToExtrp)
 {
-  for (long unsigned int itrack=0;itrack<trackExtrapolations.size();itrack++){
+  for (long unsigned int itrack=0; itrack<trackExtrapolations.size(); itrack++) {
     DTrackFitter::Extrapolation_t extrapolation = trackExtrapolations[itrack];
     double x0 = extrapolation.position.x();
     double y0 = extrapolation.position.y();
@@ -208,13 +207,14 @@ void DTRDSegment_factory_extrapolation::FindSegmentPoints(vector<TrackPoint> &tr
       double xpoint = point.point->x;
       double ypoint = point.point->y;
       double zpoint = point.point->z;
-
-      // cout << "Extrapolation: " << x0 << ", " << y0 << ", " << z0 << endl;
-      // cout << "Point: " << xpoint << ", " << ypoint << ", " << zpoint << endl;
-      
-      // cout << "Distance to extrapolation: " << dist(xpoint, ypoint, zpoint) << ", "
-      //      << "Distance to extrapolation threshold: " << distToExtrp << endl;
-
+	  
+	  if (DEBUG_LEVEL>0) {
+        cout << "Extrapolation: " << x0 << ", " << y0 << ", " << z0 << endl;
+        cout << "Point: " << xpoint << ", " << ypoint << ", " << zpoint << endl;
+        
+        cout << "Distance to extrapolation: " << dist(xpoint, ypoint, zpoint) << ", "
+            << "Distance to extrapolation threshold: " << distToExtrp << endl;
+	  }
       if (dist(xpoint, ypoint, zpoint) < distToExtrp) {
         point.trackID = itrack;
         point.tagged = true;

--- a/src/libraries/TRD/DTRDSegment_factory_extrapolation.h
+++ b/src/libraries/TRD/DTRDSegment_factory_extrapolation.h
@@ -43,7 +43,7 @@ private:
 	       double &x0,double &y0,double &tx,double &ty,
 	       double &var_x,double &var_y,double &var_tx,double &var_ty) const;
   void FindSegmentPoints(vector<TrackPoint> &trackPoints, vector<DTrackFitter::Extrapolation_t> &trackExtrapolations, double distToExtrp);
-  double dTRDz;
+  double dTRDx=0.,dTRDy=0., dTRDz=0.;
   double distToExtrp;
   int DEBUG_LEVEL;
 };

--- a/src/libraries/TRD/DTRDStripCluster_factory.cc
+++ b/src/libraries/TRD/DTRDStripCluster_factory.cc
@@ -54,8 +54,8 @@ void DTRDStripCluster_factory::Init()
 {
 	auto app = GetApplication();
 
-	MINIMUM_HITS_FOR_CLUSTERING = 10;
-    app->SetDefaultParameter("TRDCLUSTER:MINIMUM_HITS_FOR_CLUSTERING",MINIMUM_HITS_FOR_CLUSTERING);
+	MINIMUM_HITS_FOR_CLUSTERING = 6;
+    app->SetDefaultParameter("TRDCLUSTER:MINIMUM_HITS_FOR_CLUSTERING",MINIMUM_HITS_FOR_CLUSTERING,"Minimum total Hits for a cluster (default: 6.0)");
 
 	CLUSTERING_THRESHOLD = 1.2;
     app->SetDefaultParameter("TRDCLUSTER:CLUSTERING_THRESHOLD",CLUSTERING_THRESHOLD);
@@ -172,10 +172,13 @@ void DTRDStripCluster_factory::Process(const std::shared_ptr<const JEvent>& even
 				new_cluster->t_max = p_max_q.x;
 
 				double pos_width = GetClusterPosWidth(points, iClusterId);
-				if (pos_width > max_pos_width) {
+				if (pos_width > max_pos_width || pos_width==0) {
 					continue;
 				}
 				double time_width = GetClusterTimeWidth(points, iClusterId);
+				if (time_width==0) {
+                    continue;
+                }
 				new_cluster->pos_width = pos_width;
 				new_cluster->time_width = time_width;
 

--- a/src/libraries/TRD/DTRDStripCluster_factory.h
+++ b/src/libraries/TRD/DTRDStripCluster_factory.h
@@ -50,6 +50,7 @@ class DTRDStripCluster_factory:public JFactoryT<DTRDStripCluster> {
 		int GetClusterNHits(vector<Point> &points, int clusterId);
 		float GetTotalClusterEnergy(vector<Point> &points, int clusterId);
 		pair<double,double> GetClusterCentroid(vector<Point> &points, int clusterId);
+		
 		Point GetMaxQPoint(vector<Point> &points, int clusterId){
 			Point p_max = points[0];
 			for (auto &point : points) {
@@ -59,6 +60,7 @@ class DTRDStripCluster_factory:public JFactoryT<DTRDStripCluster> {
 			}
 			return p_max;
 		}
+		
 		double GetClusterPosWidth(vector<Point> &points, int clusterId) {
 			double min_y = 1e9;
 			double max_y = -1e9;
@@ -70,6 +72,7 @@ class DTRDStripCluster_factory:public JFactoryT<DTRDStripCluster> {
 			}
 			return max_y - min_y;
 		}
+		
 		double GetClusterTimeWidth(vector<Point> &points, int clusterId) {
 			double min_x = 1e9;
 			double max_x = -1e9;

--- a/src/plugins/monitoring/TRDTrack/JEventProcessor_TRDTrack.cc
+++ b/src/plugins/monitoring/TRDTrack/JEventProcessor_TRDTrack.cc
@@ -260,7 +260,7 @@ void JEventProcessor_TRDTrack::Init()
 	//efficiency array plots
 	trdDir->cd();
 	gDirectory->mkdir("Time-Based_Efficiency")->cd();
-
+	
 	hDL1Time=new TH1D("DL1Time","DL1Trigger Time; 4*(Peak Time) [s]",160,0.,160.);
 	hPSPairTime=new TH1D("PSPairTime","PS Identified Pair Trigger Time; 4*(Peak Time) [ns]",400,0.,400.);
 	
@@ -340,18 +340,18 @@ void JEventProcessor_TRDTrack::Init()
 	for (unsigned int i=0; i<=100; i++) {
 		if (PlotEfficienciesOverTime) {
 	    hSeenHitsSingleX_fine[i] = new TH1F(Form("seenHitsSingleX_fine_%i", i+1),
-                                    Form("Single Hit X Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),75,-85.,-10.);
+                                    Form("Single Hit X Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
 		hSeenHitsSingleY_fine[i] = new TH1F(Form("seenHitsSingleY_fine_%i", i+1),
-                                    Form("Single Hit Y Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),40,-70.,-30.);
+                                    Form("Single Hit Y Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
 		}
 		hSeenPointsSingleX_fine[i] = new TH1F(Form("seenPointsSingleX_fine_%i", i+1),
-                                    Form("Single Point X Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),75,-85.,-10.);
+                                    Form("Single Point X Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
     	hSeenPointsSingleY_fine[i] = new TH1F(Form("seenPointsSingleY_fine_%i", i+1),
-                                    Form("Single Point Y Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),40,-70.,-30.);
+                                    Form("Single Point Y Display for Track Extraps Seen in TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
 		hExtrapsX_fine[i] = new TH1F(Form("ExtrapsX_fine_%i", i+1),
-                                    Form("Track X Extrapolations that Pass Through TRD (%i - %i)",i*20000,(i+1)*20000),75,-85.,-10.);
+                                    Form("Track X Extrapolations that Pass Through TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
     	hExtrapsY_fine[i] = new TH1F(Form("ExtrapsY_fine_%i", i+1),
-                                    Form("Track X Extrapolations that Pass Through TRD (%i - %i)",i*20000,(i+1)*20000),40,-70.,-30.);
+                                    Form("Track X Extrapolations that Pass Through TRD (%i - %i)",i*20000,(i+1)*20000),90,-90.,0.);
 		if (PlotEfficienciesOverTime) {
 		hHit_PulseHeight_X[i] = new TH1F(Form("Hit_PulseHeight_X%i", i+1),
                                     Form("GEMTRD X Plane Pulse Height (%i - %i); Pulse Height [fADC Units]",i*20000,(i+1)*20000),350,0.,3500.);
@@ -409,7 +409,7 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 	NEvents++;
   	lockService->RootFillLock(this); //ACQUIRE ROOT FILL LOCK
 	
-	int numTracks=0, extrapInTRD=0, goodFCALTrack=0, extrapInTRD_good=0, extrapInTRD_goodEl=0, extrapInTRD_goodPi=0, singleSeenExtrap=0,  singleSeenExtrapHit=0, singleSeenExtrap_el=0, extrapInTRD_el=0, singleSeenExtrap_pi=0, extrapInTRD_pi=0, extrapToFCAL=0, extrapToFCAL_el=0, extrapToFCAL_pi=0, hasMinMom=0, hasMinMom_el=0, hasMinMom_pi=0, matchedToTOF=0, matchedToTOF_el=0, matchedToTOF_pi=0;
+	int numTracks=0, extrapInTRD=0, goodFCALTrack=0, extrapInTRD_good=0, extrapInTRD_goodEl=0, extrapInTRD_goodPi=0, singleSeenExtrap=0,  singleSeenExtrapHit=0, singleSeenExtrap_el=0, extrapInTRD_el=0, singleSeenExtrap_pi=0, extrapInTRD_pi=0, extrapToFCAL=0, extrapToFCAL_el=0, extrapToFCAL_pi=0, hasMinMom=0, hasMinMom_el=0, hasMinMom_pi=0, matchedToTOF=0, matchedToTOF_el=0, matchedToTOF_pi=0, extrapToECAL=0, extrapToTOF=0, extrapToTRD=0, extrapToECAL_el=0, extrapToTOF_el=0, extrapToTRD_el=0, extrapToECAL_pi=0, extrapToTOF_pi=0, extrapToTRD_pi=0;
 	
 	// ======================================================
 	//				Efficiency vs Time Graphs
@@ -534,7 +534,8 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 		double extrap_FCALEnergy = 0.;
 		bool extrap_existsAtTRD = false;
         bool extrap_existsAtFCAL = false;
-        //bool extrap_existsAtTOF = false;
+		bool extrap_existsAtECAL = false;
+        bool extrap_existsAtTOF = false;
         bool hyp_matchedToFCAL = false;
         bool hyp_matchedToTOF = false;
 		bool hasMinMomentum = false;
@@ -555,14 +556,22 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
             const DTrackTimeBased *time_track=best_hyp->Get_TrackTimeBased();
             vector<DTrackFitter::Extrapolation_t> trd_extrapolations = time_track->extrapolations.at(SYS_TRD);
             vector<DTrackFitter::Extrapolation_t> fcal_extrapolations = time_track->extrapolations.at(SYS_FCAL);
+			vector<DTrackFitter::Extrapolation_t> ecal_extrapolations = time_track->extrapolations.at(SYS_ECAL);
+			vector<DTrackFitter::Extrapolation_t> tof_extrapolations = time_track->extrapolations.at(SYS_TOF);
 
             if (fcal_extrapolations.size()>0) extrap_existsAtFCAL = true;
+			if (ecal_extrapolations.size()>0) extrap_existsAtECAL = true;
+			if (tof_extrapolations.size()>0) extrap_existsAtTOF = true;
             if (trd_extrapolations.size()>0) extrap_existsAtTRD = true;
             if (fcalparms!=nullptr) hyp_matchedToFCAL = true;
             if (tofparms!=nullptr) { hyp_matchedToTOF = true; matchedToTOF++; }
 			
-			if (extrap_existsAtFCAL && extrap_existsAtTRD) {
-				extrapToFCAL++;
+			if (extrap_existsAtTRD) {
+				extrapToTRD++;
+				if (extrap_existsAtECAL) extrapToECAL++;
+				if (extrap_existsAtTOF) extrapToTOF++;
+				if (extrap_existsAtFCAL) extrapToFCAL++;
+				if (extrap_existsAtFCAL || extrap_existsAtECAL) {
 				if (runNumber<140000) { //Spring 2025 ECAL Commissioning Period
                     if ((trd_extrapolations[0].position.x() > -83.47) && (trd_extrapolations[0].position.x() < -11.47) && (trd_extrapolations[0].position.y() > -68.6) && (trd_extrapolations[0].position.y() < -32.61)) {
                         passedThroughTRD = true;
@@ -731,7 +740,8 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 					} //end PlotEfficienciesOverTime
                 } //--END passedThroughTRD
                 } //--END hasMinMomentum & hyp_matchedToTOF
-            } //--END if extrap_existsAtFCAL && extrap_existsAtTRD
+            } //--END if extrap_existsAt FCAL || ECAL
+			} //--END if extrap_existsAtTRD
 		} //--END using Best track hypothesis
 		
 		//--END MISC. MONITORING FOLDER ------------------------------------------------
@@ -748,7 +758,8 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
         extrap_FCALEnergy = 0.;
         extrap_existsAtTRD = false;
         extrap_existsAtFCAL = false;
-        //extrap_existsAtTOF = false;
+		extrap_existsAtECAL = false;
+        extrap_existsAtTOF = false;
         hyp_matchedToFCAL = false;
         hyp_matchedToTOF = false;
         hasMinMomentum = false;
@@ -762,13 +773,21 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 			const DTrackTimeBased *time_track=hyp_el->Get_TrackTimeBased();
 			vector<DTrackFitter::Extrapolation_t> trd_extrapolations = time_track->extrapolations.at(SYS_TRD);
         	vector<DTrackFitter::Extrapolation_t> fcal_extrapolations = time_track->extrapolations.at(SYS_FCAL);
+			vector<DTrackFitter::Extrapolation_t> ecal_extrapolations = time_track->extrapolations.at(SYS_ECAL);
+			vector<DTrackFitter::Extrapolation_t> tof_extrapolations = time_track->extrapolations.at(SYS_TOF);
 			if (fcal_extrapolations.size()>0) extrap_existsAtFCAL = true;
+			if (tof_extrapolations.size()>0) extrap_existsAtTOF = true;
+			if (ecal_extrapolations.size()>0) extrap_existsAtECAL = true;
             if (trd_extrapolations.size()>0) extrap_existsAtTRD = true;
             if (fcalparms!=nullptr) hyp_matchedToFCAL = true;
             if (tofparms!=nullptr) { hyp_matchedToTOF = true; matchedToTOF_el++; }
 			
-			if (extrap_existsAtFCAL && extrap_existsAtTRD) {
-				extrapToFCAL_el++;
+			if (extrap_existsAtTRD) {
+				extrapToTRD_el++;
+				if (extrap_existsAtFCAL) extrapToFCAL_el++;
+				if (extrap_existsAtECAL) extrapToECAL_el++;
+				if (extrap_existsAtTOF) extrapToTOF_el++;
+				if (extrap_existsAtFCAL || extrap_existsAtECAL) {
 				if (runNumber<140000) { //Spring 2025 ECAL Commissioning Period
                     if ((trd_extrapolations[0].position.x() > -83.47) && (trd_extrapolations[0].position.x() < -11.47) && (trd_extrapolations[0].position.y() > -68.6) && (trd_extrapolations[0].position.y() < -32.61)) {
                         passedThroughTRD = true;
@@ -798,7 +817,8 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 						extrapSeenByFCAL = true;
 					}
 				} //--END hyp_matchedToFCAL
-			} //--END if extrap_existsAtFCAL && extrap_existsAtTRD
+				} //--END if extrap_existsAt FCAL || ECAL
+			} //--END if extrap_existsAtTRD
 				
 			if (hasMinMomentum && hyp_matchedToTOF && passedThroughTRD) {
 					extrapInTRD_goodEl++;
@@ -910,10 +930,10 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 		isEnergetic = false;
 		extrapSeenByFCAL = false;
         extrap_FCALEnergy = 0.;
-		
+		extrap_existsAtECAL = false;
 		extrap_existsAtTRD = false;
 		extrap_existsAtFCAL = false;
-		//extrap_existsAtTOF = false;
+		extrap_existsAtTOF = false;
 		hyp_matchedToFCAL = false;
 		hyp_matchedToTOF = false;
 		hasMinMomentum = false;
@@ -925,14 +945,21 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 			const DTrackTimeBased *time_track=hyp_pi->Get_TrackTimeBased();
             vector<DTrackFitter::Extrapolation_t> trd_extrapolations = time_track->extrapolations.at(SYS_TRD);
 			vector<DTrackFitter::Extrapolation_t> fcal_extrapolations = time_track->extrapolations.at(SYS_FCAL);
-			
+			vector<DTrackFitter::Extrapolation_t> ecal_extrapolations = time_track->extrapolations.at(SYS_ECAL);
+			vector<DTrackFitter::Extrapolation_t> tof_extrapolations = time_track->extrapolations.at(SYS_TOF);
 			if (fcal_extrapolations.size()>0) extrap_existsAtFCAL = true;
 			if (trd_extrapolations.size()>0) extrap_existsAtTRD = true;
+			if (ecal_extrapolations.size()>0) extrap_existsAtECAL = true;
+			if (tof_extrapolations.size()>0) extrap_existsAtTOF = true;
 			if (fcalparms!=nullptr) hyp_matchedToFCAL = true;
 			if (tofparms!=nullptr) { hyp_matchedToTOF = true; matchedToTOF_pi++; }
 			
-			if (extrap_existsAtFCAL && extrap_existsAtTRD) {
-				extrapToFCAL_pi++;
+			if (extrap_existsAtTRD) {
+				extrapToTRD_pi++;
+				if (extrap_existsAtFCAL) extrapToFCAL_pi++;
+				if (extrap_existsAtECAL) extrapToECAL_pi++;
+				if (extrap_existsAtTOF) extrapToTOF_pi++;
+				if (extrap_existsAtFCAL || extrap_existsAtECAL) {
 				if (runNumber<140000) { //Spring 2025 ECAL Commisioning Period
 					if ((trd_extrapolations[0].position.x() > -83.47) && (trd_extrapolations[0].position.x() < -11.47) && (trd_extrapolations[0].position.y() > -68.6) && (trd_extrapolations[0].position.y() < -32.61)) {
                     	passedThroughTRD = true;
@@ -962,7 +989,8 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
                 		isEnergetic = true;
                 	}
 				} //--END hyp_matchedToFCAL
-			} //--END if extrap_existsAtFCAL && extrap_existsAtTRD
+				} //--END if extrap_existsAt FCAL || ECAL
+			} //--END if extrap_existsAtTRD
 				
 			if (hasMinMomentum && hyp_matchedToTOF && passedThroughTRD) {
 					extrapInTRD_goodPi++;
@@ -1072,8 +1100,11 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 	if (numTracks>0) { Count("nTrack"); Count_el("nTrack"); Count_pi("nTrack"); }
 	
 	//--Best Hyp
-	if (goodFCALTrack>0) Count("goodTrackThruFCAL");
-	if (extrapToFCAL>0) Count("extrapToFCAL");
+	//if (goodFCALTrack>0) Count("goodTrackThruFCAL");
+	if (extrapToTRD>0) Count("extrapToTRDz");
+	if (extrapToTOF>0) Count("extrapToTOFz");
+	if (extrapToFCAL>0) Count("extrapToFCALz");
+	if (extrapToECAL>0) Count("extrapToECALz");
 	if (matchedToTOF>0) Count("matchedToTOF");
 	if (hasMinMom>0) Count("minMomOK");
 	if (extrapInTRD>0) Count("ExtrapThruTRD");
@@ -1082,7 +1113,10 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 	//if (singleSeenExtrapHit>0) Count("GoodExtrapSeenByTRD_Hits");
 	
 	//--e+/e- Hyp
-	if (extrapToFCAL_el>0) Count_el("extrapToFCAL");
+	if (extrapToTRD_el>0) Count_el("extrapToTRDz");
+    if (extrapToTOF_el>0) Count_el("extrapToTOFz");
+    if (extrapToFCAL_el>0) Count_el("extrapToFCALz");
+	if (extrapToECAL_el>0) Count_el("extrapToECALz");
 	if (matchedToTOF_el>0) Count_el("matchedToTOF");
 	if (hasMinMom_el>0) Count_el("minMomOK");
 	if (extrapInTRD_el>0) Count_el("ExtrapThruTRD");
@@ -1090,7 +1124,10 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 	if (singleSeenExtrap_el>0) Count_el("GoodExtrapSeenByTRD");
 	
 	//--pi+/pi- Hyp
-	if (extrapToFCAL_pi>0) Count_pi("extrapToFCAL");
+	if (extrapToTRD_pi>0) Count_pi("extrapToTRDz");
+    if (extrapToTOF_pi>0) Count_pi("extrapToTOFz");
+    if (extrapToFCAL_pi>0) Count_pi("extrapToFCALz");
+	if (extrapToECAL_pi>0) Count_pi("extrapToECALz");
 	if (matchedToTOF_pi>0) Count_pi("matchedToTOF");
 	if (hasMinMom_pi>0) Count_pi("minMomOK");
 	if (extrapInTRD_pi>0) Count_pi("ExtrapThruTRD");

--- a/src/plugins/monitoring/TRDTrack/JEventProcessor_TRDTrack.cc
+++ b/src/plugins/monitoring/TRDTrack/JEventProcessor_TRDTrack.cc
@@ -112,14 +112,14 @@ void JEventProcessor_TRDTrack::Init()
 	hExtrapXPointDiff=new TH1D("ExtrapXPointDiff","Track Extrap Difference from TRD Point_Hits, X Plane;x(Extrap) - x(TRD Point_Hit) [cm]",250,-5.5,5.5);
     hExtrapYPointDiff=new TH1D("ExtrapYPointDiff","Track Extrap Difference from TRD Point_Hits, Y Plane;y(Extrap) - y(TRD Point_Hit) [cm]",250,-5.5,5.5);
     hExtrapXYPointDiff=new TH2D("ExtrapXYPointDiff","2D Track Extrap Difference from TRD Point_Hits;x(Extrap) - x(TRD Point_Hit) [cm];y(Extrap) - y(TRD Point_Hit) [cm]",250,-5.5,5.5,250,-5.5,5.5);
-	hExtrapXPointDiffvsTime=new TH2D("ExtrapXPointDiffvsTime","Track Extrap Difference from TRD Point_Hits vs Drift Time, X Plane;x(Extrap) - x(TRD Point_Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,400,0.,200.*8);
-    hExtrapYPointDiffvsTime=new TH2D("ExtrapYPointDiffvsTime","Track Extrap Difference from TRD Point_Hits vs Drift Time, Y Plane;y(Extrap) - y(TRD Point_Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,400,0.,200.*8);
-	hExtrapXPointDiffvsX=new TH2D("ExtrapXPointDiffvsX","Track Extrap Difference from TRD Point_Hits vs Position, X Plane;x(Extrap) - x(TRD Point_Hit) [cm]; x(TRD Point_Hit) [cm]",250,-5.5,5.5,750,-85.,-10.);
-    hExtrapYPointDiffvsY=new TH2D("ExtrapYPointDiffvsY","Track Extrap Difference from TRD Point_Hits vs Position, Y Plane;y(Extrap) - y(TRD Point_Hit);y(TRD Point_Hit) [cm]",250,-5.5,5.5,400,-70.,-30.);
+	hExtrapXPointDiffvsTime=new TH2D("ExtrapXPointDiffvsTime","Track Extrap Difference from TRD Point_Hits vs Drift Time, X Plane;x(Extrap) - x(TRD Point_Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
+    hExtrapYPointDiffvsTime=new TH2D("ExtrapYPointDiffvsTime","Track Extrap Difference from TRD Point_Hits vs Drift Time, Y Plane;y(Extrap) - y(TRD Point_Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
+	hExtrapXPointDiffvsX=new TH2D("ExtrapXPointDiffvsX","Track Extrap Difference from TRD Point_Hits vs Position, X Plane;x(Extrap) - x(TRD Point_Hit) [cm]; x(TRD Point_Hit) [cm]",250,-5.5,5.5,450,-90.,0.);
+    hExtrapYPointDiffvsY=new TH2D("ExtrapYPointDiffvsY","Track Extrap Difference from TRD Point_Hits vs Position, Y Plane;y(Extrap) - y(TRD Point_Hit);y(TRD Point_Hit) [cm]",250,-5.5,5.5,450,-90.,0.);
 	
 		
 	//--Plots for TRD Hit objects
-	hExtrapXHitDiffvsTime=new TH2D("ExtrapXHitDiffvsTime","Track Extrap Difference from TRD Hits vs Drift Time, X Plane;x(Extrap) - x(TRD Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,400,0.,200.*8);
+	hExtrapXHitDiffvsTime=new TH2D("ExtrapXHitDiffvsTime","Track Extrap Difference from TRD Hits vs Drift Time, X Plane;x(Extrap) - x(TRD Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
 	hExtrapYHitDiffvsTime=new TH2D("ExtrapYHitDiffvsTime","Track Extrap Difference from TRD Hits vs Drift Time, Y Plane;y(Extrap) - y(TRD Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
 	hResXHitDiffvsTime=new TH2D("ResXHitDiffvsTime","Track Extrap X Difference from TRD Hits vs Drift Time;x(Extrap) - x(TRD Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
     hResYHitDiffvsTime=new TH2D("ResYHitDiffvsTime","Track Extrap Y Difference from TRD Hits vs Drift Time;y(Extrap) - y(TRD Hit) [cm]; 8*(Peak Time) [ns]",250,-5.5,5.5,200,0.,200.*8);
@@ -142,9 +142,9 @@ void JEventProcessor_TRDTrack::Init()
 	hFCALTimeCorr=new TH2D("FCALTimeCorr","Time Corr. Between FCAL Shower Time and FCAL_Track_Match Flight Time;Time (FCAL Shower) [ns];Time (Track Flight Time) [ns]",210,-6.,99.,210,-6.,99.);
 	hFCALExtrapE_TRD=new TH1D("FCALExtrapE_TRD","FCAL Shower Energy with Track Extrap through TRD;E [GeV]",240,-0.1,11.9);
     hFCALExtrapEP_TRD=new TH1D("FCALExtrapEP_TRD","FCAL E/P with Track Extrap through TRD;(FCAL Shower E) / (Track Extrap P_Mag)",300,-0.1,2.9);
-    hFCALExtrapEPvsP_TRD=new TH2D("FCALExtrapEPvsP_TRD","FCAL E/P vs P with Track Extrap through TRD;(FCAL Shower E) / (Track Extrap P_Mag); (Track Extrap P_Mag) [GeV/c]",300,-0.1,2.9,240,-0.1,11.9);
+    hFCALExtrapEPvsP_TRD=new TH2D("FCALExtrapEPvsP_TRD","FCAL E/P vs P with Track Extrap through TRD;(FCAL Shower E) / (Track Extrap P_Mag); (Track Extrap P_Mag) [GeV/c]",150,-0.1,2.9,120,-0.1,11.9);
 	hFCALExtrapTheta_TRD=new TH1D("FCALExtrapTheta_TRD","FCAL Track Extrap Angle at FCAL Z Plane (with Extrap through TRD);Theta [Degrees]",350,-0.1,34.9);
-    hFCALExtrapThetavsP_TRD=new TH2D("FCALExtrapThetavsP_TRD","FCAL Track Extrap Angle (at FCAL Z Plane) vs P (with Extrap through TRD);Theta [Degrees];(Track Extrap P_Mag) [GeV/c]",350,-0.1,34.9,480,-0.1,11.9);
+    hFCALExtrapThetavsP_TRD=new TH2D("FCALExtrapThetavsP_TRD","FCAL Track Extrap Angle (at FCAL Z Plane) vs P (with Extrap through TRD);Theta [Degrees];(Track Extrap P_Mag) [GeV/c]",175,-0.1,34.9,120,-0.1,11.9);
 	
 	//--Plots for Efficiency estimates
 	hnumPointsSeen=new TH1D("numPointsSeen","N Point_Hits within +/-1.5cm of a Track Extrap that Passed Through TRD; # Point_Hits",35,-0.5,34.5);
@@ -523,6 +523,7 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 	hTrackMult->Fill(tracks.size());
   	for (unsigned int j=0; j<tracks.size(); j++) {
 		
+		numTracks++;
 		bool passedThroughTRD = false;
 		bool TrackMatch = false;
 		bool hitTrackMatchX = false;
@@ -695,9 +696,9 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
                                 hHit_DriftTime_X[NEvents/20000]->Fill(hit->t);
                             }
                         }
-                        if (hit->plane == 1) {
+                        if (hit->plane == 1 && passedThroughTRD) {
                             hExtrapXHitDiffvsTime->Fill(trd_extrapolations[0].position.x() - newX, hit->t);
-                            if (trd_extrapolations[0].position.x() > -10.) hResXHitDiffvsTime->Fill(trd_extrapolations[0].position.x() - newX, hit->t);
+                            hResXHitDiffvsTime->Fill(trd_extrapolations[0].position.x() - newX, hit->t);
                             hResXHitDiff_Corrected->Fill((trd_extrapolations[0].position.x() - newX)-((hit->t - 473.197)/165.83));
                         }
                         if (hit->plane == 2 && abs(trd_extrapolations[0].position.y() - newY) <= 1.8) { //if within 1.8cm
@@ -714,9 +715,9 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
                                 hHit_DriftTime_Y[NEvents/20000]->Fill(hit->t);
                             }
                         }
-                        if (hit->plane == 2) {
+                        if (hit->plane == 2 && passedThroughTRD) {
                             hExtrapYHitDiffvsTime->Fill(trd_extrapolations[0].position.y() - newY, hit->t);
-                            if (trd_extrapolations[0].position.y() > -55.) hResYHitDiffvsTime->Fill(trd_extrapolations[0].position.y() - newY, hit->t);
+                            hResYHitDiffvsTime->Fill(trd_extrapolations[0].position.y() - newY, hit->t);
                             hResYHitDiff_Corrected->Fill((trd_extrapolations[0].position.y() - newY)-((hit->t - 558.016)/439.767));
                         }
                     } //--END Hits Loop
@@ -1070,25 +1071,30 @@ void JEventProcessor_TRDTrack::Process(const std::shared_ptr<const JEvent> &even
 
 	if (numTracks>0) { Count("nTrack"); Count_el("nTrack"); Count_pi("nTrack"); }
 	
+	//--Best Hyp
 	if (goodFCALTrack>0) Count("goodTrackThruFCAL");
 	if (extrapToFCAL>0) Count("extrapToFCAL");
-	if (extrapToFCAL_el>0) Count_el("extrapToFCAL");
-	if (extrapToFCAL_pi>0) Count_pi("extrapToFCAL");
-	if (hasMinMom>0) Count("minMomOK");
-	if (hasMinMom>0) Count_el("minMomOK");
-	if (hasMinMom>0) Count_pi("minMomOK");
 	if (matchedToTOF>0) Count("matchedToTOF");
-	if (matchedToTOF_el>0) Count_el("matchedToTOF");
-	if (matchedToTOF_pi>0) Count_pi("matchedToTOF");
+	if (hasMinMom>0) Count("minMomOK");
 	if (extrapInTRD>0) Count("ExtrapThruTRD");
 	if (extrapInTRD_good>0) Count("GoodExtrapThruTRD");
-	if (extrapInTRD_goodEl>0) Count_el("GoodExtrapThruTRD");
-	if (extrapInTRD_goodPi>0) Count_pi("GoodExtrapThruTRD");
 	if (singleSeenExtrap>0) Count("GoodExtrapSeenByTRD");
-	if (singleSeenExtrapHit>0) Count("GoodExtrapSeenByTRD_Hits");
+	//if (singleSeenExtrapHit>0) Count("GoodExtrapSeenByTRD_Hits");
+	
+	//--e+/e- Hyp
+	if (extrapToFCAL_el>0) Count_el("extrapToFCAL");
+	if (matchedToTOF_el>0) Count_el("matchedToTOF");
+	if (hasMinMom_el>0) Count_el("minMomOK");
 	if (extrapInTRD_el>0) Count_el("ExtrapThruTRD");
+	if (extrapInTRD_goodEl>0) Count_el("GoodExtrapThruTRD");
 	if (singleSeenExtrap_el>0) Count_el("GoodExtrapSeenByTRD");
+	
+	//--pi+/pi- Hyp
+	if (extrapToFCAL_pi>0) Count_pi("extrapToFCAL");
+	if (matchedToTOF_pi>0) Count_pi("matchedToTOF");
+	if (hasMinMom_pi>0) Count_pi("minMomOK");
 	if (extrapInTRD_pi>0) Count_pi("ExtrapThruTRD");
+	if (extrapInTRD_goodPi>0) Count_pi("GoodExtrapThruTRD");
     if (singleSeenExtrap_pi>0) Count_pi("GoodExtrapSeenByTRD");
 	
   	lockService->RootFillUnLock(this); //RELEASE ROOT FILL LOCK

--- a/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.cc
+++ b/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.cc
@@ -220,11 +220,11 @@ void JEventProcessor_TRD_online::Init() {
 		hHit_NPKs[i] = new TH1I(Form("Hit_NPKs_Plane%d",i),Form("TRD Plane %d fADC Peak Multiplicity for Stored Hits;Raw Peaks;Events",i),15,0.5,0.5+15);
 		hHit_Occupancy[i] = new TH1D(Form("Hit_Occupancy_Plane%d",i),Form("TRD Plane %d Hit Occupancy;Strip;Calibrated Hits / Counter",i),NTRDstrips,0.5,0.5+NTRDstrips);
 		hHit_Time[i] = new TH1D(Form("Hit_Time_Plane%d",i),Form("TRD Plane %d Time;8*(Peak Time) [ns];Calibrated Hits / 2 ns",i),225,0.0,1800.0);
-		hHit_PulseHeight[i] = new TH1D(Form("Hit_PulseHeight_Plane%d",i),Form("TRD Plane %d Pulse Height;(Pulse Peak - Ped)[fADC units];Calibrated Hits / 1 unit",i),350,0.0,3500.0);
+		hHit_PulseHeight[i] = new TH1D(Form("Hit_PulseHeight_Plane%d",i),Form("TRD Plane %d Pulse Height;(Pulse Peak - Ped)[fADC units];Calibrated Hits / 1 unit",i),175,0.0,3500.0);
         hHit_TimeVsStrip[i] = new TH2D(Form("Hit_TimeVsStrip_Plane%d",i),Form("TRD Plane %d Time vs. Strip;Strip;8*(Peak Time) [ns]",i),NTRDstrips,0.5,0.5+NTRDstrips,225,0.0,1800.0);
-		hHit_StripVsdE[i] = new TH2D(Form("Hit_StripVsdE_Plane%d",i),Form("TRD Plane %d Hit Charge vs. Strip;Strip;dE [q]",i),NTRDstrips,0.5,0.5+NTRDstrips,350,0.,3500.0);
-		hHit_TimeVsdE[i] = new TH2D(Form("Hit_TimeVsdE_Plane%d",i),Form("TRD Plane %d Hit Charge vs. Time;dE [q];8*(Peak Time) [ns]",i),350,0.,3500.,225,0.0,1800.0);
-		hHit_TimeVsdE_Max[i] = new TH2D(Form("Hit_TimeVsdE_Max_Plane%d",i),Form("TRD Plane %d Max Hit Charge vs. Time;8*(Peak Time) [ns];Max dE [q]",i),225,0.,1800.,350,0.,3500.);
+		hHit_StripVsdE[i] = new TH2D(Form("Hit_StripVsdE_Plane%d",i),Form("TRD Plane %d Hit Charge vs. Strip;Strip;dE [q]",i),NTRDstrips,0.5,0.5+NTRDstrips,175,0.,3500.0);
+		hHit_TimeVsdE[i] = new TH2D(Form("Hit_TimeVsdE_Plane%d",i),Form("TRD Plane %d Hit Charge vs. Time;dE [q];8*(Peak Time) [ns]",i),175,0.,3500.,250,0.0,2000.0);
+		hHit_TimeVsdE_Max[i] = new TH2D(Form("Hit_TimeVsdE_Max_Plane%d",i),Form("TRD Plane %d Max Hit Charge vs. Time;8*(Peak Time) [ns];Max dE [q]",i),250,0.,2000.,175,0.,3500.);
 		
 	}
     
@@ -233,48 +233,47 @@ void JEventProcessor_TRD_online::Init() {
 	// point based on hits
 	gDirectory->mkdir("Point_Hit")->cd();
     hPointH_NHits = new TH1I("PointH_NHits","TRD Calibrated Point_Hit Multiplicity;Calibrated Points;Events",100,0.5,0.5+100);
-    hPointH_XYT = new TH3D("PointH_XYT","TRD 3D Point_Hits;X [cm];Y [cm];8*(Peak Time) [ns]",900,-90.,0.,900,-90.,0.,225,0.,1800.);
-    hPointH_Time = new TH1D("PointH_Time","TRD Point_Hit Time;8*(Peak Time) [ns]",225,0.,1800.);
+    hPointH_XYT = new TH3D("PointH_XYT","TRD 3D Point_Hits;X [cm];Y [cm];8*(Peak Time) [ns]",450,-90.,0.,450,-90.,0.,250,0.,2000.);
+    hPointH_Time = new TH1D("PointH_Time","TRD Point_Hit Time;8*(Peak Time) [ns]",250,0.,2000.);
 	hPointH_TimeDiff = new TH1D("PointH_TimeDiff","TRD Point_Hit xTime - yTime; xTime - yTime [ns]",55,-22.,22.);
-    hPointH_dE = new TH1D("PointH_dE","TRD Point_Hit Charge;Average dE [q]",350,0.,3500.);
+    hPointH_dE = new TH1D("PointH_dE","TRD Point_Hit Charge;Average dE [q]",175,0.,3500.);
     hPointH_dEDiff = new TH1D("PointH_dEDiff","TRD Point_Hit Charge X,Y Weighted Diff.;(dE_x - dE_y)/(dE_x + dE_y)",100,-1.,1.);
     hPointH_dERatio = new TH1D("PointH_dERatio","TRD Point_Hit dE_x / dE_y;(dE_x / dE_y)",100,-0.,6.);
-    hPointH_dE_XY = new TH2D("PointH_dE_XY","TRD Point_Hit Charge Corr. in X,Y;X Strip dE [q]; Y Strip dE [q]",350,0.,3500.,350,0.,3500.);
-    hPointH_TimeVsdEX= new TH2D("PointH_TimeVsdEX","TRD Point_Hit Charge of X in Time;X Strip dE [q];8*(Peak Time) [ns]",350,0.,3500.,225,0.,1800.);
-    hPointH_TimeVsdEY= new TH2D("PointH_TimeVsdEY","TRD Point_Hit Charge of Y in Time;Y Strip dE [q];8*(Peak Time) [ns]",350,0.,3500.,225,0.,1800.);
-	hPointH_TimeVsdE_Max= new TH2D("PointH_TimeVsdE_Max","TRD Max Point_Hit Charge in Time;8*(Peak Time) [ns];Max dE [q]",225,0.,1800.,350,0.,3500.);
-	hPointH_TimeVsdE_el_Max= new TH2D("PointH_TimeVsdE_el_Max","TRD Max Point_Hit Charge in Time (El Cut Passed);8*(Peak Time) [ns];Max dE [q]",225,0.,1800.,350,0.,3500.);
-	hPointH_TimeVsdE_pi_Max= new TH2D("PointH_TimeVsdE_pi_Max","TRD Max Point_Hit Charge in Time (El Cut Failed);8*(Peak Time) [ns];Max dE [q]",225,0.,1800.,350,0.,3500.);
-    hPointH_OccupancyX = new TH1D("PointH_OccupancyX","TRD Point_Hit X;X [cm]",900,-90.,0.);
-    hPointH_OccupancyY = new TH1D("PointH_OccupancyY","TRD Point_Hit Y;Y [cm]",900,-90,0.);
-    hPointH_XYDisplay = new TH2D("PointH_XYDisplay","TRD XY 2D Point_Hit Display ;X [cm];Y [cm]",900,-90.,0.,900,-90.,0.);
-    hPointH_ZXDisplay = new TH2D("PointH_ZXDisplay","TRD XZ 2D Point_Hit Display;X [cm];Z [cm]",900,-90.,0.,480,527.5,533.5);
-    hPointH_ZYDisplay = new TH2D("PointH_ZYDisplay","TRD YZ 2D Point_Hit Display;Y [cm];Z [cm]",900,-90.,0.,480,527.5,533.5);
-    hPointH_TimeVsX= new TH2D("PointH_TimeVsX","TRD Point_Hit X in Time;X [cm];8*(Peak Time) [ns]",900,-90.,0.,225,0.,1800.);
-    hPointH_TimeVsY= new TH2D("PointH_TimeVsY","TRD Point_Hit Y in Time;Y [cm];8*(Peak Time) [ns]",900,-90.,0.,225,0.,1800.);
+    hPointH_dE_XY = new TH2D("PointH_dE_XY","TRD Point_Hit Charge Corr. in X,Y;X Strip dE [q]; Y Strip dE [q]",175,0.,3500.,175,0.,3500.);
+    hPointH_TimeVsdEX= new TH2D("PointH_TimeVsdEX","TRD Point_Hit Charge of X in Time;X Strip dE [q];8*(Peak Time) [ns]",175,0.,3500.,250,0.,2000.);
+    hPointH_TimeVsdEY= new TH2D("PointH_TimeVsdEY","TRD Point_Hit Charge of Y in Time;Y Strip dE [q];8*(Peak Time) [ns]",175,0.,3500.,250,0.,2000.);
+	hPointH_TimeVsdE_Max= new TH2D("PointH_TimeVsdE_Max","TRD Max Point_Hit Charge in Time;8*(Peak Time) [ns];Max dE [q]",250,0.,2000.,175,0.,3500.);
+	hPointH_TimeVsdE_el_Max= new TH2D("PointH_TimeVsdE_el_Max","TRD Max Point_Hit Charge in Time (El Cut Passed);8*(Peak Time) [ns];Max dE [q]",250,0.,2000.,175,0.,3500.);
+	hPointH_TimeVsdE_pi_Max= new TH2D("PointH_TimeVsdE_pi_Max","TRD Max Point_Hit Charge in Time (El Cut Failed);8*(Peak Time) [ns];Max dE [q]",250,0.,2000.,175,0.,3500.);
+    hPointH_OccupancyX = new TH1D("PointH_OccupancyX","TRD Point_Hit X;X [cm]",450,-90.,0.);
+    hPointH_OccupancyY = new TH1D("PointH_OccupancyY","TRD Point_Hit Y;Y [cm]",450,-90,0.);
+    hPointH_XYDisplay = new TH2D("PointH_XYDisplay","TRD XY 2D Point_Hit Display ;X [cm];Y [cm]",450,-90.,0.,450,-90.,0.);
+    hPointH_ZXDisplay = new TH2D("PointH_ZXDisplay","TRD XZ 2D Point_Hit Display;X [cm];Z [cm]",450,-90.,0.,480,527.5,533.5);
+    hPointH_ZYDisplay = new TH2D("PointH_ZYDisplay","TRD YZ 2D Point_Hit Display;Y [cm];Z [cm]",450,-90.,0.,480,527.5,533.5);
+    hPointH_TimeVsX= new TH2D("PointH_TimeVsX","TRD Point_Hit X in Time;X [cm];8*(Peak Time) [ns]",450,-90.,0.,250,0.,2000.);
+    hPointH_TimeVsY= new TH2D("PointH_TimeVsY","TRD Point_Hit Y in Time;Y [cm];8*(Peak Time) [ns]",450,-90.,0.,250,0.,2000.);
 	
-	trdDir->cd();
 	// point based on clusters
     trdDir->cd();
     gDirectory->mkdir("Point")->cd();
     hPoint_NHits = new TH1I("Point_NHits","TRD Calibrated Point Multiplicity;Calibrated Points;Events",100,0.5,0.5+100);
-    hPoint_XYT = new TH3D("Point_XYT","TRD 3D Points;X [cm];Y [cm];8*(Peak Time) [ns]",900,-90.,0.,900,-90.,0.,225,0.,1800.);
+    hPoint_XYT = new TH3D("Point_XYT","TRD 3D Points;X [cm];Y [cm];8*(Peak Time) [ns]",225,-90.,0.,225,-90.,0.,250,0.,2000.);
     hPoint_Time = new TH1D("Point_Time","TRD Point Time;8*(Peak Time) [ns]; ",225,0.,1800.);
     hPoint_TimeDiff = new TH1D("Point_TimeDiff","TRD Point xTime - yTime; xTime - yTime [ns]",55,-22.,22.);
-	hPoint_dE = new TH1D("Point_dE","TRD Point Charge;Average dE [q]; ",350,0.,3500.);
+	hPoint_dE = new TH1D("Point_dE","TRD Point Charge;Average dE [q]; ",250,0.,10000.);
     hPoint_dEDiff = new TH1D("Point_dEDiff","TRD Point Charge X,Y Weighted Diff.;(dE_x - dE_y)/(dE_x + dE_y); ",100,-1.,1.);
     hPoint_dERatio = new TH1D("Point_dERatio","TRD Point dE_x / dE_y;(dE_x / dE_y); ",100,-0.,6.);
-    hPoint_dE_XY = new TH2D("Point_dE_XY","TRD Point Charge Corr. in X,Y;X Strip dE [q]; Y Strip dE [q]",350,0.,3500.,350,0.,3500.);
-    hPoint_TimeVsdEX= new TH2D("Point_TimeVsdEX","TRD Point Charge of X in Time;X Strip dE [q];8*(Peak Time) [ns]",350,0.,3500.,225,0.,1800.);
-    hPoint_TimeVsdEY= new TH2D("Point_TimeVsdEY","TRD Point Charge of Y in Time;Y Strip dE [q];8*(Peak Time) [ns]",350,0.,3500.,225,0.,1800.);
-	hPoint_TimeVsdE_Max= new TH2D("Point_TimeVsdE_Max","TRD Max Point Charge in Time;8*(Peak Time) [ns];Max dE [q]",225,0.,1800,500,0.,10000.);
-    hPoint_OccupancyX = new TH1D("Point_OccupancyX","TRD Point X;X [cm]; ",900,-90.,0.);
-    hPoint_OccupancyY = new TH1D("Point_OccupancyY","TRD Point Y;Y [cm]; ",900,-90.,0.);
-    hPoint_XYDisplay = new TH2D("Point_XYDisplay","TRD XY 2D Point Display ;X [cm];Y [cm]",900,-90.,0.,900,-90.,0.);
-    hPoint_ZXDisplay = new TH2D("Point_ZXDisplay","TRD XZ 2D Point Display;X [cm];Z [cm]",900,-90.,0.,480,527.5,533.5);
-    hPoint_ZYDisplay = new TH2D("Point_ZYDisplay","TRD YZ 2D Point Display;Y [cm];Z [cm]",900,-90.,0.,480,527.5,533.5);
-    hPoint_TimeVsX= new TH2D("Point_TimeVsX","TRD Point X in Time;X [cm];8*(Peak Time) [ns]",900,-90.,0.,225,0.,1800.);
-    hPoint_TimeVsY= new TH2D("Point_TimeVsY","TRD Point Y in Time;Y [cm];8*(Peak Time) [ns]",900,-90.,0.,225,0.,1800.);
+    hPoint_dE_XY = new TH2D("Point_dE_XY","TRD Point Charge Corr. in X,Y;X Strip dE [q]; Y Strip dE [q]",175,0.,3500.,175,0.,3500.);
+    hPoint_TimeVsdEX= new TH2D("Point_TimeVsdEX","TRD Point Charge of X in Time;X Strip dE [q];8*(Peak Time) [ns]",250,0.,10000.,250,0.,2000.);
+    hPoint_TimeVsdEY= new TH2D("Point_TimeVsdEY","TRD Point Charge of Y in Time;Y Strip dE [q];8*(Peak Time) [ns]",250,0.,10000.,250,0.,2000.);
+	hPoint_TimeVsdE_Max= new TH2D("Point_TimeVsdE_Max","TRD Max Point Charge in Time;8*(Peak Time) [ns];Max dE [q]",250,0.,2000,250,0.,10000.);
+    hPoint_OccupancyX = new TH1D("Point_OccupancyX","TRD Point X;X [cm]; ",450,-90.,0.);
+    hPoint_OccupancyY = new TH1D("Point_OccupancyY","TRD Point Y;Y [cm]; ",450,-90.,0.);
+    hPoint_XYDisplay = new TH2D("Point_XYDisplay","TRD XY 2D Point Display ;X [cm];Y [cm]",450,-90.,0.,450,-90.,0.);
+    hPoint_ZXDisplay = new TH2D("Point_ZXDisplay","TRD XZ 2D Point Display;X [cm];Z [cm]",450,-90.,0.,480,527.5,533.5);
+    hPoint_ZYDisplay = new TH2D("Point_ZYDisplay","TRD YZ 2D Point Display;Y [cm];Z [cm]",450,-90.,0.,480,527.5,533.5);
+    hPoint_TimeVsX= new TH2D("Point_TimeVsX","TRD Point X in Time;X [cm];8*(Peak Time) [ns]",450,-90.,0.,250,0.,2000.);
+    hPoint_TimeVsY= new TH2D("Point_TimeVsY","TRD Point Y in Time;Y [cm];8*(Peak Time) [ns]",450,-90.,0.,250,0.,2000.);
 
     trdDir->cd();
 	// cluster-level hists
@@ -294,10 +293,10 @@ void JEventProcessor_TRD_online::Init() {
         else
 	{    NTRDstrips = NTRD_ystrips;}
 			
-		hClusterHits_TimeVsPos[i] = new TH2D(Form("ClusterHits_TimeVsPos_Plane%d",i),Form("TRD Plane %d Cluster Hits Time vs. Position;8*(Peak Time) [ns];Position [cm]",i),250,0,2000.0,100,-50,50);
-        hCluster_TimeVsPos[i] = new TH2D(Form("Cluster_TimeVsPos_Plane%d",i),Form("TRD Plane %d Cluster Time vs. Position;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,100,-50,50);	
-		hClusterHits_TimeVsStrip[i] = new TH2D(Form("ClusterHits_TimeVsStrip_Plane%d",i),Form("TRD Plane %d Cluster Hits Time vs. Strip;8*(Peak Time) [ns];Strip",i),225,0,1800.0,NTRDstrips,0.5,0.5+NTRDstrips);
-		hCluster_TimeVsdE_Max[i] = new TH2D(Form("Cluster_TimeVsdE_Max_Plane%d",i),Form("TRD Plane %d Max Cluster Charge in Time;8*(Peak Time) [ns];Max dE [q]",i),150,0.,1200.,800,0.,10000.);
+		hClusterHits_TimeVsPos[i] = new TH2D(Form("ClusterHits_TimeVsPos_Plane%d",i),Form("TRD Cluster-Associated Hits Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0,2000.0,450,-90.,0.);
+        hCluster_TimeVsPos[i] = new TH2D(Form("Cluster_TimeVsPos_Plane%d",i),Form("TRD Cluster Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,450,-90.,0.);
+		hClusterHits_TimeVsStrip[i] = new TH2D(Form("ClusterHits_TimeVsStrip_Plane%d",i),Form("TRD Cluster-Associated Hits Time vs. Strip, Plane %d;8*(Peak Time) [ns];Strip Number",i),250,0,2000.0,NTRDstrips,0.5,0.5+NTRDstrips);
+		hCluster_TimeVsdE_Max[i] = new TH2D(Form("Cluster_TimeVsdE_Max_Plane%d",i),Form("TRD Max Cluster Charge vs. Time, Plane %d;8*(Peak Time) [ns];Cluster Max dE [q]",i),250,0.,2000.,175,0.,10000.);
 		
     }
     
@@ -311,26 +310,28 @@ void JEventProcessor_TRD_online::Init() {
 	
 	// event-by-event histos
 	trdDir->cd();
-    gDirectory->mkdir("EventMonitor")->cd();
-    // histograms for each plane
-    for(int i=0; i<NTRDplanes; i++) {
-        int NTRDstrips = 0.;
-        if(i==0)
-    {    NTRDstrips = NTRD_xstrips;}
-        else
-    {    NTRDstrips = NTRD_ystrips;}
+    TDirectory *eventDir = gDirectory->mkdir("EventMonitor");
+	eventDir->cd();
+	for(int j=0; j<NEventsMonitor; j++) {
+		//sub-folder for each event
+		 gDirectory->mkdir(Form("Event_%d",j))->cd();
 		
-        for(int j=0; j<NEventsMonitor; j++) {
-            hClusterHits_TimeVsPosEvent[i][j] = new TH2D(Form("ClusterHits_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Plane %d Cluster Hits Time vs. Pos;8*(Peak Time) [ns];Position [cm]",i),250,0,2000.0,100,-50.,50.);
-            hCluster_TimeVsPosEvent[i][j] = new TH2D(Form("Cluster_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Plane %d Cluster Time vs. Pos;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,100,-50.,50.);
-            hDigiHit_TimeVsStripEvent[i][j] = new TH2D(Form("DigiHit_TimeVsStrip_Plane%d_Event%d",i,j),Form("TRD Plane %d DigiHit Time vs. Strip;8*(Peak Time) [ns];Strip",i),250,0.,2000.0,NTRDstrips,-0.5,-0.5+NTRDstrips);
-            hPoint_TimeVsPosEvent[i][j] = new TH2D(Form("Point_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Plane %d Point Time vs. Pos;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,100,-50.,50.);
-			hPointH_TimeVsPosEvent[i][j] = new TH2D(Form("PointH_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Plane %d Point_Hit Time vs. Pos;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,100,-50.,50.);
-			
-			hPoint_ZVsX_Event[j] = new TH2D(Form("Point_ZVsX_Event%d",i),"TRD Point X vs. Z;Z [cm];X [cm]",100,528,533,900,-90,0);
-        	hPoint_ZVsY_Event[j] = new TH2D(Form("Point_ZVsY_Event%d",i),"TRD Point Y vs. Z;Z [cm];Y [cm]",100,528,533,900,-90,0);
-        }
-    }
+		// histograms for each plane
+    	for(int i=0; i<NTRDplanes; i++) {
+        	int NTRDstrips = 0.;
+        	if(i==0) { NTRDstrips = NTRD_xstrips; }
+        	else { NTRDstrips = NTRD_ystrips; }
+            hDigiHit_TimeVsStripEvent[i][j] = new TH2D(Form("DigiHit_TimeVsStrip_Plane%d_Event%d",i,j),Form("TRD DigiHit Time vs. Strip, Plane %d;8*(Peak Time) [ns];Strip Number",i),250,0.,2000.0,NTRDstrips,-0.5,-0.5+NTRDstrips);
+			hClusterHits_TimeVsPosEvent[i][j] = new TH2D(Form("ClusterHits_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Cluster-Associated Hits Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0,2000.0,450,-90.,0.);
+            hCluster_TimeVsPosEvent[i][j] = new TH2D(Form("Cluster_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Cluster Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,450,-90.,0.);
+            hPointH_TimeVsPosEvent[i][j] = new TH2D(Form("PointH_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Point_Hit Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,450,-90.,0.);
+			hPoint_TimeVsPosEvent[i][j] = new TH2D(Form("Point_TimeVsPos_Plane%d_Event%d",i,j),Form("TRD Point Time vs. Pos, Plane %d;8*(Peak Time) [ns];Position [cm]",i),250,0.,2000.0,450,-90.,0.);
+		}
+		hPoint_ZVsX_Event[j] = new TH2D(Form("Point_ZVsX_Event%d",j),"TRD Point X vs. Z (GlueX Coordinates);Z [cm];X [cm]",100,528,533,450,-90,0);
+        hPoint_ZVsY_Event[j] = new TH2D(Form("Point_ZVsY_Event%d",j),"TRD Point Y vs. Z (GlueX Coordinates);Z [cm];Y [cm]",100,528,533,450,-90,0);
+		
+		eventDir->cd();
+	}
 	
 	if (useNizarTrackMatching) {
 	//const double dTRDpos[2] = {-47.4695,-59.0315}; // TRD offsets from geometry //This needs fixed!!! since it has changed by run period. Needs somehow pulled from databases instead of set here
@@ -366,9 +367,12 @@ void JEventProcessor_TRD_online::BeginRun(const std::shared_ptr<const JEvent>& e
     // This is called whenever the run number changes
 	
     const DGeometry *geom = GetDGeometry(event);
-	
-	vector<double> z_trd;
-    geom->GetTRDZ(z_trd);
+	geom->GetGEMTRDz(dTRDz);
+  	vector<double>xvec,yvec;
+  	if(geom->GetGEMTRDxy_vec(xvec,yvec)){
+    	dTRDx=xvec[0];
+    	dTRDy=yvec[0];
+  	}
 }
 
 
@@ -486,7 +490,7 @@ void JEventProcessor_TRD_online::Process(const std::shared_ptr<const JEvent>& ev
         int plane = cluster->plane-1;
         double pos = 1000.;
         if (plane == 0) {
-			pos = cluster->pos.x();
+			pos = cluster->pos.x() + dTRDx;
 			if (cluster->q_tot > cluster_maxQ_x) {
                 cluster_maxQ_x = cluster->q_tot;
                 cluster_maxTime_x = cluster->t_avg;
@@ -494,7 +498,7 @@ void JEventProcessor_TRD_online::Process(const std::shared_ptr<const JEvent>& ev
 			NCluster_X++;
 		}
         else if (plane == 1) {
-			pos = cluster->pos.y();
+			pos = cluster->pos.y() + dTRDy;
 			if (cluster->q_tot > cluster_maxQ_y) {
                 cluster_maxQ_y = cluster->q_tot;
                 cluster_maxTime_y = cluster->t_avg;
@@ -511,8 +515,8 @@ void JEventProcessor_TRD_online::Process(const std::shared_ptr<const JEvent>& ev
     for (const auto& hit : hits) {
         int plane = hit->plane-1;
 		double pos = 1000.;
-		if (plane==0) pos = -1.*STRIP_PITCH*double(NTRD_xstrips/2-hit->strip+0.5);
-		else if (plane==1) pos = STRIP_PITCH*double(NTRD_ystrips/2-hit->strip+0.5);
+		if (plane==0) pos = -1.*STRIP_PITCH*double(NTRD_xstrips/2-hit->strip+0.5) + dTRDx;
+		else if (plane==1) pos = STRIP_PITCH*double(NTRD_ystrips/2-hit->strip+0.5) + dTRDy;
 		
         hClusterHits_TimeVsStrip[plane]->Fill(hit->t, hit->strip);
 		if (pos<1000.) hClusterHits_TimeVsPos[plane]->Fill(hit->t, pos);
@@ -610,16 +614,16 @@ void JEventProcessor_TRD_online::Process(const std::shared_ptr<const JEvent>& ev
     	for (const auto& cluster : clusters) {
     		int plane = cluster->plane-1;
         	double pos = 1000.;
-        	if (plane == 0) pos = cluster->pos.x();
-        	else pos = cluster->pos.y();
+        	if (plane == 0) pos = cluster->pos.x() + dTRDx;
+        	else pos = cluster->pos.y() + dTRDy;
         	if (pos<1000.) hCluster_TimeVsPosEvent[plane][eventClusterCount]->Fill(cluster->t_avg, pos);
     	}
 
         for (const auto& hit : hits) {
             int plane = hit->plane-1;
             double pos = 1000.;
-            if (plane == 0) pos = -1*STRIP_PITCH*double(NTRD_xstrips/2-hit->strip+0.5);
-            else pos = STRIP_PITCH*double(NTRD_ystrips/2-hit->strip+0.5);
+            if (plane == 0) pos = -1*STRIP_PITCH*double(NTRD_xstrips/2-hit->strip+0.5) + dTRDx;
+            else pos = STRIP_PITCH*double(NTRD_ystrips/2-hit->strip+0.5) + dTRDy;
             if (pos<1000.) hClusterHits_TimeVsPosEvent[plane][eventClusterCount]->Fill(hit->t, pos);
         }
 		

--- a/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.h
+++ b/src/plugins/monitoring/TRD_online/JEventProcessor_TRD_online.h
@@ -16,7 +16,8 @@ private:
     void Process(const std::shared_ptr<const JEvent>& event) override;
     void EndRun() override;
     void Finish() override;
-
+	double dTRDx=0.,dTRDy=0.,dTRDz=0.;
+	
     std::shared_ptr<JLockService> lockService;
 
     //int wirePlaneOffset;


### PR DESCRIPTION
Small changes - initialized some variables in the TRD libraries that weren't before, added some verboseness functionality to the DEBUG flags in the libraries, fixed some geometry offsets in the TRDTrack plugin and added more hCount increments, and improved histogram organization for event-by-event monitoring in the TRD_online plugin. Note that we found a bug in the Clustering library that causes the Cluster position in Y to be shifted from the Cluster-associated-Hit information in Y (though the X information between the two is consistent). This bug is visible in these event-by-event monitoring plots. and must have been there for some time. It remains included now - it will need found and fixed later.