### PR TITLE
Ps monitor

### DIFF
--- a/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.cc
+++ b/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.cc
@@ -123,6 +123,8 @@ static TH1F *htagm_hit_t_time_all;
 
 static TH1D *hdt_psc_rf, *hdt_ps_rf, *hdt_tagh_rf, *hdt_tagm_rf;
 
+static bool message = true;
+
 
 // Define RFTime_factory
 DRFTime_factory* dRFTimeFactory;
@@ -292,6 +294,17 @@ void JEventProcessor_lumi_mon::Process(const std::shared_ptr<const JEvent> &even
 	vector<const DRFTime*>   locRFTimes;
 
       	event->Get(locRFTimes, RFsrc);
+
+	if(locRFTimes.size() == 0){
+	  if(message && (event->GetEventNumber() != 0) ){
+	    // Switch to the TAGH RF, if the PSC RF (or the RF specified by the parameter) is not available
+	    cout << " RF is not availbale, switch to the TAGH  " << event->GetEventNumber() << endl;
+	    message = false;
+	  }
+	  event->Get(locRFTimes, "TAGH");
+	}
+	
+
 	
 	const DRFTime* locRFTime = NULL;
 	

--- a/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.cc
+++ b/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.cc
@@ -150,6 +150,8 @@ void JEventProcessor_lumi_mon::Init()
   auto app = GetApplication();
   lockService = app->GetService<JLockService>();
 
+  app->SetDefaultParameter("lumi_mon:RFsrc", RFsrc, "Select the source of the RF signal: default PSC");
+  
   TDirectory *main = gDirectory;
   TDirectory *dlumi_mon = gDirectory->mkdir("Lumi_mon");
   dlumi_mon->cd();
@@ -288,7 +290,9 @@ void JEventProcessor_lumi_mon::Process(const std::shared_ptr<const JEvent> &even
 
 	// RF 
 	vector<const DRFTime*>   locRFTimes;
-	event->Get(locRFTimes, "PSC");
+
+      	event->Get(locRFTimes, RFsrc);
+	
 	const DRFTime* locRFTime = NULL;
 	
 	if (locRFTimes.size() > 0)

--- a/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
+++ b/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
@@ -35,6 +35,8 @@ class JEventProcessor_lumi_mon:public JEventProcessor{
 
 		std::shared_ptr<JLockService> lockService;
 
+                std::string RFsrc = "PSC";
+  
 };
 
 #endif // _JEventProcessor_lumi_mon_

--- a/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
+++ b/src/plugins/monitoring/lumi_mon/JEventProcessor_lumi_mon.h
@@ -30,12 +30,12 @@ class JEventProcessor_lumi_mon:public JEventProcessor{
 		void Init() override;
 		void BeginRun(const std::shared_ptr<const JEvent>& event) override;
 		void Process(const std::shared_ptr<const JEvent>& event) override;
-		void EndRun() override;
+                void EndRun() override;
 		void Finish() override;
 
 		std::shared_ptr<JLockService> lockService;
-
-                std::string RFsrc = "PSC";
+  
+  		std::string RFsrc = "PSC";
   
 };
 


### PR DESCRIPTION
Switch to the TAGH RF, if the PSC RF (or the RF specified by the parameter) is not available