### PR TITLE
Various minor RF and PS related changes

### DIFF
--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
@@ -34,6 +34,9 @@ void DPSCPair_factory::Init()
   app->SetDefaultParameter("PSCPair:DELTA_T_PAIR_MAX",DELTA_T_PAIR_MAX,
 			      "Maximum difference in ns between a pair of hits"
 			      " in left and right arm of coarse PS");
+  app->SetDefaultParameter("PSCPair:USE_ADC_HITS", USE_ADC_HITS, "Require PSC hits to have a fADC time (default: true)");
+  app->SetDefaultParameter("PSCPair:USE_TDC_HITS", USE_TDC_HITS, "Require PSC hits to have a TDC time (default: true)");
+  
 }
 
 //------------------
@@ -56,21 +59,22 @@ void DPSCPair_factory::Process(const std::shared_ptr<const JEvent>& event)
   if (hits.size()>1) {
     for (unsigned int i=0; i < hits.size()-1; i++) {
       for (unsigned int j=i+1; j < hits.size(); j++) {
-	if (!hits[i]->has_TDC||!hits[j]->has_TDC) continue;
-	if (!hits[i]->has_fADC||!hits[j]->has_fADC) continue;
-	if (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX) {
-	  if (hits[i]->arm==0) {
-	    ee.first = hits[i];
-	    ee.second = hits[j];
-	  }
-	  else if (hits[i]->arm==1) {
-	    ee.first = hits[j];
-	    ee.second = hits[i];
-	  }
-	  DPSCPair *pair = new DPSCPair;
-	  pair->ee = ee;
-	  Insert(pair);
-	}
+          if (USE_TDC_HITS && (!hits[i]->has_TDC||!hits[j]->has_TDC)) continue;
+          if (USE_ADC_HITS && (!hits[i]->has_fADC||!hits[j]->has_fADC)) continue;
+          if ( (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX)
+               || !USE_TDC_HITS || !USE_ADC_HITS ) {
+              if (hits[i]->arm==0) {
+                  ee.first = hits[i];
+                  ee.second = hits[j];
+              }
+              else if (hits[i]->arm==1) {
+                  ee.first = hits[j];
+                  ee.second = hits[i];
+              }
+              DPSCPair *pair = new DPSCPair;
+              pair->ee = ee;
+              Insert(pair);
+          }
       }
     }
   }

--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
@@ -51,6 +51,9 @@ void DPSCPair_factory::BeginRun(const std::shared_ptr<const JEvent>& event)
 //------------------
 void DPSCPair_factory::Process(const std::shared_ptr<const JEvent>& event)
 {
+  if(!USE_ADC_HITS && !USE_TDC_HITS)
+  	return;
+
   // get coarse pair spectrometer hits
   vector<const DPSCHit*> hits;
   event->Get(hits);
@@ -61,7 +64,20 @@ void DPSCPair_factory::Process(const std::shared_ptr<const JEvent>& event)
       for (unsigned int j=i+1; j < hits.size(); j++) {
           if (USE_TDC_HITS && (!hits[i]->has_TDC||!hits[j]->has_TDC)) continue;
           if (USE_ADC_HITS && (!hits[i]->has_fADC||!hits[j]->has_fADC)) continue;
-          if ( (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(hits[i]->t-hits[j]->t)<DELTA_T_PAIR_MAX)
+          
+          double t1 = -1.e6, t2 = -1.e6;
+          if( USE_ADC_HITS && USE_TDC_HITS ) {
+          	t1 = hits[i]->t;
+          	t2 = hits[j]->t;
+          } else if(!USE_TDC_HITS) {
+          	t1 = hits[i]->time_fadc;
+          	t2 = hits[j]->time_fadc;
+          } else {  // !USE_ADC_HITS
+          	t1 = hits[i]->t;
+          	t2 = hits[j]->t;
+          }
+          
+          if ( (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(t1-t2)<DELTA_T_PAIR_MAX)
                || !USE_TDC_HITS || !USE_ADC_HITS ) {
               if (hits[i]->arm==0) {
                   ee.first = hits[i];

--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.cc
@@ -77,8 +77,7 @@ void DPSCPair_factory::Process(const std::shared_ptr<const JEvent>& event)
           	t2 = hits[j]->t;
           }
           
-          if ( (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(t1-t2)<DELTA_T_PAIR_MAX)
-               || !USE_TDC_HITS || !USE_ADC_HITS ) {
+          if ( (std::abs(hits[i]->arm-hits[j]->arm)==1&&fabs(t1-t2)<DELTA_T_PAIR_MAX) ) {
               if (hits[i]->arm==0) {
                   ee.first = hits[i];
                   ee.second = hits[j];

--- a/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.h
+++ b/src/libraries/PAIR_SPECTROMETER/DPSCPair_factory.h
@@ -11,6 +11,7 @@
 #include <JANA/JFactoryT.h>
 #include "DPSCPair.h"
 
+
 class DPSCPair_factory:public JFactoryT<DPSCPair>{
  public:
   DPSCPair_factory(){};
@@ -24,6 +25,9 @@ class DPSCPair_factory:public JFactoryT<DPSCPair>{
   void Process(const std::shared_ptr<const JEvent>& event) override;
   void EndRun() override;
   void Finish() override;
+
+    bool USE_ADC_HITS = true;
+    bool USE_TDC_HITS = true;
 };
 
 #endif // _DPSCPair_factory_

--- a/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.cc
+++ b/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.cc
@@ -89,7 +89,10 @@ void JEventProcessor_PSC_TW::Init()
 	//  ... fill historgrams or trees ...
 	// GetLockService(locEvent)->RootUnLock();
 	//
+    
+    app->SetDefaultParameter("PSC_TW:RF_TAG", dRFTag, "Tag value for getting specific RF time (default: PSC)");
 
+    
    TDirectory *main = gDirectory;
    TDirectory *pscDir = gDirectory->mkdir("PSC_TW");
    pscDir->cd();
@@ -165,7 +168,7 @@ void JEventProcessor_PSC_TW::Process(const std::shared_ptr<const JEvent>& event)
    vector<const DPSCPair*>	pairs;
 
    event->Get(pairs);
-   event->Get(locRFTimes,"PSC");
+   event->Get(locRFTimes,dRFTag);
 
    const DRFTime* locRFTime = NULL;
 

--- a/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.h
+++ b/src/plugins/Calibration/PSC_TW/JEventProcessor_PSC_TW.h
@@ -14,6 +14,8 @@
 #include <PAIR_SPECTROMETER/DPSCHit.h>
 #include <PAIR_SPECTROMETER/DPSCPair.h>
 
+#include <string>
+
 class JEventProcessor_PSC_TW:public JEventProcessor{
    public:
       JEventProcessor_PSC_TW();
@@ -27,6 +29,8 @@ class JEventProcessor_PSC_TW:public JEventProcessor{
       void Finish() override;
 
       std::shared_ptr<JLockService> lockService;
+
+      std::string dRFTag = "PSC";
 };
 
 #endif // _JEventProcessor_PSC_TW_

--- a/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
+++ b/src/plugins/Calibration/TAGH_timewalk/JEventProcessor_TAGH_timewalk.cc
@@ -153,13 +153,14 @@ void JEventProcessor_TAGH_timewalk::Process(const std::shared_ptr<const JEvent>&
     vector <const DRFTime*> rfTimesPSC;
 
 
+    bool psc_rftime_found = false;
+    
     event->Get(rfTimesPSC,"PSC");
 
-    if (rfTimesPSC.size() > 0)
+    if (rfTimesPSC.size() > 0) {
       rfTimePSC = rfTimesPSC[0];
-    else
-      return; // NOERROR;
-
+      psc_rftime_found = true;
+    }
 
     event->Get(rfTimes,"TAGH");
 
@@ -174,12 +175,15 @@ void JEventProcessor_TAGH_timewalk::Process(const std::shared_ptr<const JEvent>&
     double t_rf_psc     =  0.;
     int    psc_found    =  0.;
 
-    if((ps_pairs.size() > 0) && (psc_pairs.size() > 0)){
-
-      double psc_time  = (psc_pairs[0]->ee.first->t  +  psc_pairs[0]->ee.second->t)/2.;
-      t_rf_psc = dRFTimeFactory->Step_TimeToNearInputTime(rfTimePSC->dTime, psc_time);      
-
-      psc_found = 1;
+    if(psc_rftime_found) {
+    
+        if((ps_pairs.size() > 0) && (psc_pairs.size() > 0)){
+            
+            double psc_time  = (psc_pairs[0]->ee.first->t  +  psc_pairs[0]->ee.second->t)/2.;
+            t_rf_psc = dRFTimeFactory->Step_TimeToNearInputTime(rfTimePSC->dTime, psc_time);      
+            
+            psc_found = 1;
+        }
     }
 
 
@@ -214,7 +218,7 @@ void JEventProcessor_TAGH_timewalk::Process(const std::shared_ptr<const JEvent>&
         hTAGHRF_tdcTimeDiffVsPulseHeight[id]->Fill(pulse_height,t_tdc-t_RF);
         hTAGHRF_correctedTdcTimeDiffVsPulseHeight[id]->Fill(pulse_height,t-t_RF);
 
-	if(psc_found){
+	if(psc_found && psc_rftime_found) {
 
 	  double Elow  = taghGeom.getElow(id);
 	  double Ehigh = taghGeom.getEhigh(id);


### PR DESCRIPTION
minor modifications to help with the analysis / calibration of the Spring 2026 data:

* made the PSC RF optional for TAGH_timewalk, since it's not required for the main time walk calibration procedure 
* added an option to switch RF sources for PSC_TW, to help for the times when the PSC RF source is not available
* toggle the requirement for ADC or TDC hits in the PSC pair factory