### PR TITLE
Tracking update jun26

### DIFF
--- a/src/libraries/PID/DDetectorMatches_factory.cc
+++ b/src/libraries/PID/DDetectorMatches_factory.cc
@@ -23,6 +23,10 @@ void DDetectorMatches_factory::Init()
   MATCH_TO_DIRC = true;
   app->SetDefaultParameter("PID:MATCH_TO_DIRC",MATCH_TO_DIRC);
 
+  FAST_TRACKING_MODE=false;
+  app->SetDefaultParameter("TRKFIT:FAST_TRACKING_MODE",FAST_TRACKING_MODE);
+  if (FAST_TRACKING_MODE) MATCH_TO_DIRC=false;
+
   MATCH_TO_TRD = false;
   app->SetDefaultParameter("PID:MATCH_TO_TRD",MATCH_TO_TRD);
 }

--- a/src/libraries/PID/DDetectorMatches_factory.h
+++ b/src/libraries/PID/DDetectorMatches_factory.h
@@ -70,6 +70,7 @@ class DDetectorMatches_factory : public JFactoryT<DDetectorMatches>
   void MatchToTrack(const DParticleID* locParticleID, const DECALShower* locECALShower, const vector<const DTrackTimeBased*>& locTrackTimeBasedVector, DDetectorMatches* locDetectorMatches) const;
 
   bool ENABLE_FCAL_SINGLE_HITS, ENABLE_ECAL_SINGLE_HITS,MATCH_TO_DIRC, MATCH_TO_TRD;
+  bool FAST_TRACKING_MODE;
 };
 
 #endif // _DDetectorMatches_factory_

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -3555,7 +3555,7 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
 				double& StartTime) const{
   if (ECALShowers.size()==0) return false;
   if (extrapolations.size()==0) return false;
-  double StartTimeGuess=StartTime;
+
   DVector3 trackpos=extrapolations[0].position;
   double d_min=1e6;
   unsigned int best_ecal_match=0;
@@ -3567,13 +3567,13 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       best_ecal_match=i;
     }
   }
-  StartTime=ECALShowers[best_ecal_match]->t-extrapolations[0].t;
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   double p=extrapolations[0].momentum.Mag();
   double cut=ECAL_CUT_PAR1+ECAL_CUT_PAR2/p;
-  if (d_min<cut) return true;
-
+  if (d_min<cut){
+    StartTime=ECALShowers[best_ecal_match]->t-extrapolations[0].t;
+    return true;
+  }
   return false;
 }
 
@@ -3582,7 +3582,7 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
 				double& StartTime) const{
   if (ECALHits.size()==0) return false;
   if (extrapolations.size()==0) return false;
-  double StartTimeGuess=StartTime;
+
   DVector3 trackpos=extrapolations[0].position;
   double d_min=1e6;
   unsigned int best_ecal_match=0;
@@ -3594,11 +3594,10 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       best_ecal_match=i;
     }
   }
-  StartTime=ECALHits[best_ecal_match]->t-extrapolations[0].t;
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   // Cut is 1*sqrt(2.) + small amount to account for track position resolution
   if (d_min<1.5){
+    StartTime=ECALHits[best_ecal_match]->t-extrapolations[0].t;
     return true;
   }
 
@@ -3610,7 +3609,7 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
 				double& StartTime) const{
   if (FCALShowers.size()==0) return false;
   if (extrapolations.size()==0) return false;
-  double StartTimeGuess=StartTime;
+
   DVector3 trackpos=extrapolations[0].position;
   double d_min=1e6;
   unsigned int best_fcal_match=0;
@@ -3622,13 +3621,13 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       best_fcal_match=i;
     }
   }
-  StartTime=FCALShowers[best_fcal_match]->getTime()-extrapolations[0].t;
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   double p=extrapolations[0].momentum.Mag();
   double cut=FCAL_CUT_PAR1+FCAL_CUT_PAR2/p;
-  if (d_min<cut) return true;
-
+  if (d_min<cut){
+    StartTime=FCALShowers[best_fcal_match]->getTime()-extrapolations[0].t;
+    return true;
+  }
   return false;
 }  
 
@@ -3637,7 +3636,7 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
 				double& StartTime) const{
   if (FCALHits.size()==0) return false;
   if (extrapolations.size()==0) return false;
-  double StartTimeGuess=StartTime;
+
   DVector3 trackpos=extrapolations[0].position;
   double d_min=1e6;
   unsigned int best_fcal_match=0;
@@ -3649,14 +3648,13 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       best_fcal_match=i;
     }
   }
-  StartTime=FCALHits[best_fcal_match]->t-extrapolations[0].t;
-  // apply timewalk correction
-  StartTime-=dFCALTimewalkPar1*exp(-dFCALTimewalkPar2*FCALHits[best_fcal_match]->E); 
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   double p=extrapolations[0].momentum.Mag();
   double cut=FCAL_CUT_PAR1+FCAL_CUT_PAR2/p;
   if (d_min<cut){
+    StartTime=FCALHits[best_fcal_match]->t-extrapolations[0].t;
+    // apply timewalk correction
+    StartTime-=dFCALTimewalkPar1*exp(-dFCALTimewalkPar2*FCALHits[best_fcal_match]->E); 
     return true;
   }
 
@@ -3670,7 +3668,6 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
   if (SCHits.size()==0) return false;
   if (extrapolations.size()==0) return false;
 
-  double StartTimeGuess=StartTime;
   DVector3 trackpos=extrapolations[0].position;
   double z=trackpos.z();
   double dphi_min=1000.;
@@ -3689,13 +3686,13 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       }
     }
   }	   
-  double sc_corrected_time=Get_CorrectedHitTime(SCHits[best_sc_match],trackpos);
-  StartTime=sc_corrected_time-extrapolations[0].t;
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   double sc_dphi_cut = dSCCutPars_WireBased[0] + dSCCutPars_WireBased[1]*exp(dSCCutPars_WireBased[2]*(trackpos.Z() - dSCCutPars_WireBased[3]));
-  if (fabs(180.*dphi_min/M_PI) <= sc_dphi_cut) return true;
-  
+  if (fabs(180.*dphi_min/M_PI) <= sc_dphi_cut){
+     double sc_corrected_time=Get_CorrectedHitTime(SCHits[best_sc_match],trackpos);
+     StartTime=sc_corrected_time-extrapolations[0].t;
+    return true;
+  }
   return false;
 } 
 
@@ -3705,7 +3702,6 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
   if (TOFPoints.size()==0) return false;
   if (extrapolations.size()==0) return false;
 
-  double StartTimeGuess=StartTime;
   DVector3 trackpos=extrapolations[0].position;
   // Set up cuts
   double locMatchCut_2D = exp(-1.0*TOF_CUT_PAR1*extrapolations[0].momentum.Mag() + TOF_CUT_PAR2) + TOF_CUT_PAR3;
@@ -3725,29 +3721,29 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
       best_tof_match=i;
     }
   }
-  // Get the start time and check that it is consistent with an initial guess
-  // to within some OUT_OF_TIME_CUT
-  StartTime=Get_CorrectedHitTime(TOFPoints[best_tof_match],trackpos)
-    -extrapolations[0].t;
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
 
   // Apply matching criteria
+  bool got_match=false;
   if (TOFPoints[best_tof_match]->Is_XPositionWellDefined()==false){
     if (dy_at_min<locMatchCut_1D){
-      return true;
+      got_match=true;
     }
   }
   else if (TOFPoints[best_tof_match]->Is_YPositionWellDefined()==false){ 
     if (dx_at_min<locMatchCut_1D){
-      return true;
+      got_match=true;
     }
   }
   else{
     if (sqrt(d2_min)<locMatchCut_2D){
-      return true;
+      got_match=true;
     }
   }
-
+  if (got_match){
+    StartTime=Get_CorrectedHitTime(TOFPoints[best_tof_match],trackpos)
+      -extrapolations[0].t;
+    return true;
+  }
   return false;
 }
 
@@ -3757,7 +3753,7 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
   if (locBCALShowers.size()==0) return false; 
   if (extrapolations.size()==0) return false;
 
-  double StartTimeGuess=StartTime;
+  double BestMatchStartTime=StartTime;
   double dphi_min=1e6;
   double locP=0.,dz=0.;
   for (unsigned int i=0;i<locBCALShowers.size();i++){
@@ -3774,13 +3770,10 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
 	dphi_min=dphi;
 	dz=pos.z()-bcalpos.z();
 	locP=mom.Mag();
-	StartTime=locBCALShowers[i]->t-t;
+	BestMatchStartTime=locBCALShowers[i]->t-t;
       }
     }
   }
-  // Check that the "start time" is not too far out of time with the rest of 
-  // the event
-  if (fabs(StartTime-StartTimeGuess)>OUT_OF_TIME_CUT) return false;
   
   // look for a match in z-position
   if(fabs(dz) > BCAL_Z_CUT) return false;
@@ -3788,7 +3781,8 @@ bool DParticleID::Get_StartTime(const vector<DTrackFitter::Extrapolation_t> &ext
   // .. and in phi
   double locDeltaPhi = 180.0*dphi_min/M_PI;
   double locPhiCut = BCAL_PHI_CUT_PAR1 + BCAL_PHI_CUT_PAR2*exp(-1.0*BCAL_PHI_CUT_PAR3*locP);
-  if (fabs(locDeltaPhi)<locPhiCut){    
+  if (fabs(locDeltaPhi)<locPhiCut){
+    StartTime=BestMatchStartTime;
     return true;
   }
 

--- a/src/libraries/PID/DParticleID.cc
+++ b/src/libraries/PID/DParticleID.cc
@@ -53,6 +53,13 @@ DParticleID::DParticleID(const std::shared_ptr<const JEvent>& event)
   OUT_OF_TIME_CUT = 35.0; // Changed 200 -> 35 ns, March 2016
   app->SetDefaultParameter("PID:OUT_OF_TIME_CUT",OUT_OF_TIME_CUT);
 
+  bool FAST_TRACKING_MODE=false;
+  app->SetDefaultParameter("TRKFIT:FAST_TRACKING_MODE",FAST_TRACKING_MODE);
+  if (FAST_TRACKING_MODE){
+    // Effectively disable the out-of-time cut
+    OUT_OF_TIME_CUT=1000.;
+  }
+  
   CDC_TIME_CUT_FOR_DEDX = 1000.0; 
   app->SetDefaultParameter("PID:CDC_TIME_CUT_FOR_DEDX",CDC_TIME_CUT_FOR_DEDX);
     

--- a/src/libraries/TRACKING/DTrackFitter.cc
+++ b/src/libraries/TRACKING/DTrackFitter.cc
@@ -174,7 +174,7 @@ void DTrackFitter::AddHits(vector<const DTRDPoint*> trdhits)
 //-------------------
 // FitTrack
 //-------------------
-DTrackFitter::fit_status_t DTrackFitter::FitTrack(const DVector3 &pos, const DVector3 &mom, double q, double mass,double t0,DetectorSystem_t t0_det)
+DTrackFitter::fit_status_t DTrackFitter::FitTrack(const DVector3 &pos, const DVector3 &mom, double q, double mass,double t0,double t0_sigma,DetectorSystem_t t0_det)
 {
 #ifdef PROFILE_TRK_TIMES
     prof_time start_time;
@@ -183,7 +183,7 @@ DTrackFitter::fit_status_t DTrackFitter::FitTrack(const DVector3 &pos, const DVe
 	input_params.setMomentum(mom);
 	input_params.setPID(IDTrack(q, mass));
 	input_params.setTime(t0);
-	input_params.setT0(t0,0.,t0_det);
+	input_params.setT0(t0,t0_sigma,t0_det);
 
 	DTrackFitter::fit_status_t status = FitTrack();
 
@@ -219,7 +219,7 @@ DTrackFitter::fit_status_t
 DTrackFitter::FindHitsAndFitTrack(const DKinematicData &starting_params, 
 				  const map<DetectorSystem_t,vector<DTrackFitter::Extrapolation_t> >&extrapolations,
 				  const std::shared_ptr<const JEvent>& loop,
-				  double mass,int N,double t0,
+				  double mass,int N,double t0,double t0_sigma,
 				  DetectorSystem_t t0_det){
   // Reset fitter saving the type of fit we're doing
   fit_type_t save_type = fit_type;
@@ -285,7 +285,7 @@ DTrackFitter::FindHitsAndFitTrack(const DKinematicData &starting_params,
   // Do the fit 
   DVector3 pos = starting_params.position();
   DVector3 mom = starting_params.momentum();
-  fit_status = FitTrack(pos, mom,q, mass,t0,t0_det);
+  fit_status = FitTrack(pos, mom,q, mass,t0,t0_sigma,t0_det);
   
 #ifdef PROFILE_TRK_TIMES
   start_time.TimeDiffNow(prof_times, "Find Hits and Fit Track");
@@ -299,7 +299,7 @@ DTrackFitter::FindHitsAndFitTrack(const DKinematicData &starting_params,
 DTrackFitter::fit_status_t 
 DTrackFitter::FindHitsAndFitTrack(const DKinematicData &starting_params,
 				  const DReferenceTrajectory *rt, const std::shared_ptr<const JEvent>& loop,
-				  double mass,int N,double t0,
+				  double mass,int N,double t0,double t0_sigma,
 				  DetectorSystem_t t0_det)
 {
 	/// Fit a DTrackCandidate using a given mass hypothesis.
@@ -376,7 +376,7 @@ DTrackFitter::FindHitsAndFitTrack(const DKinematicData &starting_params,
 #endif
 
 	// Do the fit
-	fit_status = FitTrack(pos, mom,q, mass,t0,t0_det);
+	fit_status = FitTrack(pos, mom,q, mass,t0,t0_sigma,t0_det);
 
 #ifdef PROFILE_TRK_TIMES
 	start_time.TimeDiffNow(prof_times, "Find Hits and Fit Track");

--- a/src/libraries/TRACKING/DTrackFitter.h
+++ b/src/libraries/TRACKING/DTrackFitter.h
@@ -177,7 +177,7 @@ class DTrackFitter: public JObject{
 		void SetInputParameters(const DTrackingData &starting_params){input_params=starting_params;}
 		
 		// Wrappers
-		fit_status_t FitTrack(const DVector3 &pos, const DVector3 &mom, double q, double mass,double t0=Quiet_NaN,DetectorSystem_t t0_det=SYS_NULL);
+  fit_status_t FitTrack(const DVector3 &pos, const DVector3 &mom, double q, double mass,double t0=Quiet_NaN,double t0_sigma=Quiet_NaN,DetectorSystem_t t0_det=SYS_NULL);
 		fit_status_t FitTrack(const DTrackingData &starting_params);
 		
 		// Methods that actually do something
@@ -187,13 +187,14 @@ class DTrackFitter: public JObject{
 				      const std::shared_ptr<const JEvent> &loop, double mass=-1.0,
 				      int N=0,
 				      double t0=Quiet_NaN,
+				      double t0_sigma=Quiet_NaN,
 				      DetectorSystem_t t0_det=SYS_NULL
 				      ); ///< mass<0 means get it from starting_params
 		fit_status_t 
 		  FindHitsAndFitTrack(const DKinematicData &starting_params, 
 				      const map<DetectorSystem_t,vector<DTrackFitter::Extrapolation_t> >&extrapolations,
 				      const std::shared_ptr<const JEvent>& loop,
-				      double mass,int N,double t0,
+				      double mass,int N,double t0,double t0_sigma,
 				      DetectorSystem_t t0_det);
 		
 		jerror_t CorrectForELoss(const DKinematicData &starting_params, DReferenceTrajectory *rt, DVector3 &pos, DVector3 &mom, double mass);

--- a/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
+++ b/src/libraries/TRACKING/DTrackFitterKalmanSIMD.cc
@@ -827,23 +827,8 @@ DTrackFitter::fit_status_t DTrackFitterKalmanSIMD::FitTrack(void)
 
    // start time and variance
    mT0=input_params.t0();
-   switch(input_params.t0_detector()){
-   case SYS_TOF:
-     mVarT0=0.01;
-     break;
-   case SYS_CDC:
-     mVarT0=7.5;
-     break;
-   case SYS_FDC:
-     mVarT0=7.5;
-     break;
-   case SYS_BCAL:
-     mVarT0=0.25;
-     break;
-   default:
-     mVarT0=0.09;
-     break;
-   }
+   double t0_sigma=input_params.t0_err();
+   mVarT0=t0_sigma*t0_sigma;
 
    // Copy hits from base class into structures specific to DTrackFitterKalmanSIMD
    if (USE_CDC_HITS) 
@@ -860,10 +845,6 @@ DTrackFitter::fit_status_t DTrackFitterKalmanSIMD::FitTrack(void)
 
    unsigned int num_good_cdchits=my_cdchits.size();
    unsigned int num_good_fdchits=my_fdchits.size(); 
-
-   // keep track of the range of detector elements that could be hit
-   // for calculating the number of expected hits later on
-   //int min_cdc_ring=-1, max_cdc_ring=-1;
 
    // Order the cdc hits by ring number
    if (num_good_cdchits>0){
@@ -933,7 +914,7 @@ DTrackFitter::fit_status_t DTrackFitterKalmanSIMD::FitTrack(void)
       fdc_used_in_fit=vector<bool>(my_fdchits.size());
    }
  
-   //_DBG_ << SystemName(input_params.t0_detector()) << " " << mT0 <<endl;
+  //_DBG_ << SystemName(input_params.t0_detector()) << " " << mT0 << endl;
 
    //Set the mass
    MASS=input_params.mass();
@@ -10096,7 +10077,7 @@ void DTrackFitterKalmanSIMD::AddExtrapolation(DetectorSystem_t detector,
 						     t*TIME_UNIT_CONVERSION,s,
 						     s_theta_ms_sum,
 						     theta2ms_sum));
-  if (DEBUG_LEVEL>0){
+  if (DEBUG_LEVEL>3){
     cout << SystemName(detector) << ": s=" << s 
 	 << " t=" << t*TIME_UNIT_CONVERSION << " (x,y,z)=("
 	 << position.x() <<","<<position.y()<<","<<position.z()<<") (px,py,pz)="
@@ -10121,7 +10102,7 @@ void DTrackFitterKalmanSIMD::AddExtrapolation(DetectorSystem_t detector,
 						     t*TIME_UNIT_CONVERSION,s,
 						     s_theta_ms_sum,
 						     theta2ms_sum));
-  if (DEBUG_LEVEL>0){
+  if (DEBUG_LEVEL>3){
     cout << SystemName(detector) << ": s=" << s 
 	 << " t=" << t*TIME_UNIT_CONVERSION << " (x,y,z)=("<< position.x() 
 	 <<","<<position.y()<<","<<position.z()<<") (px,py,pz)="

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -880,30 +880,17 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
 				    const std::shared_ptr<const JEvent>&event,
 				    double mass){  
   if(DEBUG_LEVEL>1){_DBG__;_DBG_<<"---- Starting time based fit with mass: "<<mass<<endl;}
-  // Get the hits from the wire-based track
-  vector<const DFDCPseudo*>myfdchits;
-  track->GetT(myfdchits);
-  vector<const DCDCTrackHit *>mycdchits;
-  track->GetT(mycdchits);
-
+  
   // Do the fit
   DTrackFitter::fit_status_t status = DTrackFitter::kFitNotDone;
   if (USE_HITS_FROM_WIREBASED_FIT) {
-    fitter->Reset();
-    fitter->SetFitType(DTrackFitter::kTimeBased);	
-    
-    fitter->AddHits(myfdchits);
-    fitter->AddHits(mycdchits);
-
-    status=fitter->FitTrack(track->position(),track->momentum(),
-			    track->charge(),mass,mStartTime,mStartDetector);
+    status=FitWithWireBasedHits(track,mass);
   }   
   else{   
     fitter->Reset();
-    fitter->SetFitType(DTrackFitter::kTimeBased);    
+    fitter->SetFitType(DTrackFitter::kTimeBased);
     status = fitter->FindHitsAndFitTrack(*track, track->extrapolations,event, 
-					 mass,
-					 mycdchits.size()+2*myfdchits.size(),
+					 mass,track->Ndof+5,
 					 mStartTime,mStartDetector);
     
     // If the status is kFitNotDone, then not enough hits were attached to this
@@ -911,13 +898,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
     // from the wire-based track
     if (status==DTrackFitter::kFitNotDone){
       //_DBG_ << " Using wire-based hits " << endl;
-      fitter->Reset();
-      fitter->SetFitType(DTrackFitter::kTimeBased);   
-      fitter->AddHits(myfdchits);
-      fitter->AddHits(mycdchits);
-      
-      status=fitter->FitTrack(track->position(),track->momentum(),
-			      track->charge(),mass,mStartTime,mStartDetector);
+      status=FitWithWireBasedHits(track,mass);
     }
 
   }
@@ -935,11 +916,12 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
   // wire-based fit result.  In this case set the status word to 
   // kFitNoImprovement and copy the wire-based parameters into the time-based
   // class.
-  if (myfdchits.size()>3 && mycdchits.size()>3){
+  if (track->NumFDC>3 && track->NumCDC>3){
     unsigned int ndof=fitter->GetNdof();
     if (TMath::Prob(track->chisq,track->Ndof)>
-	TMath::Prob(fitter->GetChisq(),ndof)&&ndof<5)
+	TMath::Prob(fitter->GetChisq(),ndof)&&ndof<5){
       status=DTrackFitter::kFitNoImprovement;
+    }
   }
       
   // Check the status value from the fit
@@ -950,6 +932,12 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
     break;
   case DTrackFitter::kFitNoImprovement:
     {
+      // Get the hits from the wire-based track
+      vector<const DFDCPseudo*>myfdchits;
+      track->GetT(myfdchits);
+      vector<const DCDCTrackHit *>mycdchits;
+      track->GetT(mycdchits);
+      
       // Create a new time-based track object
       MakeTimeBasedFromWireBased(myfdchits,mycdchits,start_times,track);
       return true;
@@ -1476,4 +1464,23 @@ void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo
   timebased_track->AddAssociatedObject(track);
   
   Insert(timebased_track);
+}
+
+DTrackFitter::fit_status_t
+DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,
+					      double mass){
+  // Get the hits from the wire-based track
+  vector<const DFDCPseudo*>myfdchits;
+  track->GetT(myfdchits);
+  vector<const DCDCTrackHit *>mycdchits;
+  track->GetT(mycdchits);
+
+  fitter->Reset();
+  fitter->SetFitType(DTrackFitter::kTimeBased);
+
+  fitter->AddHits(myfdchits);
+  fitter->AddHits(mycdchits);
+
+  return fitter->FitTrack(track->position(),track->momentum(),
+			  track->charge(),mass,mStartTime,mStartDetector);
 }

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -965,21 +965,9 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->measured_cdc_hits_on_track = cdchits.size();
       timebased_track->measured_fdc_hits_on_track = fdchits.size();
 
-      // dEdx
-      double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
-      double locdx_CDC,locdx_CDC_amp;
-      unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-      pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC,locdx_CDC_amp, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      // Add the dEdx info to the track
+      GetdEdxInfo(timebased_track);
       
-      timebased_track->ddEdx_FDC = locdEdx_FDC;
-      timebased_track->ddx_FDC = locdx_FDC;
-      timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
-      timebased_track->ddEdx_CDC = locdEdx_CDC;
-      timebased_track->ddEdx_CDC_amp= locdEdx_CDC_amp;
-      timebased_track->ddx_CDC = locdx_CDC;
-      timebased_track->ddx_CDC_amp= locdx_CDC_amp;
-      timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
-
       // Set CDC ring & FDC plane hit patterns before candidate and wirebased tracks are associated
       timebased_track->dCDCRings = pid_algorithm->Get_CDCRingBitPattern(cdchits);
       timebased_track->dFDCPlanes = pid_algorithm->Get_FDCPlaneBitPattern(fdchits);
@@ -1015,12 +1003,6 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   // Create a new time-based track object
   DTrackTimeBased *timebased_track = new DTrackTimeBased();
   *static_cast<DTrackingData*>(timebased_track) = *static_cast<const DTrackingData*>(src_track);
-
-  // Get the hits used in the fit  
-  vector<const DCDCTrackHit *>src_cdchits;
-  src_track->GetT(src_cdchits);
-  vector<const DFDCPseudo *>src_fdchits;
-  src_track->GetT(src_fdchits);
 
   // Copy over DKinematicData part from the result of a successful fit
   timebased_track->setPID(IDTrack(q, my_mass));
@@ -1062,8 +1044,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
     fitter->SetFitType(DTrackFitter::kTimeBased);    
     status = fitter->FindHitsAndFitTrack(*timebased_track,
 					 timebased_track->extrapolations,event, 
-					 my_mass,
-					 src_cdchits.size()+2*src_fdchits.size(),
+					 my_mass,timebased_track->Ndof+5,
 					 timebased_track->t0(),
 					 timebased_track->t0_err(),
 					 timebased_track->t0_detector());
@@ -1091,8 +1072,8 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
 
       // Add hits used as associated objects
-      const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();
-      const vector<const DFDCPseudo*> &fdchits = fitter->GetFDCFitHits();
+      auto cdchits = fitter->GetCDCFitHits();
+      auto fdchits = fitter->GetFDCFitHits();
        
       for(unsigned int m=0; m<cdchits.size(); m++)
 	timebased_track->AddAssociatedObject(cdchits[m]);
@@ -1101,14 +1082,24 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
        
       timebased_track->measured_cdc_hits_on_track = cdchits.size();
       timebased_track->measured_fdc_hits_on_track = fdchits.size();
-       
+      timebased_track->dCDCRings = pid_algorithm->Get_CDCRingBitPattern(cdchits);
+      timebased_track->dFDCPlanes = pid_algorithm->Get_FDCPlaneBitPattern(fdchits);
+
+      // Add dEx info to the track
+      GetdEdxInfo(timebased_track);
+      
       // Compute the figure-of-merit based on tracking
       timebased_track->FOM = TMath::Prob(timebased_track->chisq, timebased_track->Ndof);
-      
     }
   }
 
-  if (status!=DTrackFitter::kFitSuccess){ 
+  if (status!=DTrackFitter::kFitSuccess){
+    // Get the hits used in the intitial fit  
+    vector<const DCDCTrackHit *>src_cdchits;
+    src_track->GetT(src_cdchits);
+    vector<const DFDCPseudo *>src_fdchits;
+    src_track->GetT(src_fdchits);
+    
     for(unsigned int m=0; m<src_fdchits.size(); m++)
       timebased_track->AddAssociatedObject(src_fdchits[m]); 
     for(unsigned int m=0; m<src_cdchits.size(); m++)
@@ -1116,114 +1107,30 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
     
     timebased_track->measured_cdc_hits_on_track = src_cdchits.size();
     timebased_track->measured_fdc_hits_on_track = src_fdchits.size();
-  }
+    timebased_track->dCDCRings=src_track->dCDCRings;
+    timebased_track->dFDCPlanes=src_track->dFDCPlanes;
 
-  // dEdx
-  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
-  double locdx_CDC,locdx_CDC_amp;
-  unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC,locdx_CDC_amp, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
-  
-  timebased_track->ddEdx_FDC = locdEdx_FDC;
-  timebased_track->ddx_FDC = locdx_FDC;
-  timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
-  timebased_track->ddEdx_CDC = locdEdx_CDC;
-  timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
-  timebased_track->ddx_CDC = locdx_CDC;
-  timebased_track->ddx_CDC_amp = locdx_CDC_amp;
-  timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
-
-  // The above code has a truncated mean algorithm for dEdx hardwired for the FDC
-  // and selectable between on and off for the CDC_amp. Here I save the complete
-  // information for a variety of truncation choices, and let the user decide later.
-
-  if (SAVE_TRUNCATED_DEDX) {
-    std::vector<DParticleID::dedx_t> locdEdxHits_CDC;
-    std::vector<DParticleID::dedx_t> locdEdxHits_FDC;
-    jerror_t locReturnStatus = pid_algorithm->GetDCdEdxHits(timebased_track, locdEdxHits_CDC, locdEdxHits_FDC);
-    if (locReturnStatus == NOERROR) {
-      const int maxtrunc(5);
-      sort(locdEdxHits_CDC.begin(),locdEdxHits_CDC.end(), DTrackTimeBased_dedx_cmp);  
-      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
-        for (int i=itrunc; i < (int)locdEdxHits_CDC.size(); ++i) {
-          double dx = locdEdxHits_CDC[i].dx;
-          double dE = locdEdxHits_CDC[i].dEdx * dx;
-          if (itrunc < (int)timebased_track->ddx_CDC_trunc.size()) {
-            timebased_track->ddx_CDC_trunc[itrunc] += dx;
-            timebased_track->ddEdx_CDC_trunc[itrunc] += dE;
-          }
-          else {
-            timebased_track->ddx_CDC_trunc.push_back(dx);
-            timebased_track->ddEdx_CDC_trunc.push_back(dE);
-          }
-        }
-        if (itrunc < (int)timebased_track->ddx_CDC_trunc.size())
-          timebased_track->ddEdx_CDC_trunc[itrunc] /= timebased_track->ddx_CDC_trunc[itrunc] + 1e-99;
-      }
-
-      sort(locdEdxHits_CDC.begin(),locdEdxHits_CDC.end(), DTrackTimeBased_dedx_amp_cmp);  
-      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
-        for (int i=itrunc; i < (int)locdEdxHits_CDC.size(); ++i) {
-          double dx = locdEdxHits_CDC[i].dx;
-          double dE = locdEdxHits_CDC[i].dEdx_amp * dx;
-          if (itrunc < (int)timebased_track->ddx_CDC_amp_trunc.size()) {
-            timebased_track->ddx_CDC_amp_trunc[itrunc] += dx;
-            timebased_track->ddEdx_CDC_amp_trunc[itrunc] += dE;
-          }
-          else {
-            timebased_track->ddx_CDC_amp_trunc.push_back(dx);
-            timebased_track->ddEdx_CDC_amp_trunc.push_back(dE);
-          }
-        }
-        if (itrunc < (int)timebased_track->ddx_CDC_amp_trunc.size())
-          timebased_track->ddEdx_CDC_amp_trunc[itrunc] /= timebased_track->ddx_CDC_amp_trunc[itrunc] + 1e-99;
-      }
-
-      sort(locdEdxHits_FDC.begin(),locdEdxHits_FDC.end(), DTrackTimeBased_dedx_cmp);  
-      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
-        for (int i=itrunc; i < (int)locdEdxHits_FDC.size(); ++i) {
-          double dx = locdEdxHits_FDC[i].dx;
-          double dE = locdEdxHits_FDC[i].dEdx * dx;
-          if (itrunc < (int)timebased_track->ddx_FDC_trunc.size()) {
-            timebased_track->ddx_FDC_trunc[itrunc] += dx;
-            timebased_track->ddEdx_FDC_trunc[itrunc] += dE;
-          }
-          else {
-            timebased_track->ddx_FDC_trunc.push_back(dx);
-            timebased_track->ddEdx_FDC_trunc.push_back(dE);
-          }
-        }
-        if (itrunc < (int)timebased_track->ddx_FDC_trunc.size())
-          timebased_track->ddEdx_FDC_trunc[itrunc] /= timebased_track->ddx_FDC_trunc[itrunc] + 1e-99;
-      }
-
-      sort(locdEdxHits_FDC.begin(),locdEdxHits_FDC.end(), DTrackTimeBased_dedx_amp_cmp);  
-      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
-        for (int i=itrunc; i < (int)locdEdxHits_FDC.size(); ++i) {
-          double dx = locdEdxHits_FDC[i].dx;
-          double dE = locdEdxHits_FDC[i].dEdx_amp * dx;
-          if (itrunc < (int)timebased_track->ddx_FDC_amp_trunc.size()) {
-            timebased_track->ddx_FDC_amp_trunc[itrunc] += dx;
-            timebased_track->ddEdx_FDC_amp_trunc[itrunc] += dE;
-          }
-          else {
-            timebased_track->ddx_FDC_amp_trunc.push_back(dx);
-            timebased_track->ddEdx_FDC_amp_trunc.push_back(dE);
-          }
-        }
-        if (itrunc < (int)timebased_track->ddx_FDC_amp_trunc.size())
-          timebased_track->ddEdx_FDC_amp_trunc[itrunc] /= timebased_track->ddx_FDC_amp_trunc[itrunc] + 1e-99;
-      }
+    // Copy dEdx data to the new track from the source track
+    timebased_track->ddEdx_FDC = src_track->ddEdx_FDC;
+    timebased_track->ddx_FDC = src_track->ddx_FDC;
+    timebased_track->dNumHitsUsedFordEdx_FDC = src_track->dNumHitsUsedFordEdx_FDC;
+    timebased_track->ddEdx_CDC = src_track->ddEdx_CDC;
+    timebased_track->ddEdx_CDC_amp = src_track->ddEdx_CDC_amp;
+    timebased_track->ddx_CDC = src_track->ddx_CDC;
+    timebased_track->ddx_CDC_amp = src_track->ddx_CDC_amp;
+    timebased_track->dNumHitsUsedFordEdx_CDC = src_track->dNumHitsUsedFordEdx_CDC;
+    if (SAVE_TRUNCATED_DEDX){
+      timebased_track->ddx_FDC_trunc=src_track->ddx_FDC_trunc;
+      timebased_track->ddEdx_FDC_trunc=src_track->ddEdx_FDC_trunc;
+      timebased_track->ddx_FDC_amp_trunc=src_track->ddx_FDC_amp_trunc;
+      timebased_track->ddEdx_FDC_amp_trunc=src_track->ddEdx_FDC_amp_trunc;
+      timebased_track->ddx_CDC_trunc =src_track->ddx_CDC_trunc;
+      timebased_track->ddEdx_CDC_trunc =src_track->ddEdx_CDC_trunc;
+      timebased_track->ddx_CDC_amp_trunc=src_track->ddx_CDC_amp_trunc;
+      timebased_track->ddEdx_CDC_amp_trunc=src_track->ddEdx_CDC_amp_trunc;
     }
   }
 
-  // Set CDC ring & FDC plane hit patterns before candidate and wirebased tracks are associated
-  vector<const DCDCTrackHit*> tempCDCTrackHits = timebased_track->Get<DCDCTrackHit>();
-  vector<const DFDCPseudo*> tempFDCPseudos = timebased_track->Get<DFDCPseudo>();
-
-  timebased_track->dCDCRings = pid_algorithm->Get_CDCRingBitPattern(tempCDCTrackHits);
-  timebased_track->dFDCPlanes = pid_algorithm->Get_FDCPlaneBitPattern(tempFDCPseudos);
-  
   tracks_to_add.push_back(timebased_track);
 }
 
@@ -1404,21 +1311,11 @@ void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo
   
   timebased_track->measured_cdc_hits_on_track = cdchits.size();
   timebased_track->measured_fdc_hits_on_track = fdchits.size();
+  timebased_track->dCDCRings=pid_algorithm->Get_CDCRingBitPattern(cdchits);
+  timebased_track->dFDCPlanes=pid_algorithm->Get_FDCPlaneBitPattern(fdchits);
 
   // dEdx
-  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
-  double locdx_CDC_amp,locdx_CDC;
-  unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
-  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp, locdx_CDC, locdx_CDC_amp,locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
-  
-  timebased_track->ddEdx_FDC = locdEdx_FDC;
-  timebased_track->ddx_FDC = locdx_FDC;
-  timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
-  timebased_track->ddEdx_CDC = locdEdx_CDC; 
-  timebased_track->ddEdx_CDC_amp = locdEdx_CDC_amp;
-  timebased_track->ddx_CDC = locdx_CDC; 
-  timebased_track->ddx_CDC_amp = locdx_CDC_amp;
-  timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
+  GetdEdxInfo(timebased_track);
 
   // Yes, the line below is redundant, but it is needed if mass hypotheses
   // need to be added
@@ -1446,3 +1343,103 @@ DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,doubl
 			  start_time.t0,start_time.system);
 }
 
+// Add the dEdx data to the track object
+void DTrackTimeBased_factory::GetdEdxInfo(DTrackTimeBased *timebased_track) const{
+  double locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp;
+  double locdx_CDC,locdx_CDC_amp;
+  unsigned int locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC;
+  pid_algorithm->CalcDCdEdx(timebased_track, locdEdx_FDC, locdx_FDC, locdEdx_CDC, locdEdx_CDC_amp,locdx_CDC,locdx_CDC_amp, locNumHitsUsedFordEdx_FDC, locNumHitsUsedFordEdx_CDC);
+      
+  timebased_track->ddEdx_FDC = locdEdx_FDC;
+  timebased_track->ddx_FDC = locdx_FDC;
+  timebased_track->dNumHitsUsedFordEdx_FDC = locNumHitsUsedFordEdx_FDC;
+  timebased_track->ddEdx_CDC = locdEdx_CDC;
+  timebased_track->ddEdx_CDC_amp= locdEdx_CDC_amp;
+  timebased_track->ddx_CDC = locdx_CDC;
+  timebased_track->ddx_CDC_amp= locdx_CDC_amp;
+  timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
+  
+  // The above code has a truncated mean algorithm for dEdx hardwired for the FDC
+  // and selectable between on and off for the CDC_amp. Here I save the complete
+  // information for a variety of truncation choices, and let the user decide later.
+
+  if (SAVE_TRUNCATED_DEDX) {
+    std::vector<DParticleID::dedx_t> locdEdxHits_CDC;
+    std::vector<DParticleID::dedx_t> locdEdxHits_FDC;
+    jerror_t locReturnStatus = pid_algorithm->GetDCdEdxHits(timebased_track, locdEdxHits_CDC, locdEdxHits_FDC);
+    if (locReturnStatus == NOERROR) {
+      const int maxtrunc(5);
+      sort(locdEdxHits_CDC.begin(),locdEdxHits_CDC.end(), DTrackTimeBased_dedx_cmp);  
+      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
+        for (int i=itrunc; i < (int)locdEdxHits_CDC.size(); ++i) {
+          double dx = locdEdxHits_CDC[i].dx;
+          double dE = locdEdxHits_CDC[i].dEdx * dx;
+          if (itrunc < (int)timebased_track->ddx_CDC_trunc.size()) {
+            timebased_track->ddx_CDC_trunc[itrunc] += dx;
+            timebased_track->ddEdx_CDC_trunc[itrunc] += dE;
+          }
+          else {
+            timebased_track->ddx_CDC_trunc.push_back(dx);
+            timebased_track->ddEdx_CDC_trunc.push_back(dE);
+          }
+        }
+        if (itrunc < (int)timebased_track->ddx_CDC_trunc.size())
+          timebased_track->ddEdx_CDC_trunc[itrunc] /= timebased_track->ddx_CDC_trunc[itrunc] + 1e-99;
+      }
+
+      sort(locdEdxHits_CDC.begin(),locdEdxHits_CDC.end(), DTrackTimeBased_dedx_amp_cmp);  
+      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
+        for (int i=itrunc; i < (int)locdEdxHits_CDC.size(); ++i) {
+          double dx = locdEdxHits_CDC[i].dx;
+          double dE = locdEdxHits_CDC[i].dEdx_amp * dx;
+          if (itrunc < (int)timebased_track->ddx_CDC_amp_trunc.size()) {
+            timebased_track->ddx_CDC_amp_trunc[itrunc] += dx;
+            timebased_track->ddEdx_CDC_amp_trunc[itrunc] += dE;
+          }
+          else {
+            timebased_track->ddx_CDC_amp_trunc.push_back(dx);
+            timebased_track->ddEdx_CDC_amp_trunc.push_back(dE);
+          }
+        }
+        if (itrunc < (int)timebased_track->ddx_CDC_amp_trunc.size())
+          timebased_track->ddEdx_CDC_amp_trunc[itrunc] /= timebased_track->ddx_CDC_amp_trunc[itrunc] + 1e-99;
+      }
+
+      sort(locdEdxHits_FDC.begin(),locdEdxHits_FDC.end(), DTrackTimeBased_dedx_cmp);  
+      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
+        for (int i=itrunc; i < (int)locdEdxHits_FDC.size(); ++i) {
+          double dx = locdEdxHits_FDC[i].dx;
+          double dE = locdEdxHits_FDC[i].dEdx * dx;
+          if (itrunc < (int)timebased_track->ddx_FDC_trunc.size()) {
+            timebased_track->ddx_FDC_trunc[itrunc] += dx;
+            timebased_track->ddEdx_FDC_trunc[itrunc] += dE;
+          }
+          else {
+            timebased_track->ddx_FDC_trunc.push_back(dx);
+            timebased_track->ddEdx_FDC_trunc.push_back(dE);
+          }
+        }
+        if (itrunc < (int)timebased_track->ddx_FDC_trunc.size())
+          timebased_track->ddEdx_FDC_trunc[itrunc] /= timebased_track->ddx_FDC_trunc[itrunc] + 1e-99;
+      }
+
+      sort(locdEdxHits_FDC.begin(),locdEdxHits_FDC.end(), DTrackTimeBased_dedx_amp_cmp);  
+      for (int itrunc=0; itrunc <= maxtrunc; ++itrunc) {
+        for (int i=itrunc; i < (int)locdEdxHits_FDC.size(); ++i) {
+          double dx = locdEdxHits_FDC[i].dx;
+          double dE = locdEdxHits_FDC[i].dEdx_amp * dx;
+          if (itrunc < (int)timebased_track->ddx_FDC_amp_trunc.size()) {
+            timebased_track->ddx_FDC_amp_trunc[itrunc] += dx;
+            timebased_track->ddEdx_FDC_amp_trunc[itrunc] += dE;
+          }
+          else {
+            timebased_track->ddx_FDC_amp_trunc.push_back(dx);
+            timebased_track->ddEdx_FDC_amp_trunc.push_back(dE);
+          }
+        }
+        if (itrunc < (int)timebased_track->ddx_FDC_amp_trunc.size())
+          timebased_track->ddEdx_FDC_amp_trunc[itrunc] /= timebased_track->ddx_FDC_amp_trunc[itrunc] + 1e-99;
+      }
+    }
+  }
+}

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -1318,8 +1318,9 @@ DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,doubl
   fitter->AddHits(myfdchits);
   fitter->AddHits(mycdchits);
 
-  return fitter->FitTrack(track->position(),track->momentum(),track->charge(),mass,
-			  start_time.t0,start_time.system);
+  return fitter->FitTrack(track->position(),track->momentum(),track->charge(),
+			  mass,start_time.t0,start_time.t0_sigma,
+			  start_time.system);
 }
 
 // Add the dEdx data to the track object

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -327,8 +327,7 @@ void DTrackTimeBased_factory::Process(const std::shared_ptr<const JEvent>& event
     for (unsigned int i=0;i<tracks.size();i++){
       vector<const DFDCPseudo*>fdchits=tracks[i]->Get<DFDCPseudo>();
       vector<const DCDCTrackHit*>cdchits=tracks[i]->Get<DCDCTrackHit>();
-      vector<DTrackTimeBased::DStartTime_t>start_times;
-      MakeTimeBasedFromWireBased(fdchits,cdchits,start_times,tracks[i]);
+      MakeTimeBasedFromWireBased(fdchits,cdchits,tracks[i]);
     }
     return;
   }
@@ -374,13 +373,13 @@ void DTrackTimeBased_factory::Process(const std::shared_ptr<const JEvent>& event
 
     unsigned int num=mData.size();
 
-    // Create vector of start times from various sources
-    vector<DTrackTimeBased::DStartTime_t>start_times;
-    CreateStartTimeList(track,sc_hits,tof_points,bcal_showers,fcal_showers,
-			fcal_hits,ecal_showers,ecal_hits,start_times);
-	
+    // Get the start time for the track
+    DTrackTimeBased::DStartTime_t start_time;
+    GetStartTime(track,sc_hits,tof_points,bcal_showers,fcal_showers,fcal_hits,ecal_showers,
+		 ecal_hits,start_time);
+    
     // Fit the track
-    DoFit(track,start_times,event,track->mass());
+    DoFit(track,start_time,event,track->mass());
   
     //_DBG_<< "eventnumber:   " << eventnumber << endl;
     if (PID_FORCE_TRUTH && mData.size()>num) {
@@ -774,109 +773,90 @@ int DTrackTimeBased_factory::GetThrownIndex(vector<const DMCThrown*>& locMCThrow
 
 // Create a list of start (vertex) times from various sources, ordered by 
 // uncertainty.
-void DTrackTimeBased_factory
-  ::CreateStartTimeList(const DTrackWireBased *track,
-			vector<const DSCHit*>&sc_hits,
-			vector<const DTOFPoint*>&tof_points,
-			vector<const DBCALShower*>&bcal_showers,	
-			vector<const DFCALShower*>&fcal_showers,
-			vector<const DFCALHit*>&fcal_hits,
-			vector<const DECALShower*>&ecal_showers,
-			vector<const DECALHit*>&ecal_hits,
-			vector<DTrackTimeBased::DStartTime_t>&start_times){
-  DTrackTimeBased::DStartTime_t start_time;
-   
+void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
+					   vector<const DSCHit*>&sc_hits,
+					   vector<const DTOFPoint*>&tof_points,
+					   vector<const DBCALShower*>&bcal_showers,
+					   vector<const DFCALShower*>&fcal_showers,
+					   vector<const DFCALHit*>&fcal_hits,
+					   vector<const DECALShower*>&ecal_showers,
+					   vector<const DECALHit*>&ecal_hits,
+					   DTrackTimeBased::DStartTime_t &start_time) const {
   // Match to the start counter and the outer detectors
-  double locStartTimeVariance = 0.0;
   double track_t0=track->t0();
   double locStartTime = track_t0;  // Initial guess from tracking
  
   // Get start time estimate from Start Counter
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_START),sc_hits,locStartTime)){
     start_time.t0=locStartTime;
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
+    start_time.t0_sigma=0.3;
     start_time.system=SYS_START;
-    start_times.push_back(start_time);
+
+    return;
   }
   // Get start time estimate from TOF
   locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_TOF),tof_points,locStartTime)){
-    // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.1;
     start_time.system=SYS_TOF;
-    start_times.push_back(start_time); 
+
+    return;
   }
   // Get start time estimate from FCAL
   locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_showers,locStartTime)){
-    // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.7;
     start_time.system=SYS_FCAL;
-    start_times.push_back(start_time); 
+
+    return;
   }
   // look for matches to single FCAL hits
-  else if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_hits,locStartTime)){
-    // Fill in the start time vector
+  locStartTime = track_t0;  // Initial guess from tracking
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_hits,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.7;
     start_time.system=SYS_FCAL;
-    start_times.push_back(start_time);
+  
+    return;
   }
-
   // Get start time estimate from ECAL
   locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_showers,locStartTime)){
-    // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.4;
     start_time.system=SYS_ECAL;
-    start_times.push_back(start_time); 
+
+    return;
   }
   // look for matches to single ECAL hits
-  else if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_hits,locStartTime)){
-    // Fill in the start time vector
+  locStartTime = track_t0;  // Initial guess from tracking
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_hits,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=sqrt(locStartTimeVariance);
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.4;
     start_time.system=SYS_ECAL;
-    start_times.push_back(start_time);
+
+    return;
   }
-  
   // Get start time estimate from BCAL
-  locStartTime=track_t0;
+  locStartTime=track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_BCAL),bcal_showers,locStartTime)){
-    // Fill in the start time vector
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
-    //    start_time.t0_sigma=sqrt(locTimeVariance); //uncomment when ready
+    start_time.t0_sigma=0.35;
     start_time.system=SYS_BCAL;
-    start_times.push_back(start_time);    
+
+    return;
   }
-  // Add the t0 estimate from the tracking 
+  // If all else fails, use track info
   start_time.t0=track_t0;
-  start_time.t0_sigma=5.;
+  start_time.t0_sigma=2.5; // crude estimate
   start_time.system=track->t0_detector();
-  start_times.push_back(start_time);
-
-  // Set t0 for the fit to the first entry in the list. Usually this will be
-  // from the start counter.
-  mStartTime=start_times[0].t0;
-  mStartDetector=start_times[0].system;
-
-  //_DBG_ << SystemName(mStartDetector) << " " << mStartTime << endl;
-
 }
 
 // Create a list of start times and do the fit for a particular mass hypothesis
 bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
-				    vector<DTrackTimeBased::DStartTime_t>&start_times,
+				    DTrackTimeBased::DStartTime_t &start_time,
 				    const std::shared_ptr<const JEvent>&event,
 				    double mass){  
   if(DEBUG_LEVEL>1){_DBG__;_DBG_<<"---- Starting time based fit with mass: "<<mass<<endl;}
@@ -884,21 +864,21 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
   // Do the fit
   DTrackFitter::fit_status_t status = DTrackFitter::kFitNotDone;
   if (USE_HITS_FROM_WIREBASED_FIT) {
-    status=FitWithWireBasedHits(track,mass);
+    status=FitWithWireBasedHits(track,mass,start_time);
   }   
   else{   
     fitter->Reset();
     fitter->SetFitType(DTrackFitter::kTimeBased);
     status = fitter->FindHitsAndFitTrack(*track, track->extrapolations,event, 
-					 mass,track->Ndof+5,
-					 mStartTime,mStartDetector);
+					 mass,track->Ndof+5,start_time.t0,
+					 start_time.t0_sigma,start_time.system);
     
     // If the status is kFitNotDone, then not enough hits were attached to this
     // track using the hit-gathering algorithm.  In this case get the hits 
     // from the wire-based track
     if (status==DTrackFitter::kFitNotDone){
       //_DBG_ << " Using wire-based hits " << endl;
-      status=FitWithWireBasedHits(track,mass);
+      status=FitWithWireBasedHits(track,mass,start_time);
     }
 
   }
@@ -939,7 +919,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       track->GetT(mycdchits);
       
       // Create a new time-based track object
-      MakeTimeBasedFromWireBased(myfdchits,mycdchits,start_times,track);
+      MakeTimeBasedFromWireBased(myfdchits,mycdchits,track);
       return true;
       break;
     }
@@ -949,7 +929,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       DTrackTimeBased *timebased_track = new DTrackTimeBased();
       *static_cast<DTrackingData*>(timebased_track) = fitter->GetFitParameters();
 
-      timebased_track->setTime(mStartTime);
+      timebased_track->setTime(start_time.t0);
       timebased_track->chisq = fitter->GetChisq();
       timebased_track->Ndof = fitter->GetNdof();
       timebased_track->pulls = std::move(fitter->GetPulls());  
@@ -959,25 +939,23 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->candidateid=track->candidateid;
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
       
-      // Set the start time and add the list of start times
-      timebased_track->setT0(mStartTime,start_times[0].t0_sigma, mStartDetector);
-      timebased_track->start_times.assign(start_times.begin(), start_times.end());
+      // Set the start time
+      timebased_track->setT0(start_time.t0,start_time.t0_sigma,start_time.system);
 	  
       if (DEBUG_HISTS){
 	int id=0;
-	if (mStartDetector==SYS_CDC) id=1;
-	else if (mStartDetector==SYS_FDC) id=2;
-	else if (mStartDetector==SYS_BCAL) id=3;
-	else if (mStartDetector==SYS_FCAL) id=4;
-	else if (mStartDetector==SYS_TOF) id=5;
+	if (start_time.system==SYS_CDC) id=1;
+	else if (start_time.system==SYS_FDC) id=2;
+	else if (start_time.system==SYS_BCAL) id=3;
+	else if (start_time.system==SYS_FCAL) id=4;
+	else if (start_time.system==SYS_TOF) id=5;
 
-	Hstart_time->Fill(start_times[0].t0,id);
+	Hstart_time->Fill(start_time.t0,id);
       }
       
-      
       // Add hits used as associated objects
-      const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();
-      const vector<const DFDCPseudo*> &fdchits = fitter->GetFDCFitHits();
+      auto cdchits = fitter->GetCDCFitHits();
+      auto fdchits = fitter->GetFDCFitHits();
       
       for(unsigned int m=0; m<cdchits.size(); m++)
 	timebased_track->AddAssociatedObject(cdchits[m]);
@@ -1003,11 +981,8 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->dNumHitsUsedFordEdx_CDC = locNumHitsUsedFordEdx_CDC;
 
       // Set CDC ring & FDC plane hit patterns before candidate and wirebased tracks are associated
-      vector<const DCDCTrackHit*> tempCDCTrackHits = timebased_track->Get<DCDCTrackHit>();
-      vector<const DFDCPseudo*> tempFDCPseudos = timebased_track->Get<DFDCPseudo>();
-
-      timebased_track->dCDCRings = pid_algorithm->Get_CDCRingBitPattern(tempCDCTrackHits);
-      timebased_track->dFDCPlanes = pid_algorithm->Get_FDCPlaneBitPattern(tempFDCPseudos);
+      timebased_track->dCDCRings = pid_algorithm->Get_CDCRingBitPattern(cdchits);
+      timebased_track->dFDCPlanes = pid_algorithm->Get_FDCPlaneBitPattern(fdchits);
 
       // Add DTrack object as associate object
       timebased_track->AddAssociatedObject(track);
@@ -1057,14 +1032,6 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
   timebased_track->candidateid=src_track->candidateid;
   timebased_track->FOM=src_track->FOM;
   timebased_track->flags=DTrackTimeBased::FLAG__USED_OTHER_HYPOTHESIS;
-  
-  // Add list of start times
-  timebased_track->start_times.assign(src_track->start_times.begin(),  
-				      src_track->start_times.end());
-  // Set the start time we used
-  timebased_track->setT0(timebased_track->start_times[0].t0,
-			 timebased_track->start_times[0].t0_sigma, 
-			 timebased_track->start_times[0].system);
 
   // Add DTrack object as associate object
   vector<const DTrackWireBased*>wire_based_track;
@@ -1098,6 +1065,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
 					 my_mass,
 					 src_cdchits.size()+2*src_fdchits.size(),
 					 timebased_track->t0(),
+					 timebased_track->t0_err(),
 					 timebased_track->t0_detector());
     // if the fit returns chisq=-1, something went terribly wrong.  Do not 
     // update the parameters for the track...
@@ -1121,8 +1089,6 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
       timebased_track->IsSmoothed = fitter->GetIsSmoothed();  
       *static_cast<DTrackingData*>(timebased_track) = fitter->GetFitParameters();
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
-      
-      timebased_track->setTime(timebased_track->start_times[0].t0);
 
       // Add hits used as associated objects
       const vector<const DCDCTrackHit*> &cdchits = fitter->GetCDCFitHits();
@@ -1416,7 +1382,6 @@ void DTrackTimeBased_factory::AddMissingTrackHypotheses(unsigned int mass_bits,
 // found.
 void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo*>&fdchits,
 							 vector<const DCDCTrackHit*>&cdchits,
-							 vector<DTrackTimeBased::DStartTime_t>&start_times,
 							 const DTrackWireBased*track
 					    ){
   DTrackTimeBased *timebased_track = new DTrackTimeBased();
@@ -1431,11 +1396,7 @@ void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo
   timebased_track->FOM=track->FOM;
   timebased_track->IsSmoothed=track->IsSmoothed;
   timebased_track->flags=DTrackTimeBased::FLAG__USED_WIREBASED_FIT;
-  
-  // add the list of start times
-  timebased_track->start_times.assign(start_times.begin(),
-				      start_times.end());
-  
+    
   for(unsigned int m=0; m<fdchits.size(); m++)
     timebased_track->AddAssociatedObject(fdchits[m]); 
   for(unsigned int m=0; m<cdchits.size(); m++)
@@ -1467,8 +1428,8 @@ void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo
 }
 
 DTrackFitter::fit_status_t
-DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,
-					      double mass){
+DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,double mass,
+					      DTrackTimeBased::DStartTime_t &start_time){
   // Get the hits from the wire-based track
   vector<const DFDCPseudo*>myfdchits;
   track->GetT(myfdchits);
@@ -1481,6 +1442,7 @@ DTrackTimeBased_factory::FitWithWireBasedHits(const DTrackWireBased *track,
   fitter->AddHits(myfdchits);
   fitter->AddHits(mycdchits);
 
-  return fitter->FitTrack(track->position(),track->momentum(),
-			  track->charge(),mass,mStartTime,mStartDetector);
+  return fitter->FitTrack(track->position(),track->momentum(),track->charge(),mass,
+			  start_time.t0,start_time.system);
 }
+

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -274,12 +274,6 @@ void DTrackTimeBased_factory::BeginRun(const std::shared_ptr<const JEvent>& even
 		if(!hitMatchFOM)hitMatchFOM = new TH1F("hitMatchFOM","Total Fraction of Hit Matches", 101, 0.0, 1.01);
 		if(!chi2_trk_mom)chi2_trk_mom = new TH2F("chi2_trk_mom","Track #chi^{2}/Ndf versus Kinematic #chi^{2}/Ndf", 1000, 0.0, 100.0, 1000, 0.,100.);
 
-
-		Hstart_time=(TH2F*)gROOT->FindObject("Hstart_time");
-		if (!Hstart_time) Hstart_time=new TH2F("Hstart_time",
-						       "vertex time source vs. time",
-						 300,-50,50,9,-0.5,8.5);
-
 		root_lock->RootUnLock();
 	}
 
@@ -375,8 +369,8 @@ void DTrackTimeBased_factory::Process(const std::shared_ptr<const JEvent>& event
 
     // Get the start time for the track
     DTrackTimeBased::DStartTime_t start_time;
-    GetStartTime(track,sc_hits,tof_points,bcal_showers,fcal_showers,fcal_hits,ecal_showers,
-		 ecal_hits,start_time);
+    GetStartTime(track,sc_hits,tof_points,bcal_showers,fcal_showers,fcal_hits,
+		 ecal_showers,ecal_hits,start_time);
     
     // Fit the track
     DoFit(track,start_time,event,track->mass());
@@ -785,6 +779,9 @@ void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
   // Match to the start counter and the outer detectors
   double track_t0=track->t0();
   double locStartTime = track_t0;  // Initial guess from tracking
+  start_time.t0=track_t0;
+  start_time.t0_sigma=2.75; // crude estimate
+  start_time.system=track->t0_detector();
  
   // Get start time estimate from Start Counter
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_START),sc_hits,locStartTime)){
@@ -807,16 +804,15 @@ void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
   locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_showers,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.7;
+    start_time.t0_sigma=0.5;
     start_time.system=SYS_FCAL;
 
     return;
   }
   // look for matches to single FCAL hits
-  locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_hits,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.7;
+    start_time.t0_sigma=0.5;
     start_time.system=SYS_FCAL;
   
     return;
@@ -825,16 +821,15 @@ void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
   locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_showers,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.4;
+    start_time.t0_sigma=0.5;
     start_time.system=SYS_ECAL;
 
     return;
   }
   // look for matches to single ECAL hits
-  locStartTime = track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_hits,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.4;
+    start_time.t0_sigma=0.5;
     start_time.system=SYS_ECAL;
 
     return;
@@ -843,15 +838,11 @@ void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
   locStartTime=track_t0;  // Initial guess from tracking
   if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_BCAL),bcal_showers,locStartTime)){
     start_time.t0=locStartTime;
-    start_time.t0_sigma=0.35;
+    start_time.t0_sigma=0.5;
     start_time.system=SYS_BCAL;
 
     return;
   }
-  // If all else fails, use track info
-  start_time.t0=track_t0;
-  start_time.t0_sigma=2.5; // crude estimate
-  start_time.system=track->t0_detector();
 }
 
 // Create a list of start times and do the fit for a particular mass hypothesis
@@ -938,21 +929,7 @@ bool DTrackTimeBased_factory::DoFit(const DTrackWireBased *track,
       timebased_track->trackid = track->id;
       timebased_track->candidateid=track->candidateid;
       timebased_track->flags=DTrackTimeBased::FLAG__GOODFIT;
-      
-      // Set the start time
-      timebased_track->setT0(start_time.t0,start_time.t0_sigma,start_time.system);
-	  
-      if (DEBUG_HISTS){
-	int id=0;
-	if (start_time.system==SYS_CDC) id=1;
-	else if (start_time.system==SYS_FDC) id=2;
-	else if (start_time.system==SYS_BCAL) id=3;
-	else if (start_time.system==SYS_FCAL) id=4;
-	else if (start_time.system==SYS_TOF) id=5;
 
-	Hstart_time->Fill(start_time.t0,id);
-      }
-      
       // Add hits used as associated objects
       auto cdchits = fitter->GetCDCFitHits();
       auto fdchits = fitter->GetFDCFitHits();
@@ -1006,6 +983,7 @@ void DTrackTimeBased_factory::AddMissingTrackHypothesis(vector<DTrackTimeBased*>
 
   // Copy over DKinematicData part from the result of a successful fit
   timebased_track->setPID(IDTrack(q, my_mass));
+  timebased_track->setTime(src_track->t0());
   timebased_track->chisq = src_track->chisq;
   timebased_track->Ndof = src_track->Ndof;
   timebased_track->pulls = src_track->pulls;
@@ -1293,7 +1271,8 @@ void DTrackTimeBased_factory::MakeTimeBasedFromWireBased(vector<const DFDCPseudo
 					    ){
   DTrackTimeBased *timebased_track = new DTrackTimeBased();
   *static_cast<DTrackingData*>(timebased_track) = *static_cast<const DTrackingData*>(track);
-  
+
+  timebased_track->setTime(track->t0());
   timebased_track->chisq = track->chisq;
   timebased_track->Ndof = track->Ndof;
   timebased_track->pulls = track->pulls; 

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.cc
@@ -777,70 +777,51 @@ void DTrackTimeBased_factory::GetStartTime(const DTrackWireBased *track,
 					   vector<const DECALHit*>&ecal_hits,
 					   DTrackTimeBased::DStartTime_t &start_time) const {
   // Match to the start counter and the outer detectors
-  double track_t0=track->t0();
-  double locStartTime = track_t0;  // Initial guess from tracking
-  start_time.t0=track_t0;
+  // Initial guess from tracking
+  start_time.t0=track->t0();
   start_time.t0_sigma=2.75; // crude estimate
   start_time.system=track->t0_detector();
  
   // Get start time estimate from Start Counter
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_START),sc_hits,locStartTime)){
-    start_time.t0=locStartTime;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_START),sc_hits,start_time.t0)){
     start_time.t0_sigma=0.3;
     start_time.system=SYS_START;
-
     return;
   }
   // Get start time estimate from TOF
-  locStartTime = track_t0;  // Initial guess from tracking
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_TOF),tof_points,locStartTime)){
-    start_time.t0=locStartTime;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_TOF),tof_points,start_time.t0)){
     start_time.t0_sigma=0.1;
     start_time.system=SYS_TOF;
-
     return;
   }
   // Get start time estimate from FCAL
-  locStartTime = track_t0;  // Initial guess from tracking
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_showers,locStartTime)){
-    start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_showers,start_time.t0)){
+    start_time.t0_sigma=0.75;
     start_time.system=SYS_FCAL;
-
     return;
   }
   // look for matches to single FCAL hits
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_hits,locStartTime)){
-    start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_FCAL),fcal_hits,start_time.t0)){
+    start_time.t0_sigma=0.75;
     start_time.system=SYS_FCAL;
-  
     return;
   }
   // Get start time estimate from ECAL
-  locStartTime = track_t0;  // Initial guess from tracking
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_showers,locStartTime)){
-    start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_showers,start_time.t0)){
+    start_time.t0_sigma=0.45;
     start_time.system=SYS_ECAL;
-
     return;
   }
   // look for matches to single ECAL hits
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_hits,locStartTime)){
-    start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_ECAL),ecal_hits,start_time.t0)){
+    start_time.t0_sigma=0.45;
     start_time.system=SYS_ECAL;
-
     return;
   }
   // Get start time estimate from BCAL
-  locStartTime=track_t0;  // Initial guess from tracking
-  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_BCAL),bcal_showers,locStartTime)){
-    start_time.t0=locStartTime;
-    start_time.t0_sigma=0.5;
+  if (pid_algorithm->Get_StartTime(track->extrapolations.at(SYS_BCAL),bcal_showers,start_time.t0)){
+    start_time.t0_sigma=0.35;
     start_time.system=SYS_BCAL;
-
     return;
   }
 }

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -97,6 +97,8 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
 				  vector<DTrackTimeBased::DStartTime_t>&start_times,
 				  const DTrackWireBased*track
 				  );
+  DTrackFitter::fit_status_t FitWithWireBasedHits(const DTrackWireBased *track,
+						  double mass);
 
   // Geometry
   const DGeometry *geom;

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -63,7 +63,6 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
   TH1F *fom;
   TH1F *hitMatchFOM;
   TH2F *chi2_trk_mom;
-  TH2F *Hstart_time;
  
   void FilterDuplicates(void);  
   double GetTruthMatchingFOM(int trackIndex,DTrackTimeBased *dtrack,vector<const DMCThrown*>mcthrowns);
@@ -77,9 +76,9 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
 		    vector<const DFCALHit*>&fcal_hits,
 		    vector<const DECALShower*>&ecal_showers,
 		    vector<const DECALHit*>&ecal_hits,
-		    DTrackTimeBased::DStartTime_t &start_times) const;
+		    DTrackTimeBased::DStartTime_t &start_time) const;
   bool DoFit(const DTrackWireBased *track,
-	     DTrackTimeBased::DStartTime_t &start_times,
+	     DTrackTimeBased::DStartTime_t &start_time,
 	     const std::shared_ptr<const JEvent>&event,double mass);  
 
   void AddMissingTrackHypothesis(vector<DTrackTimeBased*>&tracks_to_add,

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -99,6 +99,7 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
   DTrackFitter::fit_status_t FitWithWireBasedHits(const DTrackWireBased *track,
 						  double mass,
 						  DTrackTimeBased::DStartTime_t &start_time);
+  void GetdEdxInfo(DTrackTimeBased *timebased_track) const;
 
   // Geometry
   const DGeometry *geom;

--- a/src/libraries/TRACKING/DTrackTimeBased_factory.h
+++ b/src/libraries/TRACKING/DTrackTimeBased_factory.h
@@ -69,17 +69,17 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
   double GetTruthMatchingFOM(int trackIndex,DTrackTimeBased *dtrack,vector<const DMCThrown*>mcthrowns);
   int GetThrownIndex(vector<const DMCThrown*>& locMCThrowns, const DKinematicData *kd, double &f);
 
-  void CreateStartTimeList(const DTrackWireBased *track,
-			   vector<const DSCHit*>&sc_hits,
-			   vector<const DTOFPoint*>&tof_points,
-			   vector<const DBCALShower*>&bcal_showers,	  
-			   vector<const DFCALShower*>&fcal_showers,
-			   vector<const DFCALHit*>&fcal_hits,
-			   vector<const DECALShower*>&ecal_showers,
-			   vector<const DECALHit*>&ecal_hits,
-			   vector<DTrackTimeBased::DStartTime_t>&start_times);
+  void GetStartTime(const DTrackWireBased *track,
+		    vector<const DSCHit*>&sc_hits,
+		    vector<const DTOFPoint*>&tof_points,
+		    vector<const DBCALShower*>&bcal_showers,	  
+		    vector<const DFCALShower*>&fcal_showers,
+		    vector<const DFCALHit*>&fcal_hits,
+		    vector<const DECALShower*>&ecal_showers,
+		    vector<const DECALHit*>&ecal_hits,
+		    DTrackTimeBased::DStartTime_t &start_times) const;
   bool DoFit(const DTrackWireBased *track,
-	     vector<DTrackTimeBased::DStartTime_t>&start_times,
+	     DTrackTimeBased::DStartTime_t &start_times,
 	     const std::shared_ptr<const JEvent>&event,double mass);  
 
   void AddMissingTrackHypothesis(vector<DTrackTimeBased*>&tracks_to_add,
@@ -94,11 +94,11 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
 				 double q,bool flipped_charge,const std::shared_ptr<const JEvent>&event);
   void MakeTimeBasedFromWireBased(vector<const DFDCPseudo*>&fdchits,
 				  vector<const DCDCTrackHit*>&cdchits,
-				  vector<DTrackTimeBased::DStartTime_t>&start_times,
 				  const DTrackWireBased*track
 				  );
   DTrackFitter::fit_status_t FitWithWireBasedHits(const DTrackWireBased *track,
-						  double mass);
+						  double mass,
+						  DTrackTimeBased::DStartTime_t &start_time);
 
   // Geometry
   const DGeometry *geom;
@@ -110,10 +110,6 @@ class DTrackTimeBased_factory:public JFactoryT<DTrackTimeBased>{
   vector<double> fdc_rmin_packages;
   double TARGET_Z=65.;
 
-  //  double mPathLength,mEndTime,mStartTime,mFlightTime;
-  double mStartTime;
-  //  DetectorSystem_t mDetector, mStartDetector;
-  DetectorSystem_t mStartDetector;
   int mNumHypPlus,mNumHypMinus;
   bool dIsNoFieldFlag,INSERT_MISSING_HYPOTHESES;
   bool FAST_TRACKING_MODE;

--- a/src/libraries/TRACKING/DTrackWireBased.h
+++ b/src/libraries/TRACKING/DTrackWireBased.h
@@ -35,6 +35,7 @@ class DTrackWireBased:public DTrackingData{
 		// use the DParticleID Get_CDCRings & Get_FDCPlanes functions to extract the information from these
 		unsigned int dCDCRings; //CDC rings where the track has an associated DCDCTrackHit //rings correspond to bits (1 -> 28)
 		unsigned int dFDCPlanes; //FDC planes where the track has an associated DFDCPseudoHit //planes correspond to bits (1 -> 24)
+  unsigned int NumFDC,NumCDC;
 
 		void Summarize(JObjectSummary& summary) const override {
 			DKinematicData::Summarize(summary);

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -291,6 +291,7 @@ void DTrackWireBased_factory::Process(const std::shared_ptr<const JEvent>& event
       double min_dphi=1e9;
       double phi=candidate->dPosition.Phi();
       double t0=candidate->dMinimumDriftTime;
+      double t0_sigma=2.5; // crude estimate
       unsigned int sc_hit_index=0;
       if (haveStartCounter){
 	for (unsigned int j=0;j<schits.size();j++){
@@ -306,6 +307,7 @@ void DTrackWireBased_factory::Process(const std::shared_ptr<const JEvent>& event
       DetectorSystem_t t0_detector=candidate->dDetector;
       if (min_dphi<SC_DPHI_CUT){
 	t0_detector=SYS_START;
+	t0_sigma=0.3;
 	t0=schits[sc_hit_index]->t;
       }
       else { // If matching to start counter did not work, try to match to BCAL
@@ -349,6 +351,7 @@ void DTrackWireBased_factory::Process(const std::shared_ptr<const JEvent>& event
 	if (matched_points.size()>=MIN_BCAL_MATCHES){
 	  t0_detector=SYS_BCAL;
 	  t0=matched_points[0]->t();
+	  t0_sigma=0.35;
 	  // Crude correction for flight time from target
 	  t0-=2.2; // assum s=65 cm at roughly the speed of light
 	}
@@ -358,11 +361,11 @@ void DTrackWireBased_factory::Process(const std::shared_ptr<const JEvent>& event
 	rt->Reset();
 	rt->q = candidate->dCharge;
 
-	DoFit(i,candidate,rt,event,ParticleMass(PiPlus),t0,t0_detector);
+	DoFit(i,candidate,rt,event,ParticleMass(PiPlus),t0,t0_sigma,t0_detector);
 	// Only do fit for proton mass hypothesis for low momentum particles
 	if (candidate->dMomentum.Mag()<PROTON_MOM_THRESH){
 	  rt->Reset();
-	  DoFit(i,candidate,rt,event,ParticleMass(Proton),t0,t0_detector);
+	  DoFit(i,candidate,rt,event,ParticleMass(Proton),t0,t0_sigma,t0_detector);
 	}
       }
       else{
@@ -383,7 +386,7 @@ void DTrackWireBased_factory::Process(const std::shared_ptr<const JEvent>& event
 
 	    rt->Reset();
             rt->q = candidate->dCharge;
-            DoFit(i,candidate,rt,event,ParticleMass(Particle_t(mass_hypotheses[j])),t0,t0_detector);
+            DoFit(i,candidate,rt,event,ParticleMass(Particle_t(mass_hypotheses[j])),t0,t0_sigma,t0_detector);
          }
 
       }
@@ -496,7 +499,7 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
 				    const DTrackCandidate *candidate,
 				    DReferenceTrajectory *rt,
 				    const std::shared_ptr<const JEvent>& event,
-				    double mass,double t0,
+				    double mass,double t0,double t0_sigma,
 				    DetectorSystem_t t0_detector){
    // Get the hits from the candidate
   vector<const DFDCPseudo*>myfdchits=candidate->fdchits;
@@ -512,7 +515,7 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
       fitter->AddHits(mycdchits);
 
       status=fitter->FitTrack(candidate->dPosition,candidate->dMomentum,
-			      candidate->dCharge,mass,t0,t0_detector);
+			      candidate->dCharge,mass,t0,t0_sigma,t0_detector);
    }
    else{
      fitter->Reset();
@@ -530,7 +533,7 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
       kd.setMomentum(candidate->dMomentum);
       status=fitter->FindHitsAndFitTrack(kd,rt,event,mass,
 					 mycdchits.size()+2*myfdchits.size(),
-					 t0,t0_detector);
+					 t0,t0_sigma,t0_detector);
       if (fitter->GetChisq()<0 || status==DTrackFitter::kFitNotDone){
 	if (DEBUG_LEVEL>1)
 	  _DBG_ << "Using hits from candidate..." << endl;
@@ -540,7 +543,7 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
          fitter->AddHits(mycdchits);
 
          status=fitter->FitTrack(candidate->dPosition,candidate->dMomentum,
-				 candidate->dCharge,mass,t0,t0_detector);
+				 candidate->dCharge,mass,t0,t0_sigma,t0_detector);
       }
    }
 

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -23,7 +23,6 @@ using namespace std;
 
 #include <TROOT.h>
 
-
 //------------------
 // CDCSortByRincreasing
 //------------------
@@ -575,17 +574,14 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
             // Add hits used as associated objects
             vector<const DCDCTrackHit*> cdchits = fitter->GetCDCFitHits();
             vector<const DFDCPseudo*> fdchits = fitter->GetFDCFitHits();
-            sort(cdchits.begin(), cdchits.end(), CDCSortByRincreasing);
-            sort(fdchits.begin(), fdchits.end(), FDCSortByZincreasing);
+	    track->NumFDC=fdchits.size();
+	    track->NumCDC=cdchits.size();
             for(unsigned int m=0; m<cdchits.size(); m++)track->AddAssociatedObject(cdchits[m]);
             for(unsigned int m=0; m<fdchits.size(); m++)track->AddAssociatedObject(fdchits[m]);
 
 	    // Set CDC ring & FDC plane hit patterns before candidate tracks are associated
-	    vector<const DCDCTrackHit*> tempCDCTrackHits = track->Get<DCDCTrackHit>();
-	    vector<const DFDCPseudo*> tempFDCPseudos = track->Get<DFDCPseudo>();
-
-	    track->dCDCRings = dPIDAlgorithm->Get_CDCRingBitPattern(tempCDCTrackHits);
-	    track->dFDCPlanes = dPIDAlgorithm->Get_FDCPlaneBitPattern(tempFDCPseudos);
+	    track->dCDCRings = dPIDAlgorithm->Get_CDCRingBitPattern(cdchits);
+	    track->dFDCPlanes = dPIDAlgorithm->Get_FDCPlaneBitPattern(fdchits);
 
             // Add DTrackCandidate as associated object
             track->AddAssociatedObject(candidate);
@@ -675,6 +671,8 @@ void DTrackWireBased_factory::AddMissingTrackHypothesis(vector<DTrackWireBased*>
   wirebased_track->candidateid=src_track->candidateid;
   wirebased_track->FOM=src_track->FOM;
   wirebased_track->IsSmoothed=src_track->IsSmoothed;
+  wirebased_track->NumFDC=src_track->NumFDC;
+  wirebased_track->NumCDC=src_track->NumCDC;
   wirebased_track->dCDCRings=src_track->dCDCRings;
   wirebased_track->dFDCPlanes=src_track->dFDCPlanes;
 

--- a/src/libraries/TRACKING/DTrackWireBased_factory.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.cc
@@ -562,10 +562,11 @@ void DTrackWireBased_factory::DoFit(unsigned int c_id,
       case DTrackFitter::kFitSuccess:
          if(!isfinite(fitter->GetFitParameters().position().X())) break;
          {    
-            // Make a new wire-based track
-             DTrackWireBased *track = new DTrackWireBased();
-             *static_cast<DTrackingData*>(track) = fitter->GetFitParameters();
-
+	   // Make a new wire-based track
+	   DTrackWireBased *track = new DTrackWireBased();
+	   *static_cast<DTrackingData*>(track) = fitter->GetFitParameters();
+	   
+	   track->setTime(track->t0());
             track->chisq = fitter->GetChisq();
             track->Ndof = fitter->GetNdof();
             track->FOM = TMath::Prob(track->chisq, track->Ndof);
@@ -667,6 +668,7 @@ void DTrackWireBased_factory::AddMissingTrackHypothesis(vector<DTrackWireBased*>
 
   // Copy over DKinematicData part from the result of a successful fit
   wirebased_track->setPID(IDTrack(q, my_mass));
+  wirebased_track->setTime(src_track->t0());
   wirebased_track->chisq = src_track->chisq;
   wirebased_track->Ndof = src_track->Ndof;
   wirebased_track->pulls = src_track->pulls;

--- a/src/libraries/TRACKING/DTrackWireBased_factory.h
+++ b/src/libraries/TRACKING/DTrackWireBased_factory.h
@@ -72,7 +72,8 @@ class DTrackWireBased_factory:public JFactoryT<DTrackWireBased>{
 		void FilterDuplicates(void);
 		void DoFit(unsigned int c_id,const DTrackCandidate *candidate,
 			   DReferenceTrajectory *rt, const std::shared_ptr<const JEvent>& event,
-			   double mass,double t0,DetectorSystem_t t0_detector);
+			   double mass,double t0,double t0_sigma,
+			   DetectorSystem_t t0_detector);
 		void AddMissingTrackHypothesis(vector<DTrackWireBased*>&tracks_to_add,
 					       const DTrackWireBased *src_track,
 					       double my_mass,double q);

--- a/src/libraries/TRACKING/DTrackWireBased_factory_StraightLine.cc
+++ b/src/libraries/TRACKING/DTrackWireBased_factory_StraightLine.cc
@@ -117,6 +117,8 @@ void DTrackWireBased_factory_StraightLine::Process(const std::shared_ptr<const J
        // Add hits used as associated objects
        vector<const DCDCTrackHit*> cdchits_on_track = fitter->GetCDCFitHits();
        vector<const DFDCPseudo*> fdchits_on_track = fitter->GetFDCFitHits();
+       track->NumFDC=fdchits_on_track.size();
+       track->NumCDC=cdchits_on_track.size();
 
        // ...also find minimum drift time...
        double tmin=1e6;


### PR DESCRIPTION
More cleanup of the code:  Remove vector of start times from the DTrackTimeBased object and a corresponding histogram.  This was used during the early development stage and is no longer needed.   Remove some duplicate code in the part of the code that finds the dEdx on the track; this change also makes sure Richard's optional dEdx vector gets called in each context.  Make sure the t0 sigma gets passed on through each stage of the tracking code.  Explicitly disable DIRC matching when in fast tracking mode.  Get rid of out-of-time cut when finding a guess for t0:  this was always flawed because the time to which the guess for t0 (as computed using the flight time to the fast detectors) is compared was derived from the earliest drift time in the chambers of the hits on the track, which could be tens of ns or more depending on the smallest distance to the wires.  The cut is still present for later stages of the reconstruction/analysis, but I effectively disable this for the fast tracking mode.   This change recovers most of the missing efficiency in p2pi reconstruction for the fast tracking mode.