### PR TITLE
Correct a few compiler warnings

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -889,7 +889,9 @@ def AddROOT(env):
 			AddROOT.ROOT_CFLAGS    += ' -DHAVE_TMVA=1'
 			AddROOT.ROOT_LINKFLAGS += ' -lTMVA'
 
-	AddCompileFlags(env, AddROOT.ROOT_CFLAGS)
+	# AddCompileFlags(env, AddROOT.ROOT_CFLAGS)
+	# ROOT CFLAGS are actually C++ flags : apply only to CXXFLAGS
+	env.AppendUnique(CXXFLAGS = AddROOT.ROOT_CFLAGS.split())
 	AddLinkFlags(env, AddROOT.ROOT_LINKFLAGS)
 
 	if env['OSNAME'].startswith("Darwin_macosx"):

--- a/src/libraries/FCAL/DFCALGeometry.h
+++ b/src/libraries/FCAL/DFCALGeometry.h
@@ -26,11 +26,12 @@ public:
   // from a database as they aren't going to change unless
   // the detector is reconstructed
   
-  enum { kBlocksWide = 59 };
-  enum { kBlocksTall = 59 };
-  enum { kMaxChannels = kBlocksWide * kBlocksTall };
-  enum { kMidBlock = ( kBlocksWide - 1 ) / 2 };
-  enum { kBeamHoleSize = 3 }; // Before adding insert for FCAL-2
+  enum { kBlocksWide = 59,
+         kBlocksTall = 59,
+	 kMaxChannels = kBlocksWide * kBlocksTall,
+	 kMidBlock = ( kBlocksWide - 1 ) / 2,
+	 kBeamHoleSize = 3 // Before adding insert for FCAL-2
+  };
 
   static double blockSize()  { return 4.0157*k_cm; }
   static double radius()  { return 1.20471*k_m; }


### PR DESCRIPTION
* compiler treats arithmetic between two different enum types as deprecated, put them in a single anonymous enum keeps them all the same type and eliminates the warning
* c++ flags should not be used for c compilation