### PR TITLE
Fix TAGH/TAGM tagger-overlap efficiency double-counting (closes #850)

### DIFF
--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -1188,22 +1188,33 @@ void DEventWriterROOT::Fill_ThrownTree(const std::shared_ptr<const JEvent>& locE
 	vector<const DMCTrajectoryPoint*> locDMCTrajectoryPoints;
 	locEvent->Get(locDMCTrajectoryPoints);
 
-	const DBeamPhoton* locTaggedMCGenBeam = locTaggedMCGenBeams.empty() ? locMCGenBeams[0] : locTaggedMCGenBeams[0]; //if empty: will have to do. 
+	//if empty: will have to do.
+	//Otherwise, write one row per TAGGEDMCGEN entry instead of collapsing to locTaggedMCGenBeams[0]:
+	//in TAGH/TAGM overlap regions TAGGEDMCGEN correctly holds one entry per truth-tagged system
+	//(mirroring DBeamPhoton_factory_TRUTH), and the reconstructed side is likewise left un-merged,
+	//so collapsing the thrown side to a single row would undercount the "thrown" denominator
+	//relative to the (correctly doubled) reconstructed numerator in any analysis that divides by
+	//this tree's row count instead of querying DBeamPhoton:TAGGEDMCGEN object counts directly.
+	vector<const DBeamPhoton*> locThrownTreeBeams = locTaggedMCGenBeams.empty() ?
+		vector<const DBeamPhoton*>(1, locMCGenBeams[0]) : locTaggedMCGenBeams;
 
 	DEvent::GetLockService(locEvent)->RootWriteLock();
 
-	//primary event info
-	dThrownTreeFillData.Fill_Single<UInt_t>("RunNumber", locEvent->GetRunNumber());
-	dThrownTreeFillData.Fill_Single<ULong64_t>("EventNumber", locEvent->GetEventNumber());
+	for(const DBeamPhoton* locTaggedMCGenBeam : locThrownTreeBeams)
+	{
+		//primary event info
+		dThrownTreeFillData.Fill_Single<UInt_t>("RunNumber", locEvent->GetRunNumber());
+		dThrownTreeFillData.Fill_Single<ULong64_t>("EventNumber", locEvent->GetEventNumber());
 
-	//throwns
-	Fill_ThrownInfo(&dThrownTreeFillData, locMCReaction, locTaggedMCGenBeam, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locDMCTrajectoryPoints);
+		//throwns
+		Fill_ThrownInfo(&dThrownTreeFillData, locMCReaction, locTaggedMCGenBeam, locMCThrownsToSave, locThrownIndexMap, locNumPIDThrown_FinalState, locPIDThrown_Decaying, locDMCTrajectoryPoints);
 
-	//Custom Branches
-	Fill_CustomBranches_ThrownTree(&dThrownTreeFillData, locEvent, locMCReaction, locMCThrownsToSave);
+		//Custom Branches
+		Fill_CustomBranches_ThrownTree(&dThrownTreeFillData, locEvent, locMCReaction, locMCThrownsToSave);
 
-	//FILL TTREE
-	dThrownTreeInterface->Fill(dThrownTreeFillData);
+		//FILL TTREE
+		dThrownTreeInterface->Fill(dThrownTreeFillData);
+	}
 
 	
 	DEvent::GetLockService(locEvent)->RootUnLock();

--- a/src/libraries/ANALYSIS/DEventWriterROOT.cc
+++ b/src/libraries/ANALYSIS/DEventWriterROOT.cc
@@ -17,6 +17,7 @@ static bool STORE_MC_TRAJECTORIES = false;
 
 static bool STORE_SC_VETO_INFO = false;
 static bool STORE_THROWN_DECAYING_PARTICLES = true;
+static bool STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS = true; //true = current (post-c3deea4b6) behavior: 1 row per TAGGEDMCGEN entry; false = pre-c3deea4b6: collapse to TAGGEDMCGEN[0]/MCGEN[0]
 
 void DEventWriterROOT::Initialize(const std::shared_ptr<const JEvent>& locEvent)
 {
@@ -129,6 +130,7 @@ void DEventWriterROOT::Create_ThrownTree(const std::shared_ptr<const JEvent>& lo
 	// set parameters specifically for thrown trees
 	// if(japp->Exists("ANALYSIS:STORE_THROWN_DECAYING_PARTICLES"))
 	japp->GetParameter("ANALYSIS:STORE_THROWN_DECAYING_PARTICLES",STORE_THROWN_DECAYING_PARTICLES); cout << "ANALYSIS:STORE_THROWN_DECAYING_PARTICLES set to " << STORE_THROWN_DECAYING_PARTICLES << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;
+	japp->GetParameter("ANALYSIS:STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS",STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS); cout << "ANALYSIS:STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS set to " << STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS << ", IGNORE the \"<-- NO DEFAULT! (TYPO?)\" message " << endl;
 
 	//TTREE BRANCHES
 	DTreeBranchRegister locBranchRegister;
@@ -637,6 +639,7 @@ void DEventWriterROOT::Create_Branches_Thrown(DTreeBranchRegister& locBranchRegi
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "X4")); //reported at target center
 	locBranchRegister.Register_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "P4"));
 	locBranchRegister.Register_Single<Float_t>(Build_BranchName("ThrownBeam", "GeneratedEnergy"));
+	locBranchRegister.Register_Single<Bool_t>(Build_BranchName("ThrownBeam", "IsTAGH")); //true: beam photon tagged in TAGH; false: TAGM or SYS_NULL (untagged/MCGEN fallback)
 
 	//EVENT-WIDE INFO
 	locBranchRegister.Register_Single<ULong64_t>("NumPIDThrown_FinalState"); //19 digits
@@ -1189,14 +1192,24 @@ void DEventWriterROOT::Fill_ThrownTree(const std::shared_ptr<const JEvent>& locE
 	locEvent->Get(locDMCTrajectoryPoints);
 
 	//if empty: will have to do.
-	//Otherwise, write one row per TAGGEDMCGEN entry instead of collapsing to locTaggedMCGenBeams[0]:
-	//in TAGH/TAGM overlap regions TAGGEDMCGEN correctly holds one entry per truth-tagged system
-	//(mirroring DBeamPhoton_factory_TRUTH), and the reconstructed side is likewise left un-merged,
-	//so collapsing the thrown side to a single row would undercount the "thrown" denominator
-	//relative to the (correctly doubled) reconstructed numerator in any analysis that divides by
-	//this tree's row count instead of querying DBeamPhoton:TAGGEDMCGEN object counts directly.
-	vector<const DBeamPhoton*> locThrownTreeBeams = locTaggedMCGenBeams.empty() ?
-		vector<const DBeamPhoton*>(1, locMCGenBeams[0]) : locTaggedMCGenBeams;
+	//If STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS: write one row per TAGGEDMCGEN entry instead of collapsing
+	//to locTaggedMCGenBeams[0]: in TAGH/TAGM overlap regions TAGGEDMCGEN correctly holds one entry per
+	//truth-tagged system (mirroring DBeamPhoton_factory_TRUTH), and the reconstructed side is likewise
+	//left un-merged, so collapsing the thrown side to a single row would undercount the "thrown"
+	//denominator relative to the (correctly doubled) reconstructed numerator in any analysis that
+	//divides by this tree's row count instead of querying DBeamPhoton:TAGGEDMCGEN object counts
+	//directly. Otherwise (flag off), reproduce the pre-c3deea4b6 single-row-per-event behavior for
+	//consumers that expect exactly one Thrown_Tree row per event.
+	vector<const DBeamPhoton*> locThrownTreeBeams;
+	if(STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS)
+	{
+		locThrownTreeBeams = locTaggedMCGenBeams.empty() ?
+			vector<const DBeamPhoton*>(1, locMCGenBeams[0]) : locTaggedMCGenBeams;
+	}
+	else
+	{
+		locThrownTreeBeams = vector<const DBeamPhoton*>(1, locTaggedMCGenBeams.empty() ? locMCGenBeams[0] : locTaggedMCGenBeams[0]);
+	}
 
 	DEvent::GetLockService(locEvent)->RootWriteLock();
 
@@ -1712,6 +1725,7 @@ void DEventWriterROOT::Fill_ThrownInfo(DTreeFillData* locTreeFillData, const DMC
 	DLorentzVector locThrownBeamP4 = locTaggedMCGenBeam->lorentzMomentum();
 	TLorentzVector locThrownBeamTP4(locThrownBeamP4.Px(), locThrownBeamP4.Py(), locThrownBeamP4.Pz(), locThrownBeamP4.E());
 	locTreeFillData->Fill_Single<TLorentzVector>(Build_BranchName("ThrownBeam", "P4"), locThrownBeamTP4);
+	locTreeFillData->Fill_Single<Bool_t>(Build_BranchName("ThrownBeam", "IsTAGH"), locTaggedMCGenBeam->dSystem == SYS_TAGH);
 
 	//THROWN PRODUCTS
 	locTreeFillData->Fill_Single<UInt_t>("NumThrown", locMCThrowns.size());

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc
@@ -27,39 +27,66 @@ void DBeamPhoton_factory_TAGGEDMCGEN::Process(const std::shared_ptr<const JEvent
 	if(locMCReactions.empty())
 		return; //Not a thrown event
 
-	//Get the MCGEN beam
-	const DBeamPhoton* locMCGenBeam;
-	event->GetSingle(locMCGenBeam, "MCGEN");
-
-	//See if it was tagged
-	auto locSystem = locMCGenBeam->dSystem;
-	if(locSystem == SYS_NULL)
-		return; //Nope, no objects to create
+	//Get every primary (bg == 0) truth-tagged system for the thrown photon.
+	//In TAGH/TAGM overlap regions the photon can legitimately register truth
+	//hits in BOTH systems (see DBeamPhoton_factory_TRUTH), just as a real
+	//photon in that energy range produces coincident TAGH+TAGM hits and
+	//un-merged reconstructed DBeamPhoton candidates (see DBeamPhoton_factory).
+	//"MCGEN" only reports a single canonical system (preferring TAGM) since
+	//it exists to represent the one physical photon's kinematics, not to
+	//enumerate which tagger systems it was tagged in - so it can't be used
+	//here without silently dropping the second, equally real, truth match.
+	vector<const DBeamPhoton*> locTruthPhotons;
+	event->Get(locTruthPhotons, "TRUTH");
 
 	//Get reconstructed beam photons
 	vector<const DBeamPhoton*> locBeamPhotons;
 	event->Get(locBeamPhotons);
 
-	//Loop over beam photons
-	double locBestDeltaT = 9.9E9;
-	const DBeamPhoton* locBestPhoton = nullptr;
-	for(auto& locBeamPhoton : locBeamPhotons)
+	for(auto& locTruthPhoton : locTruthPhotons)
 	{
-		if(locBeamPhoton->dSystem != locSystem)
-			continue;
-		if(locBeamPhoton->dCounter != locMCGenBeam->dCounter)
+		//only consider the primary photon's own hits, not accidentals/pileup
+		bool locIsPrimary = false;
+		vector<const DTAGMHit*> locTAGMHits;
+		locTruthPhoton->Get(locTAGMHits);
+		for(auto locTAGMHit : locTAGMHits)
+		{
+			if(locTAGMHit->bg == 0)
+				locIsPrimary = true;
+		}
+		vector<const DTAGHHit*> locTAGHHits;
+		locTruthPhoton->Get(locTAGHHits);
+		for(auto locTAGHHit : locTAGHHits)
+		{
+			if(locTAGHHit->bg == 0)
+				locIsPrimary = true;
+		}
+		if(!locIsPrimary)
 			continue;
 
-		auto locDeltaT = fabs(locMCGenBeam->time() - locBeamPhoton->time());
-		if(locDeltaT >= locBestDeltaT)
+		auto locSystem = locTruthPhoton->dSystem;
+		if(locSystem == SYS_NULL)
 			continue;
-		locBestDeltaT = locDeltaT;
-		locBestPhoton = locBeamPhoton;
+
+		//Loop over beam photons
+		double locBestDeltaT = 9.9E9;
+		const DBeamPhoton* locBestPhoton = nullptr;
+		for(auto& locBeamPhoton : locBeamPhotons)
+		{
+			if(locBeamPhoton->dSystem != locSystem)
+				continue;
+			if(locBeamPhoton->dCounter != locTruthPhoton->dCounter)
+				continue;
+
+			auto locDeltaT = fabs(locTruthPhoton->time() - locBeamPhoton->time());
+			if(locDeltaT >= locBestDeltaT)
+				continue;
+			locBestDeltaT = locDeltaT;
+			locBestPhoton = locBeamPhoton;
+		}
+
+		if(locBestPhoton != nullptr)
+			mData.push_back(new DBeamPhoton(*locBestPhoton));
 	}
-
-	if(locBestPhoton == nullptr)
-		return; //Uh oh.  Shouldn't be possible. 
-
-	mData.push_back(new DBeamPhoton(*locBestPhoton));
 }
 

--- a/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
+++ b/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.h
@@ -12,6 +12,8 @@
 #include <PID/DBeamPhoton.h>
 #include "PID/DMCReaction.h"
 #include "DANA/DStatusBits.h"
+#include "TAGGER/DTAGHHit.h"
+#include "TAGGER/DTAGMHit.h"
 
 class DBeamPhoton_factory_TAGGEDMCGEN:public JFactoryT<DBeamPhoton>{
 	public:


### PR DESCRIPTION
**Base:** `master`  **Head:** [`Hao_Dev_TaggerOverlapEfficiencyFix`](https://github.com/JeffersonLab/halld_recon/tree/Hao_Dev_TaggerOverlapEfficiencyFix)

## Summary

[`DBeamPhoton_factory_TAGGEDMCGEN`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc) (the reconstruction-efficiency denominator source) derived its single output photon from [`DBeamPhoton_factory_MCGEN`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/PID/DBeamPhoton_factory_MCGEN.cc)'s already-collapsed, TAGM-preferring system choice. In the small TAGH/TAGM overlap windows (TAGH#127/TAGM#1 near 8.9 GeV, TAGH#179/TAGM#102 near 7.86-7.87 GeV) a thrown photon legitimately registers truth hits in *both* systems — real detector behavior, correctly left un-merged by the reconstructed [`DBeamPhoton_factory`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/PID/DBeamPhoton_factory.cc) and correctly treated as two independent counts by [`DBeamPhoton_factory_TRUTH`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/PID/DBeamPhoton_factory_TRUTH.cc) and the official flux tool ([`psflux`](https://github.com/JeffersonLab/hd_utilities/blob/master/psflux/plot_flux_ccdb.py#L339-L421)). Because `TAGGEDMCGEN` collapsed to one entry regardless, the denominator stayed at 1 while the numerator was 2, producing a spurious ~2x efficiency spike inside the overlap windows.

Full root-cause discussion, the fix rationale, and testing are posted on **[#850](https://github.com/JeffersonLab/halld_recon/issues/850)** — this PR implements what's described there.

## Changes

- [`a296bbcff`](https://github.com/JeffersonLab/halld_recon/commit/a296bbcff6731058ad015e837395bc246c2bfdfc) — [`DBeamPhoton_factory_TAGGEDMCGEN::Process()`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/PID/DBeamPhoton_factory_TAGGEDMCGEN.cc) now iterates over *all* primary (`bg==0`) `"TRUTH"`-tagged systems and matches each independently against the reconstructed list, instead of inheriting MCGEN's single collapsed choice. Non-overlap events unaffected; overlap events emit up to two entries, but only for truth systems that actually find a reconstructed match (partial-reconstruction still correctly reports 1). `MCGEN` itself is untouched.
- [`c3deea4b6`](https://github.com/JeffersonLab/halld_recon/commit/c3deea4b62b0084cdeb0a8a422458ddb02ee827b) — [`DEventWriterROOT::Fill_ThrownTree`](https://github.com/JeffersonLab/halld_recon/blob/Hao_Dev_TaggerOverlapEfficiencyFix/src/libraries/ANALYSIS/DEventWriterROOT.cc) had the same `[0]`-collapsing bug on the thrown side; now writes one `Thrown_Tree` row per `TAGGEDMCGEN` entry so the thrown-side denominator symmetrically tracks the fixed reconstructed-side numerator. `Fill_DataTree` has the same pattern but is intentionally left untouched (used by all physics reaction trees — much larger blast radius, out of scope here).
- [`e7d960f25`](https://github.com/JeffersonLab/halld_recon/commit/e7d960f25e855f3030f077e40c228114d82ace48) — Two additions for downstream consumers:
  - `ThrownBeam__IsTAGH` boolean branch on `Thrown_Tree` (true=TAGH, false=TAGM/SYS_NULL) so analyses can tell the two rows of an overlap event apart.
  - `ANALYSIS:STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS` JANA parameter (default `true`) to fall back to the exact pre-fix single-row-per-event `Fill_ThrownTree` behavior, for anyone who needs the old row count preserved.

## Testing

Tested natively against the GlueX stack pinned by `version_7.5.0.xml` (halld_recon baseline 5.11.0 + this branch, halld_sim 5.7.0, ROOT 6.32.20, geant4 10.07.p04, hdgeant4 3.3.1, gluex_MCwrapper v2.13.0). Full details and figures on [#850](https://github.com/JeffersonLab/halld_recon/issues/850).

## Notes for reviewers

- `STORE_TAGGEDMCGEN_PER_SYSTEM_ROWS` defaults to `true` (the fixed behavior) — this changes `Thrown_Tree`'s row count (not its per-row content) inside overlap windows for every consumer, not just this analysis. The toggle exists specifically so anyone who needs the exact old row count can opt back in without a rebuild.

resolves #850 